### PR TITLE
 Add basic functionality of connection tracking

### DIFF
--- a/pkg/api/conn_track.go
+++ b/pkg/api/conn_track.go
@@ -18,6 +18,7 @@
 package api
 
 type ConnTrack struct {
+	// TODO: should by a pointer instead?
 	KeyDefinition     KeyDefinition `yaml:"keyDefinition" doc:"fields that are used to identify the connection"`
 	OutputRecordTypes []string      `yaml:"outputRecordTypes" doc:"output record types to emit"`
 	OutputFields      []OutputField `yaml:"outputFields" doc:"list of output fields"`

--- a/pkg/api/conn_track.go
+++ b/pkg/api/conn_track.go
@@ -57,7 +57,18 @@ type ConnTrackHash struct {
 
 type OutputField struct {
 	Name      string `yaml:"name" doc:"output field name"`
-	Operation string `yaml:"operation" doc:"aggregate operation on the field value"`
+	Operation string `yaml:"operation" enum:"ConnTrackOperationEnum" doc:"aggregate operation on the field value"`
 	SplitAB   bool   `yaml:"splitAB" doc:"When true, 2 output fields will be created. One for A->B and one for B->A flows."`
 	Input     string `yaml:"input" doc:"The input field to base the operation on. When omitted, 'name' is used"`
+}
+
+type ConnTrackOperationEnum struct {
+	Sum   string `yaml:"sum" doc:"sum"`
+	Count string `yaml:"count" doc:"count"`
+	Min   string `yaml:"min" doc:"min"`
+	Max   string `yaml:"max" doc:"max"`
+}
+
+func ConnTrackOperationName(operation string) string {
+	return GetEnumName(ConnTrackOperationEnum{}, operation)
 }

--- a/pkg/api/conn_track.go
+++ b/pkg/api/conn_track.go
@@ -20,8 +20,17 @@ package api
 type ConnTrack struct {
 	// TODO: should by a pointer instead?
 	KeyDefinition     KeyDefinition `yaml:"keyDefinition" doc:"fields that are used to identify the connection"`
-	OutputRecordTypes []string      `yaml:"outputRecordTypes" doc:"output record types to emit"`
+	OutputRecordTypes []string      `yaml:"outputRecordTypes" enum:"ConnTrackOutputRecordTypeEnum" doc:"output record types to emit"`
 	OutputFields      []OutputField `yaml:"outputFields" doc:"list of output fields"`
+}
+
+type ConnTrackOutputRecordTypeEnum struct {
+	NewConnection string `yaml:"newConnection" doc:"New connection"`
+	FlowLog       string `yaml:"flowLog" doc:"Flow log"`
+}
+
+func ConnTrackOutputRecordTypeName(operation string) string {
+	return GetEnumName(ConnTrackOutputRecordTypeEnum{}, operation)
 }
 
 type KeyDefinition struct {

--- a/pkg/api/enum.go
+++ b/pkg/api/enum.go
@@ -28,6 +28,7 @@ type enums struct {
 	TransformFilterOperationEnum  TransformFilterOperationEnum
 	TransformGenericOperationEnum TransformGenericOperationEnum
 	KafkaEncodeBalancerEnum       KafkaEncodeBalancerEnum
+	ConnTrackOperationEnum        ConnTrackOperationEnum
 	ConnTrackOutputRecordTypeEnum ConnTrackOutputRecordTypeEnum
 }
 

--- a/pkg/api/enum.go
+++ b/pkg/api/enum.go
@@ -28,6 +28,7 @@ type enums struct {
 	TransformFilterOperationEnum  TransformFilterOperationEnum
 	TransformGenericOperationEnum TransformGenericOperationEnum
 	KafkaEncodeBalancerEnum       KafkaEncodeBalancerEnum
+	ConnTrackOutputRecordTypeEnum ConnTrackOutputRecordTypeEnum
 }
 
 type enumNameCacheKey struct {

--- a/pkg/pipeline/conntrack/aggregator.go
+++ b/pkg/pipeline/conntrack/aggregator.go
@@ -43,10 +43,10 @@ type aggregateBase struct {
 	initVal     float64
 }
 
-type aggregateSum struct{ aggregateBase }
-type aggregateCount struct{ aggregateBase }
-type aggregateMin struct{ aggregateBase }
-type aggregateMax struct{ aggregateBase }
+type aSum struct{ aggregateBase }
+type aCount struct{ aggregateBase }
+type aMin struct{ aggregateBase }
+type aMax struct{ aggregateBase }
 
 // TODO: think of adding a more complex operation such as Average Packet Size which involves 2 input fields: Bytes/Packets
 
@@ -66,16 +66,16 @@ func newAggregator(of api.OutputField) (aggregator, error) {
 	switch of.Operation {
 	case api.ConnTrackOperationName("Sum"):
 		aggBase.initVal = 0
-		agg = &aggregateSum{aggBase}
+		agg = &aSum{aggBase}
 	case api.ConnTrackOperationName("Count"):
 		aggBase.initVal = 0
-		agg = &aggregateCount{aggBase}
+		agg = &aCount{aggBase}
 	case api.ConnTrackOperationName("Min"):
 		aggBase.initVal = math.MaxFloat64
-		agg = &aggregateMin{aggBase}
+		agg = &aMin{aggBase}
 	case api.ConnTrackOperationName("Max"):
 		aggBase.initVal = -math.MaxFloat64
-		agg = &aggregateMax{aggBase}
+		agg = &aMax{aggBase}
 	default:
 		return nil, fmt.Errorf("unknown operation: %q", of.Operation)
 	}
@@ -118,7 +118,7 @@ func (agg *aggregateBase) addField(conn connection) {
 	}
 }
 
-func (agg *aggregateSum) update(conn connection, flowLog config.GenericMap, d direction) {
+func (agg *aSum) update(conn connection, flowLog config.GenericMap, d direction) {
 	outputField := agg.getOutputField(d)
 	v, err := agg.getInputFieldValue(flowLog)
 	if err != nil {
@@ -130,14 +130,14 @@ func (agg *aggregateSum) update(conn connection, flowLog config.GenericMap, d di
 	})
 }
 
-func (agg *aggregateCount) update(conn connection, flowLog config.GenericMap, d direction) {
+func (agg *aCount) update(conn connection, flowLog config.GenericMap, d direction) {
 	outputField := agg.getOutputField(d)
 	conn.updateAggValue(outputField, func(curr float64) float64 {
 		return curr + 1
 	})
 }
 
-func (agg *aggregateMin) update(conn connection, flowLog config.GenericMap, d direction) {
+func (agg *aMin) update(conn connection, flowLog config.GenericMap, d direction) {
 	outputField := agg.getOutputField(d)
 	v, err := agg.getInputFieldValue(flowLog)
 	if err != nil {
@@ -150,7 +150,7 @@ func (agg *aggregateMin) update(conn connection, flowLog config.GenericMap, d di
 	})
 }
 
-func (agg *aggregateMax) update(conn connection, flowLog config.GenericMap, d direction) {
+func (agg *aMax) update(conn connection, flowLog config.GenericMap, d direction) {
 	outputField := agg.getOutputField(d)
 	v, err := agg.getInputFieldValue(flowLog)
 	if err != nil {

--- a/pkg/pipeline/conntrack/aggregator.go
+++ b/pkg/pipeline/conntrack/aggregator.go
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2022 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package conntrack
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+// aggregator represents a single aggregate field in a connection. The aggregated values are stored in the connection
+// but managed by the aggregator.
+type aggregator interface {
+	// addField adds an aggregate field to the connection
+	addField(conn connection)
+	// update updates the aggregate field in the connection based on the flow log.
+	update(conn connection, flowLog config.GenericMap, d direction)
+}
+
+type aggregateBase struct {
+	inputField  string
+	outputField string
+	splitAB     bool
+	initVal     float64
+}
+
+type aggregateSum struct{ aggregateBase }
+type aggregateCount struct{ aggregateBase }
+type aggregateMin struct{ aggregateBase }
+type aggregateMax struct{ aggregateBase }
+
+// TODO: think of adding a more complex operation such as Average Packet Size which involves 2 input fields: Bytes/Packets
+
+// newAggregator returns a new aggregator depending on the output field operation
+func newAggregator(of api.OutputField) (aggregator, error) {
+	if of.Name == "" {
+		return nil, fmt.Errorf("empty name %v", of)
+	}
+	var inputField string
+	if of.Input != "" {
+		inputField = of.Input
+	} else {
+		inputField = of.Name
+	}
+	aggBase := aggregateBase{inputField: inputField, outputField: of.Name, splitAB: of.SplitAB}
+	var agg aggregator
+	switch of.Operation {
+	case "sum":
+		aggBase.initVal = 0
+		agg = &aggregateSum{aggBase}
+	case "count":
+		aggBase.initVal = 0
+		agg = &aggregateCount{aggBase}
+	case "min":
+		aggBase.initVal = math.MaxFloat64
+		agg = &aggregateMin{aggBase}
+	case "max":
+		aggBase.initVal = -math.MaxFloat64
+		agg = &aggregateMax{aggBase}
+	default:
+		return nil, fmt.Errorf("unknown operation: %q", of.Operation)
+	}
+	return agg, nil
+}
+
+func (agg *aggregateBase) getOutputField(d direction) string {
+	outputField := agg.outputField
+	if agg.splitAB {
+		switch d {
+		case dirAB:
+			outputField += "_AB"
+		case dirBA:
+			outputField += "_BA"
+		default:
+			log.Panicf("splitAB aggregator %v cannot determine outputField because direction is missing. Check configuration.", outputField)
+		}
+	}
+	return outputField
+}
+
+func (agg *aggregateBase) getInputFieldValue(flowLog config.GenericMap) (float64, error) {
+	rawValue, ok := flowLog[agg.inputField]
+	if !ok {
+		return 0, fmt.Errorf("missing field %v", agg.inputField)
+	}
+	floatValue, err := utils.ConvertToFloat64(rawValue)
+	if err != nil {
+		return 0, fmt.Errorf("cannot convert %v to float64: %w", rawValue, err)
+	}
+	return floatValue, nil
+}
+
+func (agg *aggregateBase) addField(conn connection) {
+	if agg.splitAB {
+		conn.addAgg(agg.getOutputField(dirAB), agg.initVal)
+		conn.addAgg(agg.getOutputField(dirBA), agg.initVal)
+	} else {
+		conn.addAgg(agg.getOutputField(dirNA), agg.initVal)
+	}
+}
+
+func (agg *aggregateSum) update(conn connection, flowLog config.GenericMap, d direction) {
+	outputField := agg.getOutputField(d)
+	v, err := agg.getInputFieldValue(flowLog)
+	if err != nil {
+		log.Errorf("error updating connection %v: %v", string(conn.getHash().hashTotal), err)
+		return
+	}
+	conn.updateAggValue(outputField, func(curr float64) float64 {
+		return curr + v
+	})
+}
+
+func (agg *aggregateCount) update(conn connection, flowLog config.GenericMap, d direction) {
+	outputField := agg.getOutputField(d)
+	conn.updateAggValue(outputField, func(curr float64) float64 {
+		return curr + 1
+	})
+}
+
+func (agg *aggregateMin) update(conn connection, flowLog config.GenericMap, d direction) {
+	outputField := agg.getOutputField(d)
+	v, err := agg.getInputFieldValue(flowLog)
+	if err != nil {
+		log.Errorf("error updating connection %v: %v", string(conn.getHash().hashTotal), err)
+		return
+	}
+
+	conn.updateAggValue(outputField, func(curr float64) float64 {
+		return math.Min(curr, v)
+	})
+}
+
+func (agg *aggregateMax) update(conn connection, flowLog config.GenericMap, d direction) {
+	outputField := agg.getOutputField(d)
+	v, err := agg.getInputFieldValue(flowLog)
+	if err != nil {
+		log.Errorf("error updating connection %v: %v", string(conn.getHash().hashTotal), err)
+		return
+	}
+
+	conn.updateAggValue(outputField, func(curr float64) float64 {
+		return math.Max(curr, v)
+	})
+}

--- a/pkg/pipeline/conntrack/aggregator.go
+++ b/pkg/pipeline/conntrack/aggregator.go
@@ -64,16 +64,16 @@ func newAggregator(of api.OutputField) (aggregator, error) {
 	aggBase := aggregateBase{inputField: inputField, outputField: of.Name, splitAB: of.SplitAB}
 	var agg aggregator
 	switch of.Operation {
-	case "sum":
+	case api.ConnTrackOperationName("Sum"):
 		aggBase.initVal = 0
 		agg = &aggregateSum{aggBase}
-	case "count":
+	case api.ConnTrackOperationName("Count"):
 		aggBase.initVal = 0
 		agg = &aggregateCount{aggBase}
-	case "min":
+	case api.ConnTrackOperationName("Min"):
 		aggBase.initVal = math.MaxFloat64
 		agg = &aggregateMin{aggBase}
-	case "max":
+	case api.ConnTrackOperationName("Max"):
 		aggBase.initVal = -math.MaxFloat64
 		agg = &aggregateMax{aggBase}
 	default:

--- a/pkg/pipeline/conntrack/aggregator_test.go
+++ b/pkg/pipeline/conntrack/aggregator_test.go
@@ -69,6 +69,11 @@ func TestNewAggregator_Valid(t *testing.T) {
 			expected:    &aggregateSum{aggregateBase{"MyInput", "MyAgg", false, 0}},
 		},
 		{
+			name:        "Operation sum",
+			outputField: api.OutputField{Name: "MyAgg", Operation: "sum"},
+			expected:    &aggregateSum{aggregateBase{"MyAgg", "MyAgg", false, 0}},
+		},
+		{
 			name:        "Operation count",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "count"},
 			expected:    &aggregateCount{aggregateBase{"MyAgg", "MyAgg", false, 0}},

--- a/pkg/pipeline/conntrack/aggregator_test.go
+++ b/pkg/pipeline/conntrack/aggregator_test.go
@@ -44,6 +44,7 @@ func TestNewAggregator_Invalid(t *testing.T) {
 		SplitAB:   true,
 		Input:     "Input",
 	})
+	require.NotNil(t, err)
 }
 
 func TestNewAggregator_Valid(t *testing.T) {

--- a/pkg/pipeline/conntrack/aggregator_test.go
+++ b/pkg/pipeline/conntrack/aggregator_test.go
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2022 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package conntrack
+
+import (
+	"math"
+	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAggregator_Invalid(t *testing.T) {
+	var err error
+
+	// Empty Name
+	_, err = newAggregator(api.OutputField{
+		Operation: "sum",
+		SplitAB:   true,
+		Input:     "Input",
+	})
+	require.NotNil(t, err)
+
+	// unknown Operation
+	_, err = newAggregator(api.OutputField{
+		Name:      "MyAgg",
+		Operation: "unknown",
+		SplitAB:   true,
+		Input:     "Input",
+	})
+}
+
+func TestNewAggregator_Valid(t *testing.T) {
+	table := []struct {
+		name        string
+		outputField api.OutputField
+		expected    aggregator
+	}{
+		{
+			name:        "Default SplitAB",
+			outputField: api.OutputField{Name: "MyAgg", Operation: "sum"},
+			expected:    &aggregateSum{aggregateBase{"MyAgg", "MyAgg", false, 0}},
+		},
+		{
+			name:        "Default input",
+			outputField: api.OutputField{Name: "MyAgg", Operation: "sum", SplitAB: true},
+			expected:    &aggregateSum{aggregateBase{"MyAgg", "MyAgg", true, 0}},
+		},
+		{
+			name:        "Custom input",
+			outputField: api.OutputField{Name: "MyAgg", Operation: "sum", Input: "MyInput"},
+			expected:    &aggregateSum{aggregateBase{"MyInput", "MyAgg", false, 0}},
+		},
+		{
+			name:        "Operation count",
+			outputField: api.OutputField{Name: "MyAgg", Operation: "count"},
+			expected:    &aggregateCount{aggregateBase{"MyAgg", "MyAgg", false, 0}},
+		},
+		{
+			name:        "Operation max",
+			outputField: api.OutputField{Name: "MyAgg", Operation: "max"},
+			expected:    &aggregateMax{aggregateBase{"MyAgg", "MyAgg", false, -math.MaxFloat64}},
+		},
+		{
+			name:        "Operation min",
+			outputField: api.OutputField{Name: "MyAgg", Operation: "min"},
+			expected:    &aggregateMin{aggregateBase{"MyAgg", "MyAgg", false, math.MaxFloat64}},
+		},
+	}
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			agg, err := newAggregator(test.outputField)
+			require.NoError(t, err)
+			require.Equal(t, test.expected, agg)
+		})
+	}
+}
+
+func TestAddField_and_Update(t *testing.T) {
+	ofs := []api.OutputField{
+		{Name: "Bytes", Operation: "sum", SplitAB: true},
+		{Name: "Packets", Operation: "sum", SplitAB: false},
+		{Name: "numFlowLogs", Operation: "count"},
+		{Name: "minFlowLogBytes", Operation: "min", Input: "Bytes"},
+		{Name: "maxFlowLogBytes", Operation: "max", Input: "Bytes"},
+	}
+	var aggs []aggregator
+	for _, of := range ofs {
+		agg, err := newAggregator(of)
+		require.NoError(t, err)
+		aggs = append(aggs, agg)
+	}
+
+	ipA := "10.0.0.1"
+	ipB := "10.0.0.2"
+	portA := 1
+	portB := 9002
+	protocolA := 6
+
+	table := []struct {
+		name      string
+		flowLog   config.GenericMap
+		direction direction
+		expected  map[string]float64
+	}{
+		{
+			name:      "flowLog 1",
+			flowLog:   NewFlowLog(ipA, portA, ipB, portB, protocolA, 100, 10),
+			direction: dirAB,
+			expected:  map[string]float64{"Bytes_AB": 100, "Bytes_BA": 0, "Packets": 10, "maxFlowLogBytes": 100, "minFlowLogBytes": 100, "numFlowLogs": 1},
+		},
+		{
+			name:      "flowLog 2",
+			flowLog:   NewFlowLog(ipA, portA, ipB, portB, protocolA, 200, 20),
+			direction: dirBA,
+			expected:  map[string]float64{"Bytes_AB": 100, "Bytes_BA": 200, "Packets": 30, "maxFlowLogBytes": 200, "minFlowLogBytes": 100, "numFlowLogs": 2},
+		},
+	}
+
+	conn := NewConnBuilder().Build()
+	for _, agg := range aggs {
+		agg.addField(conn)
+	}
+	expectedInits := map[string]float64{"Bytes_AB": 0, "Bytes_BA": 0, "Packets": 0, "maxFlowLogBytes": -math.MaxFloat64, "minFlowLogBytes": math.MaxFloat64, "numFlowLogs": 0}
+	require.Equal(t, expectedInits, conn.(*connType).aggFields)
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			for _, agg := range aggs {
+				agg.update(conn, test.flowLog, test.direction)
+			}
+			require.Equal(t, test.expected, conn.(*connType).aggFields)
+		})
+	}
+}

--- a/pkg/pipeline/conntrack/aggregator_test.go
+++ b/pkg/pipeline/conntrack/aggregator_test.go
@@ -56,37 +56,37 @@ func TestNewAggregator_Valid(t *testing.T) {
 		{
 			name:        "Default SplitAB",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "sum"},
-			expected:    &aggregateSum{aggregateBase{"MyAgg", "MyAgg", false, 0}},
+			expected:    &aSum{aggregateBase{"MyAgg", "MyAgg", false, 0}},
 		},
 		{
 			name:        "Default input",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "sum", SplitAB: true},
-			expected:    &aggregateSum{aggregateBase{"MyAgg", "MyAgg", true, 0}},
+			expected:    &aSum{aggregateBase{"MyAgg", "MyAgg", true, 0}},
 		},
 		{
 			name:        "Custom input",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "sum", Input: "MyInput"},
-			expected:    &aggregateSum{aggregateBase{"MyInput", "MyAgg", false, 0}},
+			expected:    &aSum{aggregateBase{"MyInput", "MyAgg", false, 0}},
 		},
 		{
 			name:        "Operation sum",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "sum"},
-			expected:    &aggregateSum{aggregateBase{"MyAgg", "MyAgg", false, 0}},
+			expected:    &aSum{aggregateBase{"MyAgg", "MyAgg", false, 0}},
 		},
 		{
 			name:        "Operation count",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "count"},
-			expected:    &aggregateCount{aggregateBase{"MyAgg", "MyAgg", false, 0}},
+			expected:    &aCount{aggregateBase{"MyAgg", "MyAgg", false, 0}},
 		},
 		{
 			name:        "Operation max",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "max"},
-			expected:    &aggregateMax{aggregateBase{"MyAgg", "MyAgg", false, -math.MaxFloat64}},
+			expected:    &aMax{aggregateBase{"MyAgg", "MyAgg", false, -math.MaxFloat64}},
 		},
 		{
 			name:        "Operation min",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "min"},
-			expected:    &aggregateMin{aggregateBase{"MyAgg", "MyAgg", false, math.MaxFloat64}},
+			expected:    &aMin{aggregateBase{"MyAgg", "MyAgg", false, math.MaxFloat64}},
 		},
 	}
 

