### PR TITLE
Enum race

### DIFF
--- a/pkg/api/encode_kafka.go
+++ b/pkg/api/encode_kafka.go
@@ -35,6 +35,6 @@ type KafkaEncodeBalancerEnum struct {
 	Murmur2    string `yaml:"murmur2" doc:"Murmur2 balancer"`
 }
 
-func KafkaEncodeBalancerName(operation string) string {
-	return GetEnumName(KafkaEncodeBalancerEnum{}, operation)
+func KafkaEncodeBalancerName(enumCache *EnumNamesCache, operation string) string {
+	return GetEnumName(KafkaEncodeBalancerEnum{}, enumCache, operation)
 }

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -30,8 +30,8 @@ type PromEncodeOperationEnum struct {
 	Histogram string `yaml:"histogram" doc:"counts samples in configurable buckets"`
 }
 
-func PromEncodeOperationName(operation string) string {
-	return GetEnumName(PromEncodeOperationEnum{}, operation)
+func PromEncodeOperationName(enumCache *EnumNamesCache, operation string) string {
+	return GetEnumName(PromEncodeOperationEnum{}, enumCache, operation)
 }
 
 type PromMetricsItem struct {

--- a/pkg/api/enum.go
+++ b/pkg/api/enum.go
@@ -30,17 +30,19 @@ type enums struct {
 	KafkaEncodeBalancerEnum       KafkaEncodeBalancerEnum
 }
 
-type enumNameCacheKey struct {
-	enum      interface{}
-	operation string
+type EnumNamesCache struct {
+	namesCache map[string]string
 }
 
-var enumNamesCache = map[enumNameCacheKey]string{}
+func InitEnumCache(len int) *EnumNamesCache {
+	return &EnumNamesCache{
+		namesCache: make(map[string]string, len),
+	}
+}
 
 // GetEnumName gets the name of an enum value from the representing enum struct based on `TagYaml` tag.
-func GetEnumName(enum interface{}, operation string) string {
-	key := enumNameCacheKey{enum: enum, operation: operation}
-	cachedValue, found := enumNamesCache[key]
+func GetEnumName(enum interface{}, cache *EnumNamesCache, operation string) string {
+	cachedValue, found := cache.namesCache[operation]
 	if found {
 		return cachedValue
 	}
@@ -54,7 +56,7 @@ func GetEnumName(enum interface{}, operation string) string {
 	}
 	tag := field.Tag.Get(TagYaml)
 
-	enumNamesCache[key] = tag
+	cache.namesCache[operation] = tag
 	return tag
 }
 

--- a/pkg/api/transform_filter.go
+++ b/pkg/api/transform_filter.go
@@ -27,8 +27,8 @@ type TransformFilterOperationEnum struct {
 	RemoveEntryIfDoesntExist string `yaml:"remove_entry_if_doesnt_exist" doc:"removes the entry if the field doesnt exist"`
 }
 
-func TransformFilterOperationName(operation string) string {
-	return GetEnumName(TransformFilterOperationEnum{}, operation)
+func TransformFilterOperationName(enumCache *EnumNamesCache, operation string) string {
+	return GetEnumName(TransformFilterOperationEnum{}, enumCache, operation)
 }
 
 type TransformFilterRule struct {

--- a/pkg/api/transform_generic.go
+++ b/pkg/api/transform_generic.go
@@ -27,8 +27,8 @@ type TransformGenericOperationEnum struct {
 	ReplaceKeys          string `yaml:"replace_keys" doc:"removes all old keys and uses only the new keys"`
 }
 
-func TransformGenericOperationName(operation string) string {
-	return GetEnumName(TransformGenericOperationEnum{}, operation)
+func TransformGenericOperationName(enumCache *EnumNamesCache, operation string) string {
+	return GetEnumName(TransformGenericOperationEnum{}, enumCache, operation)
 }
 
 type GenericTransformRule struct {

--- a/pkg/api/transform_network.go
+++ b/pkg/api/transform_network.go
@@ -34,8 +34,8 @@ type TransformNetworkOperationEnum struct {
 	AddKubernetes string `yaml:"add_kubernetes" doc:"add output kubernetes fields from input"`
 }
 
-func TransformNetworkOperationName(operation string) string {
-	return GetEnumName(TransformNetworkOperationEnum{}, operation)
+func TransformNetworkOperationName(enumCache *EnumNamesCache, operation string) string {
+	return GetEnumName(TransformNetworkOperationEnum{}, enumCache, operation)
 }
 
 type NetworkTransformRule struct {

--- a/pkg/pipeline/encode/encode_kafka.go
+++ b/pkg/pipeline/encode/encode_kafka.go
@@ -41,6 +41,7 @@ type encodeKafka struct {
 	kafkaParams api.EncodeKafka
 	kafkaWriter kafkaWriteMessage
 	prevRecords []config.GenericMap
+	enumCache   *api.EnumNamesCache
 }
 
 // Encode writes entries to kafka topic
@@ -68,17 +69,19 @@ func NewEncodeKafka(params config.StageParam) (Encoder, error) {
 	log.Debugf("entering NewEncodeKafka")
 	jsonEncodeKafka := params.Encode.Kafka
 
+	enumCache := api.InitEnumCache(5)
+
 	var balancer kafkago.Balancer
 	switch jsonEncodeKafka.Balancer {
-	case api.KafkaEncodeBalancerName("RoundRobin"):
+	case api.KafkaEncodeBalancerName(enumCache, "RoundRobin"):
 		balancer = &kafkago.RoundRobin{}
-	case api.KafkaEncodeBalancerName("LeastBytes"):
+	case api.KafkaEncodeBalancerName(enumCache, "LeastBytes"):
 		balancer = &kafkago.LeastBytes{}
-	case api.KafkaEncodeBalancerName("Hash"):
+	case api.KafkaEncodeBalancerName(enumCache, "Hash"):
 		balancer = &kafkago.Hash{}
-	case api.KafkaEncodeBalancerName("Crc32"):
+	case api.KafkaEncodeBalancerName(enumCache, "Crc32"):
 		balancer = &kafkago.CRC32Balancer{}
-	case api.KafkaEncodeBalancerName("Murmur2"):
+	case api.KafkaEncodeBalancerName(enumCache, "Murmur2"):
 		balancer = &kafkago.Murmur2Balancer{}
 	default:
 		balancer = nil
@@ -108,5 +111,6 @@ func NewEncodeKafka(params config.StageParam) (Encoder, error) {
 	return &encodeKafka{
 		kafkaParams: jsonEncodeKafka,
 		kafkaWriter: &kafkaWriter,
+		enumCache:   enumCache,
 	}, nil
 }

--- a/pkg/pipeline/encode/encode_prom_test.go
+++ b/pkg/pipeline/encode/encode_prom_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -170,8 +171,9 @@ func Test_EncodeAggregate(t *testing.T) {
 				labelNames: []string{"by", "aggregate"},
 			},
 		},
-		mList:  list.New(),
-		mCache: make(metricCache),
+		mList:     list.New(),
+		mCache:    make(metricCache),
+		enumCache: api.InitEnumCache(3),
 	}
 
 	newEncode.Encode(metrics)

--- a/pkg/pipeline/transform/transform_filter.go
+++ b/pkg/pipeline/transform/transform_filter.go
@@ -24,7 +24,8 @@ import (
 )
 
 type Filter struct {
-	Rules []api.TransformFilterRule
+	Rules     []api.TransformFilterRule
+	enumCache *api.EnumNamesCache
 }
 
 // Transform transforms a flow
@@ -37,13 +38,13 @@ func (f *Filter) Transform(input []config.GenericMap) []config.GenericMap {
 		for _, rule := range f.Rules {
 			log.Debugf("rule = %v", rule)
 			switch rule.Type {
-			case api.TransformFilterOperationName("RemoveField"):
+			case api.TransformFilterOperationName(f.enumCache, "RemoveField"):
 				delete(outputEntry, rule.Input)
-			case api.TransformFilterOperationName("RemoveEntryIfExists"):
+			case api.TransformFilterOperationName(f.enumCache, "RemoveEntryIfExists"):
 				if _, ok := entry[rule.Input]; ok {
 					addToOutput = false
 				}
-			case api.TransformFilterOperationName("RemoveEntryIfDoesntExist"):
+			case api.TransformFilterOperationName(f.enumCache, "RemoveEntryIfDoesntExist"):
 				if _, ok := entry[rule.Input]; !ok {
 					addToOutput = false
 				}
@@ -62,8 +63,10 @@ func (f *Filter) Transform(input []config.GenericMap) []config.GenericMap {
 // NewTransformFilter create a new filter transform
 func NewTransformFilter(params config.StageParam) (Transformer, error) {
 	log.Debugf("entering NewTransformFilter")
+	enumCache := api.InitEnumCache(3)
 	transformFilter := &Filter{
-		Rules: params.Transform.Filter.Rules,
+		Rules:     params.Transform.Filter.Rules,
+		enumCache: enumCache,
 	}
 	return transformFilter, nil
 }

--- a/pkg/pipeline/transform/transform_filter_test.go
+++ b/pkg/pipeline/transform/transform_filter_test.go
@@ -35,10 +35,10 @@ parameters:
       type: filter
       filter:
         rules:
-        - input: dstPort
-          type: remove_field
-        - input: srcPort
-          type: remove_field
+          - input: dstPort
+            type: remove_field
+          - input: srcPort
+            type: remove_field
 `
 
 const testConfigTransformFilterRemoveEntryIfExists = `---
@@ -51,8 +51,8 @@ parameters:
       type: filter
       filter:
         rules:
-        - input: srcPort
-          type: remove_entry_if_exists
+          - input: srcPort
+            type: remove_entry_if_exists
 `
 
 const testConfigTransformFilterRemoveEntryIfDoesntExists = `---
@@ -65,8 +65,8 @@ parameters:
       type: filter
       filter:
         rules:
-        - input: doesntSrcPort
-          type: remove_entry_if_doesnt_exist
+          - input: doesntSrcPort
+            type: remove_entry_if_doesnt_exist
 `
 
 func getFilterExpectedOutput() config.GenericMap {

--- a/pkg/pipeline/transform/transform_generic.go
+++ b/pkg/pipeline/transform/transform_generic.go
@@ -24,8 +24,9 @@ import (
 )
 
 type Generic struct {
-	policy string
-	rules  []api.GenericTransformRule
+	policy    string
+	rules     []api.GenericTransformRule
+	enumCache *api.EnumNamesCache
 }
 
 // Transform transforms a flow to a new set of keys
@@ -55,18 +56,21 @@ func (g *Generic) Transform(input []config.GenericMap) []config.GenericMap {
 func NewTransformGeneric(params config.StageParam) (Transformer, error) {
 	log.Debugf("entering NewTransformGeneric")
 	log.Debugf("params.Transform.Generic = %v", params.Transform.Generic)
+	enumCache := api.InitEnumCache(2)
+
 	rules := params.Transform.Generic.Rules
 	policy := params.Transform.Generic.Policy
 	switch policy {
-	case "replace_keys", "preserve_original_keys", "":
+	case api.TransformGenericOperationName(enumCache, "ReplaceKeys"), api.TransformGenericOperationName(enumCache, "PreserveOriginalKeys"), "":
 		// valid; nothing to do
 		log.Infof("NewTransformGeneric, policy = %s", policy)
 	default:
 		log.Panicf("unknown policy %s for transform.generic", policy)
 	}
 	transformGeneric := &Generic{
-		policy: policy,
-		rules:  rules,
+		policy:    policy,
+		rules:     rules,
+		enumCache: enumCache,
 	}
 	log.Debugf("transformGeneric = %v", transformGeneric)
 	return transformGeneric, nil

--- a/pkg/pipeline/transform/transform_generic_test.go
+++ b/pkg/pipeline/transform/transform_generic_test.go
@@ -36,18 +36,18 @@ parameters:
       generic:
         policy: replace_keys
         rules:
-        - input: srcIP
-          output: SrcAddr
-        - input: dstIP
-          output: DstAddr
-        - input: dstPort
-          output: DstPort
-        - input: srcPort
-          output: SrcPort
-        - input: protocol
-          output: Protocol
-        - input: srcIP
-          output: srcIP
+          - input: srcIP
+            output: SrcAddr
+          - input: dstIP
+            output: DstAddr
+          - input: dstPort
+            output: DstPort
+          - input: srcPort
+            output: SrcPort
+          - input: protocol
+            output: Protocol
+          - input: srcIP
+            output: srcIP
 `
 
 const testConfigTransformGenericMaintainTrue = `---
@@ -61,18 +61,18 @@ parameters:
       generic:
         policy: preserve_original_keys
         rules:
-        - input: srcIP
-          output: SrcAddr
-        - input: dstIP
-          output: DstAddr
-        - input: dstPort
-          output: DstPort
-        - input: srcPort
-          output: SrcPort
-        - input: protocol
-          output: Protocol
-        - input: srcIP
-          output: srcIP
+          - input: srcIP
+            output: SrcAddr
+          - input: dstIP
+            output: DstAddr
+          - input: dstPort
+            output: DstPort
+          - input: srcPort
+            output: SrcPort
+          - input: protocol
+            output: Protocol
+          - input: srcIP
+            output: srcIP
 `
 
 func getGenericExpectedOutputShort() config.GenericMap {

--- a/pkg/pipeline/transform/transform_network_test.go
+++ b/pkg/pipeline/transform/transform_network_test.go
@@ -128,9 +128,10 @@ func Test_Transform(t *testing.T) {
 	expectedOutput := getExpectedOutput()
 
 	var networkTransform = Network{
-		api.TransformNetwork{
+		networkRules: api.TransformNetwork{
 			Rules: rules,
 		},
+		enumCache: api.InitEnumCache(7),
 	}
 
 	err := location.InitLocationDB()
@@ -154,9 +155,10 @@ func Test_TransformAddSubnetParseCIDRFailure(t *testing.T) {
 	delete(expectedOutput, "subnet24SrcIP")
 
 	var networkTransform = Network{
-		api.TransformNetwork{
+		networkRules: api.TransformNetwork{
 			Rules: rules,
 		},
+		enumCache: api.InitEnumCache(7),
 	}
 
 	err := location.InitLocationDB()
@@ -183,10 +185,10 @@ parameters:
       type: network
       network:
         rules:
-        - input: srcIP
-          output: subnetSrcIP
-          type: add_subnet
-          parameters: /24
+          - input: srcIP
+            output: subnetSrcIP
+            type: add_subnet
+            parameters: /24
   - name: write1
     write:
       type: stdout
@@ -223,10 +225,10 @@ parameters:
       type: network
       network:
         rules:
-        - input: "{{.srcIP}},{{.srcPort}},{{.dstIP}},{{.dstPort}},{{.protocol}}"
-          output: isNewFlow
-          type: conn_tracking
-          parameters: "777"
+          - input: "{{.srcIP}},{{.srcPort}},{{.dstIP}},{{.dstPort}},{{.protocol}}"
+            output: isNewFlow
+            type: conn_tracking
+            parameters: "777"
   - name: write1
     write:
       type: stdout
@@ -258,18 +260,18 @@ parameters:
       type: network
       network:
         rules:
-        - input: srcIP
-          output: subnetSrcIP
-          type: add_subnet
-          parameters: /24
-        - input: subnetSrcIP
-          output: match-10.0.*
-          type: add_regex_if
-          parameters: 10.0.*
-        - input: subnetSrcIP
-          output: match-11.0.*
-          type: add_regex_if
-          parameters: 11.0.*
+          - input: srcIP
+            output: subnetSrcIP
+            type: add_subnet
+            parameters: /24
+          - input: subnetSrcIP
+            output: match-10.0.*
+            type: add_regex_if
+            parameters: 10.0.*
+          - input: subnetSrcIP
+            output: match-11.0.*
+            type: add_regex_if
+            parameters: 11.0.*
   - name: write1
     write:
       type: stdout
@@ -288,7 +290,8 @@ parameters:
 
 func Test_Transform_AddIfScientificNotation(t *testing.T) {
 	newNetworkTransform := Network{
-		api.TransformNetwork{
+		enumCache: api.InitEnumCache(7),
+		networkRules: api.TransformNetwork{
 			Rules: api.NetworkTransformRules{
 				api.NetworkTransformRule{
 					Input:      "value",
@@ -335,7 +338,8 @@ func Test_TransformNetworkOperationNameCustomServices(t *testing.T) {
 	entry := test.GetIngestMockEntry(false)
 
 	var networkTransform = Network{
-		api.TransformNetwork{
+		enumCache: api.InitEnumCache(7),
+		networkRules: api.TransformNetwork{
 			Rules: rules,
 		},
 	}
@@ -365,7 +369,8 @@ func Test_TransformNetworkOperationNameCustomServices(t *testing.T) {
 	}
 
 	networkTransform = Network{
-		api.TransformNetwork{
+		enumCache: api.InitEnumCache(7),
+		networkRules: api.TransformNetwork{
 			Rules: rules,
 		},
 	}


### PR DESCRIPTION
Use separate enum cache tables for each of the different stages. This avoids the race condition we sometimes see in the tests without having to take a mutex.