### PR TITLE
Enable goimports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ validate_go:
 .PHONY: validate_go lint
 lint: $(GOLANGCI_LINT) ## Lint the code
 	@go mod vendor
-	@$(GOLANGCI_LINT) run --timeout 5m
+	@$(GOLANGCI_LINT) run --enable goimports --timeout 5m
 
 .PHONY: build_code
 build_code: validate_go lint

--- a/cmd/apitodoc/main.go
+++ b/cmd/apitodoc/main.go
@@ -20,10 +20,11 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"io"
 	"reflect"
 	"strings"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 )
 
 func iterate(output io.Writer, data interface{}, indent int) {

--- a/cmd/apitodoc/main_test.go
+++ b/cmd/apitodoc/main_test.go
@@ -19,8 +19,9 @@ package main
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 type DocTags struct {

--- a/cmd/confgenerator/main.go
+++ b/cmd/confgenerator/main.go
@@ -20,15 +20,16 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/netobserv/flowlogs-pipeline/pkg/confgen"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"os"
-	"path/filepath"
-	"strings"
 )
 
 var (

--- a/cmd/flowlogs-pipeline/main.go
+++ b/cmd/flowlogs-pipeline/main.go
@@ -20,6 +20,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/health"
@@ -29,10 +34,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
-	"os"
-	"path/filepath"
-	"strings"
-	"time"
 )
 
 var (

--- a/pkg/api/write_loki.go
+++ b/pkg/api/write_loki.go
@@ -20,6 +20,7 @@ package api
 import (
 	"errors"
 	"fmt"
+
 	promConfig "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 )

--- a/pkg/confgen/confgen.go
+++ b/pkg/confgen/confgen.go
@@ -19,13 +19,14 @@ package confgen
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/extract/aggregate"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 )
 
 var (

--- a/pkg/confgen/confgen_test.go
+++ b/pkg/confgen/confgen_test.go
@@ -18,11 +18,12 @@
 package confgen
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"path"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func getConfGen() *ConfGen {

--- a/pkg/confgen/config.go
+++ b/pkg/confgen/config.go
@@ -18,10 +18,11 @@
 package confgen
 
 import (
+	"io/ioutil"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
-	"io/ioutil"
 )
 
 type Options struct {

--- a/pkg/confgen/config_test.go
+++ b/pkg/confgen/config_test.go
@@ -18,10 +18,11 @@
 package confgen
 
 import (
-	"github.com/netobserv/flowlogs-pipeline/pkg/api"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/stretchr/testify/require"
 )
 
 func expectedConfig() *Config {

--- a/pkg/confgen/dedup.go
+++ b/pkg/confgen/dedup.go
@@ -18,10 +18,11 @@
 package confgen
 
 import (
+	"reflect"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/extract/aggregate"
 	log "github.com/sirupsen/logrus"
-	"reflect"
 )
 
 func (cg *ConfGen) dedupe() {

--- a/pkg/confgen/dedup_test.go
+++ b/pkg/confgen/dedup_test.go
@@ -18,10 +18,11 @@
 package confgen
 
 import (
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/extract/aggregate"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_dedupeNetworkTransformRules(t *testing.T) {

--- a/pkg/confgen/doc.go
+++ b/pkg/confgen/doc.go
@@ -19,11 +19,12 @@ package confgen
 
 import (
 	"fmt"
-	"github.com/netobserv/flowlogs-pipeline/pkg/api"
-	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/extract/aggregate"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/extract/aggregate"
 )
 
 func (cg *ConfGen) generateVisualizeText(vgs []VisualizationGrafana) string {

--- a/pkg/confgen/encode.go
+++ b/pkg/confgen/encode.go
@@ -19,6 +19,7 @@ package confgen
 
 import (
 	"encoding/json"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	log "github.com/sirupsen/logrus"

--- a/pkg/confgen/extract.go
+++ b/pkg/confgen/extract.go
@@ -19,6 +19,7 @@ package confgen
 
 import (
 	"encoding/json"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/extract/aggregate"
 	log "github.com/sirupsen/logrus"

--- a/pkg/confgen/flowlogs2metrics_config.go
+++ b/pkg/confgen/flowlogs2metrics_config.go
@@ -19,8 +19,9 @@ package confgen
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
 )
 
 func (cg *ConfGen) generateFlowlogs2PipelineConfig(fileName string) error {

--- a/pkg/confgen/grafana_jsonnet.go
+++ b/pkg/confgen/grafana_jsonnet.go
@@ -19,9 +19,10 @@ package confgen
 
 import (
 	"bytes"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"text/template"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const TypeGrafana = "grafana"

--- a/pkg/confgen/transform.go
+++ b/pkg/confgen/transform.go
@@ -19,6 +19,7 @@ package confgen
 
 import (
 	"encoding/json"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	log "github.com/sirupsen/logrus"

--- a/pkg/confgen/visualization.go
+++ b/pkg/confgen/visualization.go
@@ -19,6 +19,7 @@ package confgen
 
 import (
 	"encoding/json"
+
 	jsoniter "github.com/json-iterator/go"
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ package config
 
 import (
 	"encoding/json"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/sirupsen/logrus"
 )

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -18,13 +18,14 @@
 package health
 
 import (
+	"net"
+	"net/http"
+	"time"
+
 	"github.com/heptiolabs/healthcheck"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline"
 	log "github.com/sirupsen/logrus"
-	"net"
-	"net/http"
-	"time"
 )
 
 const defaultServerHost = "0.0.0.0"

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -2,13 +2,14 @@ package health
 
 import (
 	"fmt"
-	"github.com/netobserv/flowlogs-pipeline/pkg/config"
-	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewHealthServer(t *testing.T) {

--- a/pkg/pipeline/decode/decode_aws.go
+++ b/pkg/pipeline/decode/decode_aws.go
@@ -18,9 +18,10 @@
 package decode
 
 import (
+	"strings"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	log "github.com/sirupsen/logrus"
-	"strings"
 )
 
 var defaultKeys = []string{

--- a/pkg/pipeline/decode/decode_aws_test.go
+++ b/pkg/pipeline/decode/decode_aws_test.go
@@ -19,11 +19,12 @@ package decode
 
 import (
 	"bufio"
+	"strings"
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	"github.com/stretchr/testify/require"
-	"strings"
-	"testing"
 )
 
 const testConfig1 = `

--- a/pkg/pipeline/decode/decode_json.go
+++ b/pkg/pipeline/decode/decode_json.go
@@ -19,6 +19,7 @@ package decode
 
 import (
 	"encoding/json"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/pipeline/decode/decode_json_test.go
+++ b/pkg/pipeline/decode/decode_json_test.go
@@ -18,9 +18,10 @@
 package decode
 
 import (
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func initNewDecodeJson(t *testing.T) Decoder {

--- a/pkg/pipeline/decode/decode_test.go
+++ b/pkg/pipeline/decode/decode_test.go
@@ -18,9 +18,10 @@
 package decode
 
 import (
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func initNewDecodeNone(t *testing.T) Decoder {

--- a/pkg/pipeline/encode/encode_kafka.go
+++ b/pkg/pipeline/encode/encode_kafka.go
@@ -19,12 +19,13 @@ package encode
 
 import (
 	"encoding/json"
+	"time"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	kafkago "github.com/segmentio/kafka-go"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
-	"time"
 )
 
 const (

--- a/pkg/pipeline/encode/encode_kafka_test.go
+++ b/pkg/pipeline/encode/encode_kafka_test.go
@@ -19,13 +19,14 @@ package encode
 
 import (
 	"encoding/json"
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	kafkago "github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
-	"testing"
 )
 
 const testKafkaConfig = `---

--- a/pkg/pipeline/encode/encode_prom.go
+++ b/pkg/pipeline/encode/encode_prom.go
@@ -20,17 +20,18 @@ package encode
 import (
 	"container/list"
 	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
-	"net/http"
-	"os"
-	"strconv"
-	"sync"
-	"time"
 )
 
 const defaultExpiryTime = 120

--- a/pkg/pipeline/encode/encode_prom_test.go
+++ b/pkg/pipeline/encode/encode_prom_test.go
@@ -19,13 +19,14 @@ package encode
 
 import (
 	"container/list"
+	"testing"
+	"time"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 const testConfig = `---

--- a/pkg/pipeline/encode/encode_test.go
+++ b/pkg/pipeline/encode/encode_test.go
@@ -18,9 +18,10 @@
 package encode
 
 import (
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func initNewEncodeNone(t *testing.T) Encoder {

--- a/pkg/pipeline/extract/aggregate/aggregate.go
+++ b/pkg/pipeline/extract/aggregate/aggregate.go
@@ -19,13 +19,14 @@ package aggregate
 
 import (
 	"fmt"
-	"github.com/netobserv/flowlogs-pipeline/pkg/config"
-	"github.com/netobserv/flowlogs-pipeline/pkg/api"
-	log "github.com/sirupsen/logrus"
 	"math"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/pipeline/extract/aggregate/aggregate_test.go
+++ b/pkg/pipeline/extract/aggregate/aggregate_test.go
@@ -19,12 +19,13 @@ package aggregate
 
 import (
 	"fmt"
-	"github.com/netobserv/flowlogs-pipeline/pkg/config"
-	"github.com/netobserv/flowlogs-pipeline/pkg/test"
-	"github.com/netobserv/flowlogs-pipeline/pkg/api"
-	"github.com/stretchr/testify/require"
 	"strconv"
 	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/test"
+	"github.com/stretchr/testify/require"
 )
 
 func GetMockAggregate() Aggregate {

--- a/pkg/pipeline/extract/aggregate/aggregates.go
+++ b/pkg/pipeline/extract/aggregate/aggregates.go
@@ -19,10 +19,11 @@ package aggregate
 
 import (
 	"fmt"
-	"github.com/netobserv/flowlogs-pipeline/pkg/config"
-	"github.com/netobserv/flowlogs-pipeline/pkg/api"
-	log "github.com/sirupsen/logrus"
 	"reflect"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	log "github.com/sirupsen/logrus"
 )
 
 type Aggregates []Aggregate

--- a/pkg/pipeline/extract/aggregate/aggregates_test.go
+++ b/pkg/pipeline/extract/aggregate/aggregates_test.go
@@ -18,10 +18,11 @@
 package aggregate
 
 import (
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_NewAggregatesFromConfig(t *testing.T) {

--- a/pkg/pipeline/extract/extract_aggregate_test.go
+++ b/pkg/pipeline/extract/extract_aggregate_test.go
@@ -19,12 +19,13 @@ package extract
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/extract/aggregate"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func createAgg(name, recordKey, by, agg, op string, value float64, count int, rrv []float64) config.GenericMap {

--- a/pkg/pipeline/ingest/ingest_collector.go
+++ b/pkg/pipeline/ingest/ingest_collector.go
@@ -22,10 +22,11 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"github.com/netobserv/flowlogs-pipeline/pkg/config"
-	pUtils "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"net"
 	"time"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	pUtils "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 
 	ms "github.com/mitchellh/mapstructure"
 	goflowFormat "github.com/netsampler/goflow2/format"

--- a/pkg/pipeline/ingest/ingest_file.go
+++ b/pkg/pipeline/ingest/ingest_file.go
@@ -20,11 +20,12 @@ package ingest
 import (
 	"bufio"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	log "github.com/sirupsen/logrus"
-	"os"
-	"time"
 )
 
 type IngestFile struct {

--- a/pkg/pipeline/ingest/ingest_kafka.go
+++ b/pkg/pipeline/ingest/ingest_kafka.go
@@ -19,13 +19,14 @@ package ingest
 
 import (
 	"errors"
+	"time"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	kafkago "github.com/segmentio/kafka-go"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
-	"time"
 )
 
 type kafkaReadMessage interface {

--- a/pkg/pipeline/ingest/ingest_kafka_test.go
+++ b/pkg/pipeline/ingest/ingest_kafka_test.go
@@ -18,14 +18,15 @@
 package ingest
 
 import (
+	"testing"
+	"time"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	kafkago "github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
-	"testing"
-	"time"
 )
 
 const testConfig1 = `---

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -19,6 +19,8 @@ package pipeline
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/heptiolabs/healthcheck"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/decode"
@@ -28,7 +30,6 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/write"
 	log "github.com/sirupsen/logrus"
-	"os"
 )
 
 // interface definitions of pipeline components

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -18,6 +18,8 @@
 package pipeline
 
 import (
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/decode"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/ingest"
@@ -25,7 +27,6 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/write"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 var yamlConfigNoParams = `
@@ -48,7 +49,7 @@ func Test_transformToLoki(t *testing.T) {
 
 	v := test.InitConfig(t, yamlConfigNoParams)
 	require.NotNil(t, v)
-	
+
 	loki, err := write.NewWriteLoki(config.Parameters[0])
 	require.NoError(t, err)
 	loki.Write(transformed)

--- a/pkg/pipeline/transform/connection_tracking/connection_tracking_test.go
+++ b/pkg/pipeline/transform/connection_tracking/connection_tracking_test.go
@@ -18,9 +18,10 @@
 package connection_tracking
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_InitConnectionTracking(t *testing.T) {

--- a/pkg/pipeline/transform/kubernetes/kubernetes.go
+++ b/pkg/pipeline/transform/kubernetes/kubernetes.go
@@ -19,6 +19,10 @@ package kubernetes
 
 import (
 	"fmt"
+	"net"
+	"os"
+	"time"
+
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -28,9 +32,6 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
-	"net"
-	"os"
-	"time"
 )
 
 var Data KubeData

--- a/pkg/pipeline/transform/kubernetes/kubernetes_test.go
+++ b/pkg/pipeline/transform/kubernetes/kubernetes_test.go
@@ -18,12 +18,13 @@
 package kubernetes
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
-	"testing"
 )
 
 type IndexerMock struct {

--- a/pkg/pipeline/transform/location/location.go
+++ b/pkg/pipeline/transform/location/location.go
@@ -22,8 +22,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/ip2location/ip2location-go/v9"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -31,6 +29,9 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/ip2location/ip2location-go/v9"
+	log "github.com/sirupsen/logrus"
 )
 
 type Info struct {

--- a/pkg/pipeline/transform/location/location_test.go
+++ b/pkg/pipeline/transform/location/location_test.go
@@ -21,14 +21,15 @@ import (
 	"archive/zip"
 	"bytes"
 	"fmt"
-	"github.com/ip2location/ip2location-go/v9"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/ip2location/ip2location-go/v9"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_InitLocationDB(t *testing.T) {

--- a/pkg/pipeline/transform/transform_generic_test.go
+++ b/pkg/pipeline/transform/transform_generic_test.go
@@ -18,10 +18,11 @@
 package transform
 
 import (
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 const testConfigTransformGeneric = `---

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -20,6 +20,11 @@ package transform
 import (
 	"bytes"
 	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"text/template"
+
 	"github.com/Knetic/govaluate"
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
@@ -28,10 +33,6 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/location"
 	log "github.com/sirupsen/logrus"
 	"honnef.co/go/netdb"
-	"net"
-	"regexp"
-	"strconv"
-	"text/template"
 )
 
 type Network struct {

--- a/pkg/pipeline/transform/transform_network_test.go
+++ b/pkg/pipeline/transform/transform_network_test.go
@@ -18,12 +18,13 @@
 package transform
 
 import (
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/location"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func getMockNetworkTransformRules() api.NetworkTransformRules {

--- a/pkg/pipeline/transform_multiple_test.go
+++ b/pkg/pipeline/transform_multiple_test.go
@@ -18,9 +18,10 @@
 package pipeline
 
 import (
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 const testConfigTransformMultiple = `---

--- a/pkg/pipeline/utils/exit.go
+++ b/pkg/pipeline/utils/exit.go
@@ -18,11 +18,12 @@
 package utils
 
 import (
-	log "github.com/sirupsen/logrus"
 	"os"
 	"os/signal"
 	"sync"
 	"syscall"
+
+	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/pkg/pipeline/utils/exit_test.go
+++ b/pkg/pipeline/utils/exit_test.go
@@ -2,9 +2,10 @@ package utils
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"syscall"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_SetupElegantExit(t *testing.T) {

--- a/pkg/pipeline/utils/params_parse.go
+++ b/pkg/pipeline/utils/params_parse.go
@@ -19,6 +19,7 @@ package utils
 
 import (
 	"encoding/json"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	log "github.com/sirupsen/logrus"
 )

--- a/pkg/pipeline/write/write_loki.go
+++ b/pkg/pipeline/write/write_loki.go
@@ -20,11 +20,12 @@ package write
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/netobserv/flowlogs-pipeline/pkg/api"
-	pUtils "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"math"
 	"strings"
 	"time"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	pUtils "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 

--- a/pkg/pipeline/write/write_loki_test.go
+++ b/pkg/pipeline/write/write_loki_test.go
@@ -20,10 +20,11 @@ package write
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/netobserv/flowlogs-pipeline/pkg/config"
-	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	"testing"
 	"time"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"

--- a/pkg/pipeline/write/write_stdout.go
+++ b/pkg/pipeline/write/write_stdout.go
@@ -19,9 +19,10 @@ package write
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 type writeStdout struct {

--- a/pkg/pipeline/write/write_stdout_test.go
+++ b/pkg/pipeline/write/write_stdout_test.go
@@ -18,9 +18,10 @@
 package write
 
 import (
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_WriteStdout(t *testing.T) {

--- a/pkg/pipeline/write/write_test.go
+++ b/pkg/pipeline/write/write_test.go
@@ -18,9 +18,10 @@
 package write
 
 import (
+	"testing"
+
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_Write(t *testing.T) {

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -20,12 +20,13 @@ package test
 import (
 	"bytes"
 	"fmt"
+	"reflect"
+	"testing"
+
 	jsoniter "github.com/json-iterator/go"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
-	"reflect"
-	"testing"
 )
 
 func GetIngestMockEntry(missingKey bool) config.GenericMap {

--- a/pkg/test/utils_test.go
+++ b/pkg/test/utils_test.go
@@ -18,8 +18,9 @@
 package test
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_GetIngestMockEntry(t *testing.T) {


### PR DESCRIPTION
This PR enables `goimports` in `make lint` and runs it on all the go files in the repository.