--- a/pkg/pipeline/conntrack/aggregator_test.go
+++ b/pkg/pipeline/conntrack/aggregator_test.go
@@ -128,13 +128,13 @@ func TestAddField_and_Update(t *testing.T) {
 	}{
 		{
 			name:      "flowLog 1",
-			flowLog:   NewFlowLog(ipA, portA, ipB, portB, protocolA, 100, 10),
+			flowLog:   newMockFlowLog(ipA, portA, ipB, portB, protocolA, 100, 10),
 			direction: dirAB,
 			expected:  map[string]float64{"Bytes_AB": 100, "Bytes_BA": 0, "Packets": 10, "maxFlowLogBytes": 100, "minFlowLogBytes": 100, "numFlowLogs": 1},
 		},
 		{
 			name:      "flowLog 2",
-			flowLog:   NewFlowLog(ipA, portA, ipB, portB, protocolA, 200, 20),
+			flowLog:   newMockFlowLog(ipA, portA, ipB, portB, protocolA, 200, 20),
 			direction: dirBA,
 			expected:  map[string]float64{"Bytes_AB": 100, "Bytes_BA": 200, "Packets": 30, "maxFlowLogBytes": 200, "minFlowLogBytes": 100, "numFlowLogs": 2},
 		},

--- a/pkg/pipeline/conntrack/conn.go
+++ b/pkg/pipeline/conntrack/conn.go
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2022 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package conntrack
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+)
+
+type connection interface {
+	addAgg(fieldName string, initValue float64)
+	getAggValue(fieldName string) (float64, bool)
+	updateAggValue(fieldName string, newValueFn func(curr float64) float64)
+	toGenericMap() config.GenericMap
+	getHash() totalHashType
+}
+
+type connType struct {
+	hash      totalHashType
+	keys      config.GenericMap
+	aggFields map[string]float64
+}
+
+func (c *connType) addAgg(fieldName string, initValue float64) {
+	c.aggFields[fieldName] = initValue
+}
+
+func (c *connType) getAggValue(fieldName string) (float64, bool) {
+	v, ok := c.aggFields[fieldName]
+	return v, ok
+}
+
+func (c *connType) updateAggValue(fieldName string, newValueFn func(curr float64) float64) {
+	v, ok := c.aggFields[fieldName]
+	if !ok {
+		log.Panicf("tried updating missing field %v", fieldName)
+	}
+	c.aggFields[fieldName] = newValueFn(v)
+}
+
+func (c *connType) toGenericMap() config.GenericMap {
+	gm := config.GenericMap{}
+	for k, v := range c.aggFields {
+		gm[k] = v
+	}
+	// In case of a conflict between the keys and the aggFields, the keys should prevail.
+	for k, v := range c.keys {
+		gm[k] = v
+	}
+	return gm
+}
+
+func (c *connType) getHash() totalHashType {
+	return copyTotalHash(c.hash)
+}
+
+// TODO: Should connBuilder get a file of its own?
+type connBuilder struct {
+	conn *connType
+}
+
+func NewConnBuilder() *connBuilder {
+	return &connBuilder{
+		conn: &connType{
+			aggFields: make(map[string]float64),
+			keys:      config.GenericMap{},
+		},
+	}
+}
+
+func (cb *connBuilder) Hash(h *totalHashType) *connBuilder {
+	cb.conn.hash = copyTotalHash(*h)
+	return cb
+}
+
+func (cb *connBuilder) KeysFrom(flowLog config.GenericMap, kd api.KeyDefinition) *connBuilder {
+	for _, fg := range kd.FieldGroups {
+		for _, f := range fg.Fields {
+			// TODO: is it correct from OOP PoV to access conn.keys directly?
+			cb.conn.keys[f] = flowLog[f]
+		}
+	}
+	return cb
+}
+
+func (cb *connBuilder) Aggregators(aggs []aggregator) *connBuilder {
+	for _, agg := range aggs {
+		agg.addField(cb.conn)
+	}
+	return cb
+}
+
+func (cb *connBuilder) Build() connection {
+	return cb.conn
+}

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -61,7 +61,7 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 		// TODO: think of returning a string rather than []byte
 		computedHash, err := ComputeHash(fl, ct.config.KeyDefinition, ct.hasher)
 		if err != nil {
-			log.Warningf("skipping flow log: %v", err)
+			log.Warningf("skipping flow log %v: %v", fl, err)
 			continue
 		}
 		hashStr := hex.EncodeToString(computedHash.hashTotal)

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2022 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package conntrack
+
+import (
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"hash/fnv"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	log "github.com/sirupsen/logrus"
+)
+
+// direction indicates the direction of a flow log in a connection. It's used by aggregators to determine which split
+// of the aggregator should be updated, xxx_AB or xxx_BA.
+type direction uint8
+
+const (
+	dirNA direction = iota
+	dirAB
+	dirBA
+)
+
+type ConnectionTracker interface {
+	Track(flowLogs []config.GenericMap) []config.GenericMap
+}
+
+type conntrackImpl struct {
+	config api.ConnTrack
+	hasher hash.Hash
+	// TODO: should the key of the map be a custom hashStrType instead of string?
+	hash2conn                 map[string]connection
+	aggregators               []aggregator
+	shouldOutputFlowLogs      bool
+	shouldOutputNewConnection bool
+}
+
+func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap {
+	log.Debugf("Entering Track")
+	log.Debugf("Track none, in = %v", flowLogs)
+
+	var outputRecords []config.GenericMap
+	for _, fl := range flowLogs {
+		// TODO: think of returning a string rather than []byte
+		computedHash, err := ComputeHash(fl, ct.config.KeyDefinition, ct.hasher)
+		if err != nil {
+			log.Warningf("skipping flow log: %v", err)
+			continue
+		}
+		hashStr := hex.EncodeToString(computedHash.hashTotal)
+		conn, exists := ct.hash2conn[hashStr]
+		if !exists {
+			builder := NewConnBuilder()
+			conn = builder.
+				Hash(computedHash).
+				KeysFrom(fl, ct.config.KeyDefinition).
+				Aggregators(ct.aggregators).
+				Build()
+			ct.addConnection(hashStr, conn)
+			ct.updateConnection(conn, fl, computedHash)
+			if ct.shouldOutputNewConnection {
+				outputRecords = append(outputRecords, conn.toGenericMap())
+			}
+		} else {
+			ct.updateConnection(conn, fl, computedHash)
+		}
+
+		if ct.shouldOutputFlowLogs {
+			outputRecords = append(outputRecords, fl)
+		}
+	}
+	return outputRecords
+}
+
+func (ct *conntrackImpl) addConnection(hashStr string, conn connection) {
+	ct.hash2conn[hashStr] = conn
+}
+
+func (ct *conntrackImpl) updateConnection(conn connection, flowLog config.GenericMap, flowLogHash *totalHashType) {
+	d := ct.getFlowLogDirection(conn, flowLogHash)
+	for _, agg := range ct.aggregators {
+		agg.update(conn, flowLog, d)
+	}
+}
+
+func (ct *conntrackImpl) getFlowLogDirection(conn connection, flowLogHash *totalHashType) direction {
+	d := dirNA
+	if ct.config.KeyDefinition.Hash.FieldGroupARef != "" {
+		if hex.EncodeToString(conn.getHash().hashA) == hex.EncodeToString(flowLogHash.hashA) {
+			// A -> B
+			d = dirAB
+		} else {
+			// B -> A
+			d = dirBA
+		}
+	}
+	return d
+}
+
+// NewConnectionTrack creates a new connection track instance
+func NewConnectionTrack(config api.ConnTrack) (ConnectionTracker, error) {
+	var aggregators []aggregator
+	for _, of := range config.OutputFields {
+		agg, err := newAggregator(of)
+		if err != nil {
+			return nil, fmt.Errorf("error creating aggregator: %w", err)
+		}
+		aggregators = append(aggregators, agg)
+	}
+	shouldOutputFlowLogs := false
+	shouldOutputNewConnection := false
+	for _, option := range config.OutputRecordTypes {
+		switch option {
+		case "flowLog":
+			shouldOutputFlowLogs = true
+		case "newConnection":
+			shouldOutputNewConnection = true
+		default:
+			return nil, fmt.Errorf("unknown OutputRecordTypes: %v", option)
+		}
+	}
+
+	conntrack := &conntrackImpl{
+		config:                    config,
+		hasher:                    fnv.New32a(),
+		aggregators:               aggregators,
+		hash2conn:                 make(map[string]connection),
+		shouldOutputFlowLogs:      shouldOutputFlowLogs,
+		shouldOutputNewConnection: shouldOutputNewConnection,
+	}
+	return conntrack, nil
+}

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -128,9 +128,9 @@ func NewConnectionTrack(config api.ConnTrack) (ConnectionTracker, error) {
 	shouldOutputNewConnection := false
 	for _, option := range config.OutputRecordTypes {
 		switch option {
-		case "flowLog":
+		case api.ConnTrackOutputRecordTypeName("FlowLog"):
 			shouldOutputFlowLogs = true
-		case "newConnection":
+		case api.ConnTrackOutputRecordTypeName("NewConnection"):
 			shouldOutputNewConnection = true
 		default:
 			return nil, fmt.Errorf("unknown OutputRecordTypes: %v", option)

--- a/pkg/pipeline/conntrack/conntrack_test.go
+++ b/pkg/pipeline/conntrack/conntrack_test.go
@@ -27,15 +27,15 @@ import (
 
 func buildMockConnTrackConfig(isBidirectional bool, outputRecordType []string) *api.ConnTrack {
 	splitAB := isBidirectional
-	var h api.ConnTrackHash
+	var hash api.ConnTrackHash
 	if isBidirectional {
-		h = api.ConnTrackHash{
+		hash = api.ConnTrackHash{
 			FieldGroupRefs: []string{"protocol"},
 			FieldGroupARef: "src",
 			FieldGroupBRef: "dst",
 		}
 	} else {
-		h = api.ConnTrackHash{
+		hash = api.ConnTrackHash{
 			FieldGroupRefs: []string{"protocol", "src", "dst"},
 		}
 	}
@@ -63,7 +63,7 @@ func buildMockConnTrackConfig(isBidirectional bool, outputRecordType []string) *
 					},
 				},
 			},
-			Hash: h,
+			Hash: hash,
 		},
 		OutputFields: []api.OutputField{
 			{Name: "Bytes", Operation: "sum", SplitAB: splitAB},

--- a/pkg/pipeline/conntrack/conntrack_test.go
+++ b/pkg/pipeline/conntrack/conntrack_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func buildConnTrackConfig(isBidirectional bool, outputRecordType []string) *api.ConnTrack {
+func buildMockConnTrackConfig(isBidirectional bool, outputRecordType []string) *api.ConnTrack {
 	splitAB := isBidirectional
 	var h api.ConnTrackHash
 	if isBidirectional {
@@ -122,7 +122,7 @@ func TestTrack(t *testing.T) {
 	}{
 		{
 			"bidirectional, output new connection",
-			buildConnTrackConfig(true, []string{"newConnection"}),
+			buildMockConnTrackConfig(true, []string{"newConnection"}),
 			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
 				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1),
@@ -130,7 +130,7 @@ func TestTrack(t *testing.T) {
 		},
 		{
 			"bidirectional, output new connection and flow log",
-			buildConnTrackConfig(true, []string{"newConnection", "flowLog"}),
+			buildMockConnTrackConfig(true, []string{"newConnection", "flowLog"}),
 			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
 				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1),
@@ -142,7 +142,7 @@ func TestTrack(t *testing.T) {
 		},
 		{
 			"unidirectional, output new connection",
-			buildConnTrackConfig(false, []string{"newConnection"}),
+			buildMockConnTrackConfig(false, []string{"newConnection"}),
 			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
 				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1),
@@ -151,7 +151,7 @@ func TestTrack(t *testing.T) {
 		},
 		{
 			"unidirectional, output new connection and flow log",
-			buildConnTrackConfig(false, []string{"newConnection", "flowLog"}),
+			buildMockConnTrackConfig(false, []string{"newConnection", "flowLog"}),
 			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
 				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1),

--- a/pkg/pipeline/conntrack/conntrack_test.go
+++ b/pkg/pipeline/conntrack/conntrack_test.go
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2022 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package conntrack
+
+import (
+	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func buildConnTrackConfig(isBidirectional bool, outputRecordType []string) *api.ConnTrack {
+	splitAB := isBidirectional
+	var h api.ConnTrackHash
+	if isBidirectional {
+		h = api.ConnTrackHash{
+			FieldGroupRefs: []string{"protocol"},
+			FieldGroupARef: "src",
+			FieldGroupBRef: "dst",
+		}
+	} else {
+		h = api.ConnTrackHash{
+			FieldGroupRefs: []string{"protocol", "src", "dst"},
+		}
+	}
+	return &api.ConnTrack{
+		KeyDefinition: api.KeyDefinition{
+			FieldGroups: []api.FieldGroup{
+				{
+					Name: "src",
+					Fields: []string{
+						"SrcAddr",
+						"SrcPort",
+					},
+				},
+				{
+					Name: "dst",
+					Fields: []string{
+						"DstAddr",
+						"DstPort",
+					},
+				},
+				{
+					Name: "protocol",
+					Fields: []string{
+						"Proto",
+					},
+				},
+			},
+			Hash: h,
+		},
+		OutputFields: []api.OutputField{
+			{Name: "Bytes", Operation: "sum", SplitAB: splitAB},
+			{Name: "Packets", Operation: "sum", SplitAB: splitAB},
+			{Name: "numFlowLogs", Operation: "count", SplitAB: false},
+		},
+		OutputRecordTypes: outputRecordType,
+	}
+}
+
+func newMockRecordConnAB(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytesAB, bytesBA, packetsAB, packetsBA, numFlowLogs float64) config.GenericMap {
+	return config.GenericMap{
+		"SrcAddr":     srcIP,
+		"SrcPort":     srcPort,
+		"DstAddr":     dstIP,
+		"DstPort":     dstPort,
+		"Proto":       protocol,
+		"Bytes_AB":    bytesAB,
+		"Bytes_BA":    bytesBA,
+		"Packets_AB":  packetsAB,
+		"Packets_BA":  packetsBA,
+		"numFlowLogs": numFlowLogs,
+	}
+}
+
+func newMockRecordConn(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets, numFlowLogs float64) config.GenericMap {
+	return config.GenericMap{
+		"SrcAddr":     srcIP,
+		"SrcPort":     srcPort,
+		"DstAddr":     dstIP,
+		"DstPort":     dstPort,
+		"Proto":       protocol,
+		"Bytes":       bytes,
+		"Packets":     packets,
+		"numFlowLogs": numFlowLogs,
+	}
+}
+
+func TestTrack(t *testing.T) {
+
+	ipA := "10.0.0.1"
+	ipB := "10.0.0.2"
+	portA := 9001
+	portB := 9002
+	protocol := 6
+
+	flAB1 := NewFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
+	flAB2 := NewFlowLog(ipA, portA, ipB, portB, protocol, 222, 22)
+	flBA3 := NewFlowLog(ipB, portB, ipA, portA, protocol, 333, 33)
+	flBA4 := NewFlowLog(ipB, portB, ipA, portA, protocol, 444, 44)
+	table := []struct {
+		name          string
+		conf          *api.ConnTrack
+		inputFlowLogs []config.GenericMap
+		expected      []config.GenericMap
+	}{
+		{
+			"bidirectional, output new connection",
+			buildConnTrackConfig(true, []string{"newConnection"}),
+			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
+			[]config.GenericMap{
+				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1),
+			},
+		},
+		{
+			"bidirectional, output new connection and flow log",
+			buildConnTrackConfig(true, []string{"newConnection", "flowLog"}),
+			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
+			[]config.GenericMap{
+				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1),
+				flAB1,
+				flAB2,
+				flBA3,
+				flBA4,
+			},
+		},
+		{
+			"unidirectional, output new connection",
+			buildConnTrackConfig(false, []string{"newConnection"}),
+			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
+			[]config.GenericMap{
+				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1),
+				newMockRecordConn(ipB, portB, ipA, portA, protocol, 333, 33, 1),
+			},
+		},
+		{
+			"unidirectional, output new connection and flow log",
+			buildConnTrackConfig(false, []string{"newConnection", "flowLog"}),
+			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
+			[]config.GenericMap{
+				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1),
+				flAB1,
+				flAB2,
+				newMockRecordConn(ipB, portB, ipA, portA, protocol, 333, 33, 1),
+				flBA3,
+				flBA4,
+			},
+		},
+	}
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			ct, err := NewConnectionTrack(*test.conf)
+			require.NoError(t, err)
+			actual := ct.Track(test.inputFlowLogs)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}

--- a/pkg/pipeline/conntrack/conntrack_test.go
+++ b/pkg/pipeline/conntrack/conntrack_test.go
@@ -110,10 +110,10 @@ func TestTrack(t *testing.T) {
 	portB := 9002
 	protocol := 6
 
-	flAB1 := NewFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
-	flAB2 := NewFlowLog(ipA, portA, ipB, portB, protocol, 222, 22)
-	flBA3 := NewFlowLog(ipB, portB, ipA, portA, protocol, 333, 33)
-	flBA4 := NewFlowLog(ipB, portB, ipA, portA, protocol, 444, 44)
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
+	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22)
+	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33)
+	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 444, 44)
 	table := []struct {
 		name          string
 		conf          *api.ConnTrack

--- a/pkg/pipeline/conntrack/hash_test.go
+++ b/pkg/pipeline/conntrack/hash_test.go
@@ -18,6 +18,8 @@
 package conntrack
 
 import (
+	"encoding/hex"
+	"fmt"
 	"hash/fnv"
 	"testing"
 
@@ -38,7 +40,7 @@ func NewFlowLog(srcIP string, srcPort int, dstIP string, dstPort int, protocol i
 	}
 }
 
-var hasher = fnv.New32a()
+var testHasher = fnv.New32a()
 
 func TestComputeHash_Unidirectional(t *testing.T) {
 	keyDefinition := api.KeyDefinition{
@@ -113,8 +115,8 @@ func TestComputeHash_Unidirectional(t *testing.T) {
 	}
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
-			h1, err1 := ComputeHash(test.flowLog1, keyDefinition, hasher)
-			h2, err2 := ComputeHash(test.flowLog2, keyDefinition, hasher)
+			h1, err1 := ComputeHash(test.flowLog1, keyDefinition, testHasher)
+			h2, err2 := ComputeHash(test.flowLog2, keyDefinition, testHasher)
 			require.NoError(t, err1)
 			require.NoError(t, err2)
 			if test.sameHash {
@@ -201,14 +203,14 @@ func TestComputeHash_Bidirectional(t *testing.T) {
 	}
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
-			h1, err1 := ComputeHash(test.flowLog1, keyDefinition, hasher)
-			h2, err2 := ComputeHash(test.flowLog2, keyDefinition, hasher)
+			h1, err1 := ComputeHash(test.flowLog1, keyDefinition, testHasher)
+			h2, err2 := ComputeHash(test.flowLog2, keyDefinition, testHasher)
 			require.NoError(t, err1)
 			require.NoError(t, err2)
 			if test.sameHash {
-				require.Equal(t, h1, h2)
+				require.Equal(t, h1.hashTotal, h2.hashTotal)
 			} else {
-				require.NotEqual(t, h1, h2)
+				require.NotEqual(t, h1.hashTotal, h2.hashTotal)
 			}
 		})
 	}
@@ -242,3 +244,4 @@ func TestComputeHash_MissingField(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, h)
 }
+

--- a/pkg/pipeline/conntrack/hash_test.go
+++ b/pkg/pipeline/conntrack/hash_test.go
@@ -18,8 +18,6 @@
 package conntrack
 
 import (
-	"encoding/hex"
-	"fmt"
 	"hash/fnv"
 	"testing"
 
@@ -240,8 +238,7 @@ func TestComputeHash_MissingField(t *testing.T) {
 
 	fl := NewFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22)
 
-	h, err := ComputeHash(fl, keyDefinition, hasher)
+	h, err := ComputeHash(fl, keyDefinition, testHasher)
 	require.NoError(t, err)
 	require.NotNil(t, h)
 }
-

--- a/pkg/pipeline/conntrack/hash_test.go
+++ b/pkg/pipeline/conntrack/hash_test.go
@@ -26,18 +26,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func NewFlowLog(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets int) config.GenericMap {
-	return config.GenericMap{
-		"SrcAddr": srcIP,
-		"SrcPort": srcPort,
-		"DstAddr": dstIP,
-		"DstPort": dstPort,
-		"Proto":   protocol,
-		"Bytes":   bytes,
-		"Packets": packets,
-	}
-}
-
 var testHasher = fnv.New32a()
 
 func TestComputeHash_Unidirectional(t *testing.T) {
@@ -82,32 +70,32 @@ func TestComputeHash_Unidirectional(t *testing.T) {
 	}{
 		{
 			"Same IP, port and protocol",
-			NewFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			NewFlowLog(ipA, portA, ipB, portB, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 222, 11),
 			true,
 		},
 		{
 			"Alternating ip+port",
-			NewFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			NewFlowLog(ipB, portB, ipA, portA, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
+			newMockFlowLog(ipB, portB, ipA, portA, protocolA, 222, 11),
 			false,
 		},
 		{
 			"Alternating ip",
-			NewFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			NewFlowLog(ipB, portA, ipA, portB, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
+			newMockFlowLog(ipB, portA, ipA, portB, protocolA, 222, 11),
 			false,
 		},
 		{
 			"Alternating port",
-			NewFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			NewFlowLog(ipA, portB, ipB, portA, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
+			newMockFlowLog(ipA, portB, ipB, portA, protocolA, 222, 11),
 			false,
 		},
 		{
 			"Same IP+port, different protocol",
-			NewFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			NewFlowLog(ipA, portA, ipB, portB, protocolB, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolB, 222, 11),
 			false,
 		},
 	}
@@ -170,32 +158,32 @@ func TestComputeHash_Bidirectional(t *testing.T) {
 	}{
 		{
 			"Same IP, port and protocol",
-			NewFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			NewFlowLog(ipA, portA, ipB, portB, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 222, 11),
 			true,
 		},
 		{
 			"Alternating ip+port",
-			NewFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			NewFlowLog(ipB, portB, ipA, portA, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
+			newMockFlowLog(ipB, portB, ipA, portA, protocolA, 222, 11),
 			true,
 		},
 		{
 			"Alternating ip",
-			NewFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			NewFlowLog(ipB, portA, ipA, portB, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
+			newMockFlowLog(ipB, portA, ipA, portB, protocolA, 222, 11),
 			false,
 		},
 		{
 			"Alternating port",
-			NewFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			NewFlowLog(ipA, portB, ipB, portA, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
+			newMockFlowLog(ipA, portB, ipB, portA, protocolA, 222, 11),
 			false,
 		},
 		{
 			"Same IP+port, different protocol",
-			NewFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			NewFlowLog(ipA, portA, ipB, portB, protocolB, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolB, 222, 11),
 			false,
 		},
 	}
@@ -236,7 +224,7 @@ func TestComputeHash_MissingField(t *testing.T) {
 	portB := 9002
 	protocolA := 6
 
-	fl := NewFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22)
+	fl := newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22)
 
 	h, err := ComputeHash(fl, keyDefinition, testHasher)
 	require.NoError(t, err)

--- a/pkg/pipeline/conntrack/utils_test.go
+++ b/pkg/pipeline/conntrack/utils_test.go
@@ -1,0 +1,15 @@
+package conntrack
+
+import "github.com/netobserv/flowlogs-pipeline/pkg/config"
+
+func newMockFlowLog(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets int) config.GenericMap {
+	return config.GenericMap{
+		"SrcAddr": srcIP,
+		"SrcPort": srcPort,
+		"DstAddr": dstIP,
+		"DstPort": dstPort,
+		"Proto":   protocol,
+		"Bytes":   bytes,
+		"Packets": packets,
+	}
+}


### PR DESCRIPTION
This PR adds the basic functionality of connection tracking.
Currently it outputs only new connection records and flow logs records.

Notes:
- There are still missing parts that will be added in later PRs such as adding the hash field in the output records,  reporting on connection status/end and deleting ended connections
- I struggled finding names for the identifiers (methods, variables, etc) and deciding what should be exported (PascalCase). Please advice on better names.
- ~~Once #201 is merged, this PR should be rebased.~~