### PR TITLE
NETOBSERV-341 configure netflow v5 separately (breaking change if using v5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Flags:
 ```
 <!---END-AUTO-flowlogs-pipeline_help--->
 
-> Note: for API details refer to  [docs/api.md](docs/api.md).
+> Note: for API details refer to [docs/api.md](docs/api.md).
 > 
 ## Configuration generation
 

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -5,6 +5,7 @@ parameters:
     collector:
       hostname: 0.0.0.0
       port: 2055
+      portLegacy: 2056
     type: collector
   name: ingest_collector
 - decode:

--- a/docs/api.md
+++ b/docs/api.md
@@ -39,12 +39,13 @@ Following is the supported API format for kafka encode:
          batchSize: limit on how many messages will be buffered before being sent to a partition
 </pre>
 ## Ingest collector API
-Following is the supported API format for the netflow collector:
+Following is the supported API format for the NetFlow / IPFIX collector:
 
 <pre>
  collector:
          hostName: the hostname to listen on
-         port: the port number to listen on
+         port: the port number to listen on, for IPFIX/NetFlow v9. Omit or set to 0 to disable IPFIX/NetFlow v9 ingestion
+         portLegacy: the port number to listen on, for legacy NetFlow v5. Omit or set to 0 to disable NetFlow v5 ingestion
          batchMaxLen: the number of accumulated flows before being forwarded for processing
 </pre>
 ## Ingest Kafka API

--- a/hack/deploy-and-monitor-k8s-network-workload.sh
+++ b/hack/deploy-and-monitor-k8s-network-workload.sh
@@ -29,6 +29,7 @@ pipeline:
     collector:
       hostname: 0.0.0.0
       port: 2055
+      portLegacy: 2056
     type: collector
   decode:
     type: json

--- a/network_definitions/config.yaml
+++ b/network_definitions/config.yaml
@@ -6,6 +6,7 @@ description:
 ingest:
   collector:
     port: 2055
+    portLegacy: 2056
     hostName: 0.0.0.0
 transform:
   generic:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -26,7 +26,7 @@ const TagEnum = "enum"
 type API struct {
 	PromEncode       PromEncode          `yaml:"prom" doc:"## Prometheus encode API\nFollowing is the supported API format for prometheus encode:\n"`
 	KafkaEncode      EncodeKafka         `yaml:"kafka" doc:"## Kafka encode API\nFollowing is the supported API format for kafka encode:\n"`
-	IngestCollector  IngestCollector     `yaml:"collector" doc:"## Ingest collector API\nFollowing is the supported API format for the netflow collector:\n"`
+	IngestCollector  IngestCollector     `yaml:"collector" doc:"## Ingest collector API\nFollowing is the supported API format for the NetFlow / IPFIX collector:\n"`
 	IngestKafka      IngestKafka         `yaml:"kafka" doc:"## Ingest Kafka API\nFollowing is the supported API format for the kafka ingest:\n"`
 	IngestGRPCProto  IngestGRPCProto     `yaml:"grpc" doc:"## Ingest GRPC from Network Observability eBPF Agent\nFollowing is the supported API format for the Network Observability eBPF ingest:\n"`
 	DecodeAws        DecodeAws           `yaml:"aws" doc:"## Aws ingest API\nFollowing is the supported API format for Aws flow entries:\n"`

--- a/pkg/api/ingest_collector.go
+++ b/pkg/api/ingest_collector.go
@@ -19,6 +19,7 @@ package api
 
 type IngestCollector struct {
 	HostName    string `yaml:"hostName" doc:"the hostname to listen on"`
-	Port        int    `yaml:"port" doc:"the port number to listen on"`
+	Port        int    `yaml:"port" doc:"the port number to listen on, for IPFIX/NetFlow v9. Omit or set to 0 to disable IPFIX/NetFlow v9 ingestion"`
+	PortLegacy  int    `yaml:"portLegacy" doc:"the port number to listen on, for legacy NetFlow v5. Omit or set to 0 to disable NetFlow v5 ingestion"`
 	BatchMaxLen int    `yaml:"batchMaxLen" doc:"the number of accumulated flows before being forwarded for processing"`
 }

--- a/pkg/confgen/flowlogs2metrics_config.go
+++ b/pkg/confgen/flowlogs2metrics_config.go
@@ -53,8 +53,9 @@ func (cg *ConfGen) generateFlowlogs2PipelineConfig(fileName string) error {
 				"ingest": map[string]interface{}{
 					"type": "collector",
 					"collector": map[string]interface{}{
-						"port":     cg.config.Ingest.Collector.Port,
-						"hostname": cg.config.Ingest.Collector.HostName,
+						"port":       cg.config.Ingest.Collector.Port,
+						"portLegacy": cg.config.Ingest.Collector.PortLegacy,
+						"hostname":   cg.config.Ingest.Collector.HostName,
 					},
 				},
 			},

--- a/pkg/test/e2e/pipline/flp-config.yaml
+++ b/pkg/test/e2e/pipline/flp-config.yaml
@@ -10,6 +10,7 @@ data:
           collector:
             hostname: 0.0.0.0
             port: 2055
+            portLegacy: 2056
           type: collector
         name: ingest_collector
       - decode:


### PR DESCRIPTION
Fixes #200

@eranra @KalmanMeth 
Is it ok with you to have a breaking changes here? (people who used legacy v5 now have to configure it explicitly)
If that's a problem, we could default to the previous behaviour (legacy port = main port +1) and have another setting to disable v5, but I think it's more simple to keep default as 0 = legacy disabled.