### PR TITLE
WIP: Reworked some interfaces

### DIFF
--- a/cmd/flowlogs2metrics/main.go
+++ b/cmd/flowlogs2metrics/main.go
@@ -157,11 +157,6 @@ func main() {
 }
 
 func run() {
-	var (
-		err          error
-		mainPipeline *pipeline.Pipeline
-	)
-
 	// Initial log message
 	fmt.Printf("%s starting - version [%s]\n\n", filepath.Base(os.Args[0]), Version)
 
@@ -172,11 +167,7 @@ func run() {
 	utils.SetupElegantExit()
 
 	// Create new flows pipeline
-	mainPipeline, err = pipeline.NewPipeline()
-	if err != nil {
-		log.Fatalf("failed to initialize pipeline %s", err)
-		os.Exit(1)
-	}
+	mainPipeline := pipeline.NewPipeline()
 
 	// Starts the flows pipeline
 	mainPipeline.Run()

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
 	google.golang.org/grpc v1.43.0 // indirect
+	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb
 	github.com/ip2location/ip2location-go/v9 v9.2.0
 	github.com/json-iterator/go v1.1.12
+	github.com/mariomac/go-pipes v0.1.0
 	github.com/mitchellh/mapstructure v1.4.3
 	github.com/netobserv/loki-client-go v0.0.0-20211018150932-cb17208397a9
 	github.com/netsampler/goflow2 v1.0.5-0.20220106210010-20e8e567090c

--- a/go.sum
+++ b/go.sum
@@ -776,8 +776,6 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
-github.com/segmentio/kafka-go v0.4.27 h1:sIhEozeL/TLN2mZ5dkG462vcGEWYKS+u31sXPjKhAM4=
-github.com/segmentio/kafka-go v0.4.27/go.mod h1:XzMcoMjSzDGHcIwpWUI7GB43iKZ2fTVmryPSGLf/MPg=
 github.com/segmentio/kafka-go v0.4.28 h1:ATYbyenAlsoFxnV+VpIJMF87bvRuRsX7fezHNfpwkdM=
 github.com/segmentio/kafka-go v0.4.28/go.mod h1:XzMcoMjSzDGHcIwpWUI7GB43iKZ2fTVmryPSGLf/MPg=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
@@ -1405,6 +1403,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 h1:FVCohIoYO7IJoDDVpV2pdq7SgrMH6wHnuTyrdrxJNoY=
+gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -587,6 +587,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
+github.com/mariomac/go-pipes v0.1.0 h1:iGbKfW0+iNQyvCvDG13kOTXyhzuXjHvijS5kcftMYOI=
+github.com/mariomac/go-pipes v0.1.0/go.mod h1:UKxWnzK1YRLR7tY4OD9BjTQMImKl5MW6LviwEbiJjwg=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/pkg/pipeline/decode/decode_json.go
+++ b/pkg/pipeline/decode/decode_json.go
@@ -19,6 +19,7 @@ package decode
 
 import (
 	"encoding/json"
+
 	"github.com/netobserv/flowlogs2metrics/pkg/config"
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/pipeline/decode/decode_json.go
+++ b/pkg/pipeline/decode/decode_json.go
@@ -19,7 +19,6 @@ package decode
 
 import (
 	"encoding/json"
-
 	"github.com/netobserv/flowlogs2metrics/pkg/config"
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/pipeline/ingest/ingest.go
+++ b/pkg/pipeline/ingest/ingest.go
@@ -17,10 +17,8 @@
 
 package ingest
 
-type ProcessFunction func(entries []interface{})
-
 type Ingester interface {
-	Ingest(ProcessFunction)
+	Ingest(out chan<- []interface{})
 }
 type IngesterNone struct {
 }

--- a/pkg/pipeline/ingest/ingest_file_chunks.go
+++ b/pkg/pipeline/ingest/ingest_file_chunks.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2021 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ingest
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/netobserv/flowlogs2metrics/pkg/config"
+	"github.com/netobserv/flowlogs2metrics/pkg/pipeline/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+const chunkLines = 100
+
+// FileChunks ingest entries from a file and resends them in chunks of fixed number of lines.
+// It might be used to test processing speed in pipelines.
+type FileChunks struct {
+	fileName     string
+	PrevRecords  []interface{}
+	TotalRecords int
+}
+
+func (r *FileChunks) Ingest(process ProcessFunction) {
+	lines := make([]interface{}, 0, chunkLines)
+	file, err := os.Open(r.fileName)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	scanner := bufio.NewScanner(file)
+	nLines := 0
+	for scanner.Scan() {
+		text := scanner.Text()
+		lines = append(lines, text)
+		nLines++
+		if nLines%chunkLines == 0 {
+			r.PrevRecords = lines
+			r.TotalRecords += len(lines)
+			process(lines)
+			// reset slice length without deallocating/reallocating memory
+			lines = lines[:0]
+		}
+	}
+	if len(lines) > 0 {
+		r.PrevRecords = lines
+		r.TotalRecords += len(lines)
+		process(lines)
+	}
+}
+
+// NewFileChunks create a new ingester that sends entries in chunks of fixed number of lines.
+func NewFileChunks() (Ingester, error) {
+	log.Debugf("entering NewIngestFile")
+	if config.Opt.PipeLine.Ingest.File.Filename == "" {
+		return nil, fmt.Errorf("ingest filename not specified")
+	}
+
+	log.Infof("input file name = %s", config.Opt.PipeLine.Ingest.File.Filename)
+
+	ch := make(chan bool, 1)
+	utils.RegisterExitChannel(ch)
+	return &FileChunks{
+		fileName: config.Opt.PipeLine.Ingest.File.Filename,
+	}, nil
+}

--- a/pkg/pipeline/ingest/ingest_file_chunks.go
+++ b/pkg/pipeline/ingest/ingest_file_chunks.go
@@ -37,7 +37,7 @@ type FileChunks struct {
 	TotalRecords int
 }
 
-func (r *FileChunks) Ingest(process ProcessFunction) {
+func (r *FileChunks) Ingest(out chan<- []interface{}) {
 	lines := make([]interface{}, 0, chunkLines)
 	file, err := os.Open(r.fileName)
 	if err != nil {
@@ -56,7 +56,7 @@ func (r *FileChunks) Ingest(process ProcessFunction) {
 		if nLines%chunkLines == 0 {
 			r.PrevRecords = lines
 			r.TotalRecords += len(lines)
-			process(lines)
+			out <- lines
 			// reset slice length without deallocating/reallocating memory
 			lines = lines[:0]
 		}
@@ -64,7 +64,7 @@ func (r *FileChunks) Ingest(process ProcessFunction) {
 	if len(lines) > 0 {
 		r.PrevRecords = lines
 		r.TotalRecords += len(lines)
-		process(lines)
+		out <- lines
 	}
 }
 

--- a/pkg/pipeline/ingest/ingest_kafka_test.go
+++ b/pkg/pipeline/ingest/ingest_kafka_test.go
@@ -119,6 +119,7 @@ func Test_IngestKafka(t *testing.T) {
 	newIngest := initNewIngestKafka(t, testConfig1)
 	ingestKafka := newIngest.(*ingestKafka)
 	ingestOutput := make(chan []interface{})
+	defer close(ingestOutput)
 
 	// run Ingest in a separate thread
 	go func() {

--- a/pkg/pipeline/ingest/ingest_kafka_test.go
+++ b/pkg/pipeline/ingest/ingest_kafka_test.go
@@ -18,6 +18,9 @@
 package ingest
 
 import (
+	"testing"
+	"time"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/netobserv/flowlogs2metrics/pkg/config"
 	"github.com/netobserv/flowlogs2metrics/pkg/test"
@@ -25,8 +28,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
-	"testing"
-	"time"
 )
 
 const testConfig1 = `---
@@ -114,22 +115,14 @@ func Test_NewIngestKafka2(t *testing.T) {
 	require.Equal(t, defaultBatchReadTimeout, ingestKafka.kafkaParams.BatchReadTimeout)
 }
 
-var receivedEntries []interface{}
-var dummyChan chan bool
-
-func dummyProcessFunction(entries []interface{}) {
-	receivedEntries = entries
-	dummyChan <- true
-}
-
 func Test_IngestKafka(t *testing.T) {
-	dummyChan = make(chan bool)
 	newIngest := initNewIngestKafka(t, testConfig1)
 	ingestKafka := newIngest.(*ingestKafka)
+	ingestOutput := make(chan []interface{})
 
 	// run Ingest in a separate thread
 	go func() {
-		ingestKafka.Ingest(dummyProcessFunction)
+		ingestKafka.Ingest(ingestOutput)
 	}()
 	// wait a second for the ingest pipeline to come up
 	time.Sleep(time.Second)
@@ -145,7 +138,7 @@ func Test_IngestKafka(t *testing.T) {
 	inChan <- record3
 
 	// wait for the data to have been processed
-	<-dummyChan
+	receivedEntries := <-ingestOutput
 
 	require.Equal(t, 3, len(receivedEntries))
 	require.Equal(t, record1, receivedEntries[0])
@@ -186,7 +179,7 @@ func (f *fakeKafkaReader) Config() kafkago.ReaderConfig {
 }
 
 func Test_KafkaListener(t *testing.T) {
-	dummyChan = make(chan bool)
+	ingestOutput := make(chan []interface{})
 	newIngest := initNewIngestKafka(t, testConfig1)
 	ingestKafka := newIngest.(*ingestKafka)
 
@@ -196,11 +189,11 @@ func Test_KafkaListener(t *testing.T) {
 
 	// run Ingest in a separate thread
 	go func() {
-		ingestKafka.Ingest(dummyProcessFunction)
+		ingestKafka.Ingest(ingestOutput)
 	}()
 
 	// wait for the data to have been processed
-	<-dummyChan
+	receivedEntries := <-ingestOutput
 
 	require.Equal(t, 1, len(receivedEntries))
 	require.Equal(t, string(fakeRecord), receivedEntries[0])

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -158,7 +158,7 @@ func NewPipeline() (*Pipeline, error) {
 
 	// TODO: all this apply* functions can be removed if we change the Ingester, Transformer, etc...
 	// interfaces and use them directly here
-	ingests := node.AsInit(p.applyIngest)
+	ingests := node.AsInit(p.Ingester.Ingest)
 	decodes := node.AsMiddle(p.applyDecode)
 	transforms := node.AsMiddle(p.applyTransforms)
 	writes := node.AsTerminal(p.applyWrite)
@@ -195,13 +195,6 @@ func (p Pipeline) process() {
 	for _, t := range p.terminal {
 		<-t.Done()
 	}
-}
-
-func (p *Pipeline) applyIngest(out chan<- []interface{}) {
-	p.Ingester.Ingest(func(entries []interface{}) {
-		log.Debugf("number of entries = %d", len(entries))
-		out <- entries
-	})
 }
 
 func (p *Pipeline) applyDecode(in <-chan []interface{}, out chan<- []config.GenericMap) {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -19,6 +19,7 @@ package pipeline
 
 import (
 	"fmt"
+
 	"github.com/heptiolabs/healthcheck"
 	"github.com/netobserv/flowlogs2metrics/pkg/config"
 	"github.com/netobserv/flowlogs2metrics/pkg/pipeline/decode"
@@ -52,6 +53,8 @@ func getIngester() (ingest.Ingester, error) {
 	switch config.Opt.PipeLine.Ingest.Type {
 	case "file", "file_loop":
 		ingester, err = ingest.NewIngestFile()
+	case "file_chunks":
+		ingester, err = ingest.NewFileChunks()
 	case "collector":
 		ingester, err = ingest.NewIngestCollector()
 	case "kafka":

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -56,18 +56,18 @@ pipeline:
     - type: generic
       generic:
         rules:
-        - input: Bytes
-          output: fl2m_bytes
-        - input: DstAddr
-          output: fl2m_dstAddr
-        - input: DstPort
-          output: fl2m_dstPort
-        - input: Packets
-          output: fl2m_packets
-        - input: SrcAddr
-          output: fl2m_srcAddr
-        - input: SrcPort
-          output: fl2m_srcPort
+          - input: Bytes
+            output: fl2m_bytes
+          - input: DstAddr
+            output: fl2m_dstAddr
+          - input: DstPort
+            output: fl2m_dstPort
+          - input: Packets
+            output: fl2m_packets
+          - input: SrcAddr
+            output: fl2m_srcAddr
+          - input: SrcPort
+            output: fl2m_srcPort
   extract:
     type: none
   encode:

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -20,6 +20,8 @@ package pipeline
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/netobserv/flowlogs2metrics/pkg/config"
 	"github.com/netobserv/flowlogs2metrics/pkg/pipeline/decode"
@@ -89,6 +91,7 @@ func Test_SimplePipeline(t *testing.T) {
 	ingester := mainPipeline.Ingester.(*ingest.IngestFile)
 	decoder := mainPipeline.Decoder.(*decode.DecodeJson)
 	writer := mainPipeline.Writer.(*write.WriteNone)
+	require.Equal(t, 5103, len(ingester.PrevRecords))
 	require.Equal(t, len(ingester.PrevRecords), len(decoder.PrevRecords))
 	require.Equal(t, len(ingester.PrevRecords), len(writer.PrevRecords))
 
@@ -106,8 +109,10 @@ func Test_SimplePipeline(t *testing.T) {
 }
 
 func BenchmarkPipeline(b *testing.B) {
+	logrus.StandardLogger().SetLevel(logrus.ErrorLevel)
 	t := &testing.T{}
 	loadGlobalConfig(t)
+	config.Opt.PipeLine.Ingest.Type = "file_chunks"
 	if t.Failed() {
 		b.Fatalf("unexpected error loading config")
 	}

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -87,6 +87,7 @@ func Test_SimplePipeline(t *testing.T) {
 	// The file ingester reads the entire file, pushes it down the pipeline, and then exits
 	// So we don't need to run it in a separate go-routine
 	mainPipeline.Run()
+
 	// What is there left to check? Check length of saved data of each stage in private structure.
 	ingester := mainPipeline.Ingester.(*ingest.IngestFile)
 	decoder := mainPipeline.Decoder.(*decode.DecodeJson)

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -112,10 +112,12 @@ func BenchmarkPipeline(b *testing.B) {
 		b.Fatalf("unexpected error loading config")
 	}
 	for n := 0; n < b.N; n++ {
+		b.StopTimer()
 		p, err := NewPipeline()
 		if err != nil {
 			t.Fatalf("unexpected error %s", err)
 		}
+		b.StartTimer()
 		p.Run()
 	}
 }

--- a/pkg/pipeline/write/write.go
+++ b/pkg/pipeline/write/write.go
@@ -23,20 +23,19 @@ import (
 )
 
 type Writer interface {
-	Write(in []config.GenericMap) []config.GenericMap
+	Write(in []config.GenericMap)
 }
 type WriteNone struct {
 	PrevRecords []config.GenericMap
 }
 
 // Write writes entries
-func (t *WriteNone) Write(in []config.GenericMap) []config.GenericMap {
+func (t *WriteNone) Write(in []config.GenericMap) {
 	log.Debugf("entering Write none, in = %v", in)
 	t.PrevRecords = in
-	return in
 }
 
 // NewWriteNone create a new write
-func NewWriteNone() (Writer, error) {
+func NewWriteNone() (*WriteNone, error) {
 	return &WriteNone{}, nil
 }

--- a/pkg/pipeline/write/write_loki.go
+++ b/pkg/pipeline/write/write_loki.go
@@ -20,11 +20,12 @@ package write
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/netobserv/flowlogs2metrics/pkg/api"
-	pUtils "github.com/netobserv/flowlogs2metrics/pkg/pipeline/utils"
 	"math"
 	"strings"
 	"time"
+
+	"github.com/netobserv/flowlogs2metrics/pkg/api"
+	pUtils "github.com/netobserv/flowlogs2metrics/pkg/pipeline/utils"
 
 	"github.com/netobserv/flowlogs2metrics/pkg/config"
 
@@ -203,13 +204,11 @@ func getFloat64(timestamp interface{}) (ft float64, ok bool) {
 }
 
 // Write writes a flow before being stored
-func (l *Loki) Write(entries []config.GenericMap) []config.GenericMap {
+func (l *Loki) Write(entries []config.GenericMap) {
 	log.Debugf("entering Loki Write")
 	for _, entry := range entries {
 		l.in <- entry
 	}
-
-	return entries
 }
 
 func (l *Loki) processRecords() {

--- a/pkg/pipeline/write/write_stdout.go
+++ b/pkg/pipeline/write/write_stdout.go
@@ -19,23 +19,22 @@ package write
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/netobserv/flowlogs2metrics/pkg/config"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 type writeStdout struct {
 }
 
 // Write writes a flow before being stored
-func (t *writeStdout) Write(in []config.GenericMap) []config.GenericMap {
+func (t *writeStdout) Write(in []config.GenericMap) {
 	log.Debugf("entering writeStdout Write")
 	log.Debugf("writeStdout: number of entries = %d", len(in))
 	for _, v := range in {
 		fmt.Printf("%s: %v\n", time.Now().Format(time.StampMilli), v)
 	}
-
-	return in
 }
 
 // NewWriteStdout create a new write

--- a/pkg/pipeline/write/write_test.go
+++ b/pkg/pipeline/write/write_test.go
@@ -18,19 +18,16 @@
 package write
 
 import (
-	"github.com/netobserv/flowlogs2metrics/pkg/config"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/netobserv/flowlogs2metrics/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_Write(t *testing.T) {
-	wn := WriteNone{}
+	wn, err := NewWriteNone()
+	require.NoError(t, err)
 	wn.Write([]config.GenericMap{{"key": "test"}})
-}
-
-func Test_NewWriteNone(t *testing.T) {
-	writer, err := NewWriteNone()
-	require.Nil(t, err)
-	require.Equal(t, writer, &WriteNone{})
-
+	assert.Equal(t, []config.GenericMap{{"key": "test"}}, wn.PrevRecords)
 }

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -52,7 +52,7 @@ func InitConfig(t *testing.T, conf string) *viper.Viper {
 	v.SetConfigType("yaml")
 	r := bytes.NewReader(yamlConfig)
 	err := v.ReadConfig(r)
-	require.Equal(t, err, nil)
+	require.NoError(t, err)
 	return v
 }
 

--- a/pkg/testutils/eventually.go
+++ b/pkg/testutils/eventually.go
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2022 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Eventually retries a test until it eventually succeeds. If the timeout is reached, the test fails
+// with the same failure as its last execution.
+func Eventually(t *testing.T, timeout time.Duration, testFunc func(_ require.TestingT)) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	success := make(chan interface{})
+	errorCh := make(chan error)
+	failCh := make(chan error)
+
+	go func() {
+		for ctx.Err() == nil {
+			result := testResult{failed: false, errorCh: errorCh, failCh: failCh}
+			// Executing the function to test
+			testFunc(&result)
+			// If the function didn't reported failure and didn't reached timeout
+			if !result.HasFailed() && ctx.Err() == nil {
+				success <- 1
+				break
+			}
+		}
+	}()
+
+	// Wait for success or timeout
+	var err, fail error
+	for {
+		select {
+		case <-success:
+			return
+		case err = <-errorCh:
+		case fail = <-failCh:
+		case <-ctx.Done():
+			if err != nil {
+				t.Error(err)
+			} else if fail != nil {
+				t.Error(fail)
+			} else {
+				t.Error("timeout while waiting for test to complete")
+			}
+			return
+		}
+	}
+}
+
+// util class for Eventually
+type testResult struct {
+	sync.RWMutex
+	failed  bool
+	errorCh chan<- error
+	failCh  chan<- error
+}
+
+func (te *testResult) Errorf(format string, args ...interface{}) {
+	te.Lock()
+	te.failed = true
+	te.Unlock()
+	te.errorCh <- fmt.Errorf(format, args...)
+}
+
+func (te *testResult) FailNow() {
+	te.Lock()
+	te.failed = true
+	te.Unlock()
+	te.failCh <- errors.New("test failed")
+}
+
+func (te *testResult) HasFailed() bool {
+	te.RLock()
+	defer te.RUnlock()
+	return te.failed
+}

--- a/pkg/testutils/eventually_test.go
+++ b/pkg/testutils/eventually_test.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package testutils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEventually_Error(t *testing.T) {
+	t.Skip("We skip this test, as it is expected to fail")
+	Eventually(t, 10*time.Millisecond, func(t require.TestingT) {
+		require.True(t, false)
+	})
+}
+
+func TestEventually_Fail(t *testing.T) {
+	t.Skip("We skip this test, as it is expected to fail")
+	Eventually(t, 10*time.Millisecond, func(t require.TestingT) {
+		t.FailNow()
+	})
+}
+
+func TestEventually_Timeout(t *testing.T) {
+	t.Skip("We skip this test, as it is expected to fail")
+	Eventually(t, 10*time.Millisecond, func(t require.TestingT) {
+		time.Sleep(5 * time.Second)
+	})
+}
+
+func TestEventually_Success(t *testing.T) {
+	num := 3
+	Eventually(t, 5*time.Second, func(t require.TestingT) {
+		require.Equal(t, 0, num)
+		num--
+	})
+}


### PR DESCRIPTION
First review and merge this PR: https://github.com/netobserv/flowlogs-pipeline/pull/105

* Writer does not return anything. Is a terminal state. Until
      now the return value was used only in tests so we remove it
      from production and find another way to keep testing.
* Kafka and Prometheus have been moved from "Encoder" to
      "Writer", as Loki or any other pipeline stage that writes to
      persistence.
