### PR TITLE
Fix a bug with add_if and scientific notation

### DIFF
--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -74,13 +74,13 @@ func (n *Network) Transform(inputEntry config.GenericMap) config.GenericMap {
 				outputEntries[rule.Output+"_Matched"] = true
 			}
 		case api.TransformNetworkOperationName("AddIf"):
-			expressionString := fmt.Sprintf("%v%s", outputEntries[rule.Input], rule.Parameters)
+			expressionString := fmt.Sprintf("val %s", rule.Parameters)
 			expression, err := govaluate.NewEvaluableExpression(expressionString)
 			if err != nil {
 				log.Errorf("Can't evaluate AddIf rule: %+v expression: %v. err %v", rule, expressionString, err)
 				continue
 			}
-			result, evaluateErr := expression.Evaluate(nil)
+			result, evaluateErr := expression.Evaluate(map[string]interface{}{"val": outputEntries[rule.Input]})
 			if evaluateErr == nil && result.(bool) {
 				outputEntries[rule.Output] = outputEntries[rule.Input]
 				outputEntries[rule.Output+"_Evaluate"] = true

--- a/pkg/pipeline/transform/transform_network_test.go
+++ b/pkg/pipeline/transform/transform_network_test.go
@@ -277,3 +277,39 @@ parameters:
 	require.Equal(t, "10.0.0.0/24", output["match-10.0.*"])
 	require.NotEqual(t, "10.0.0.0/24", output["match-11.0.*"])
 }
+
+func Test_Transform_AddIfScientificNotation(t *testing.T) {
+	newNetworkTransform := Network{
+		api.TransformNetwork{
+			Rules: api.NetworkTransformRules{
+				api.NetworkTransformRule{
+					Input:      "value",
+					Output:     "bigger_than_10",
+					Type:       "add_if",
+					Parameters: ">10",
+				},
+				api.NetworkTransformRule{
+					Input:      "value",
+					Output:     "smaller_than_10",
+					Type:       "add_if",
+					Parameters: "<10",
+				},
+			},
+		},
+	}
+
+	var entry config.GenericMap
+	entry = config.GenericMap{
+		"value": 1.2345e67,
+	}
+	output := newNetworkTransform.Transform(entry)
+	require.Equal(t, true, output["bigger_than_10_Evaluate"])
+	require.Equal(t, 1.2345e67, output["bigger_than_10"])
+
+	entry = config.GenericMap{
+		"value": 1.2345e-67,
+	}
+	output = newNetworkTransform.Transform(entry)
+	require.Equal(t, true, output["smaller_than_10_Evaluate"])
+	require.Equal(t, 1.2345e-67, output["smaller_than_10"])
+}


### PR DESCRIPTION
I noticed that when the expression evaluated in "add_if" contains a scientific notation value like `1.2345e-67`, there's an error like:
```
Cannot transition token types from NUMERIC [1.2345] to VARIABLE [e]
```
The solution I found is to pass the value as a parameter to `Evaluate()`