### PR TITLE
Cleanup API for consistency, make it more consumable (breaking changes)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,10 @@ clean: ## Clean
 tests-unit: validate_go ## Unit tests
 	go test -p 1 -race -coverpkg=./... -covermode=atomic -coverprofile=/tmp/coverage.out $$(go list ./... | grep -v /e2e)
 
+.PHONY: tests-fast
+tests-fast: validate_go ## Fast unit tests (no race test / coverage)
+	go test -p 1 $$(go list ./... | grep -v /e2e)
+
 .PHONY: tests-e2e
 tests-e2e: validate_go $(KIND)  ## End-to-end tests
 	go test -p 1 -v -timeout 20m -race $$(go list ./... | grep  /e2e)

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ tests-unit: validate_go ## Unit tests
 
 .PHONY: tests-fast
 tests-fast: TEST_OPTS=
-tests-fast: tests-unit
+tests-fast: tests-unit ## Fast unit tests (no race tests / coverage)
 
 .PHONY: tests-e2e
 tests-e2e: validate_go $(KIND)  ## End-to-end tests

--- a/Makefile
+++ b/Makefile
@@ -98,13 +98,14 @@ clean: ## Clean
 	go clean ./...
 
 # note: to review coverage execute: go tool cover -html=/tmp/coverage.out
+TEST_OPTS := -race -coverpkg=./... -covermode=atomic -coverprofile=/tmp/coverage.out
 .PHONY: tests-unit
 tests-unit: validate_go ## Unit tests
-	go test -p 1 -race -coverpkg=./... -covermode=atomic -coverprofile=/tmp/coverage.out $$(go list ./... | grep -v /e2e)
+	go test -p 1 $(TEST_OPTS) $$(go list ./... | grep -v /e2e)
 
 .PHONY: tests-fast
-tests-fast: validate_go ## Fast unit tests (no race test / coverage)
-	go test -p 1 $$(go list ./... | grep -v /e2e)
+tests-fast: TEST_OPTS=
+tests-fast: tests-unit
 
 .PHONY: tests-e2e
 tests-e2e: validate_go $(KIND)  ## End-to-end tests

--- a/README.md
+++ b/README.md
@@ -632,7 +632,7 @@ Develop
   docs                  Update flowlogs-pipeline documentation  
   clean                 Clean  
   tests-unit            Unit tests  
-  tests-fast            Fast unit tests (no race test)  
+  tests-fast            Fast unit tests (no race tests / coverage)  
   tests-e2e             End-to-end tests  
   tests-all             All tests  
   benchmarks            Benchmark  

--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ service name of `dstPort` port and `protocol` protocol. Unrecognized ports are i
 > Note: `protocol` can be either network protocol name or number  
 >   
 > Note: optionally supports custom network services resolution by defining configuration parameters 
-> `servicesfile` and `protocolsfile` with paths to custom services/protocols files respectively  
+> `servicesFile` and `protocolsFile` with paths to custom services/protocols files respectively  
 
 The fourth rule `add_location` generates new fields with the geo-location information retrieved 
 from DB [ip2location](https://lite.ip2location.com/) based on `dstIP` IP. 
@@ -501,12 +501,12 @@ parameters:
     extract:
       type: aggregates
       aggregates:
-        - Name: "Average key=value for (srcIP, dstIP) pairs"
-          By:
+        - name: "Average key=value for (srcIP, dstIP) pairs"
+          by:
             - "dstIP"
             - "srcIP"
-          Operation: "avg"
-          RecordKey: "value"
+          operation: "avg"
+          recordKey: "value"
 ```
 
 The output fields of the aggregates stage are:
@@ -526,10 +526,10 @@ The pipeline processes flowlogs in batches.
 The output fields with `recent_` prefix are related to the recent batch.
 They are needed when exposing metrics in Prometheus using Counters and Histograms.
 Prometheus Counters API accepts the delta amount to be added to the counter and not the total value as in Gauges.
-In this case, `recent_op_value` and `recent_count` should be used as the `valuekey`.
+In this case, `recent_op_value` and `recent_count` should be used as the `valueKey`.
 The API of Histograms accepts the sample value, so it could be added to the appropriate bucket.
 In this case, we are interested in the raw values of the records in the aggregation group.
-No aggregate operation is needed and it should be set `raw_values`. The `valuekey` should be set to `recent_raw_values`.
+No aggregate operation is needed and it should be set `raw_values`. The `valueKey` should be set to `recent_raw_values`.
 
 **Note**: `recent_raw_values` is filled only when the operation is `raw_values`.
 
@@ -540,7 +540,7 @@ The prometheus encoder specifies which metrics to export to prometheus and which
 For example, we may want to report the number of bytes and packets for the reported flows.
 For each reported metric, we may specify a different set of labels.
 Each metric may be renamed from its internal name.
-The internal metric name is specified as `valuekey` and the exported name is specified as `name`.
+The internal metric name is specified as `valueKey` and the exported name is specified as `name`.
 A prefix for all exported metrics may be specified, and this prefix is prepended to the `name` of each specified metric.
 
 ```yaml
@@ -554,14 +554,14 @@ parameters:
         metrics:
           - name: Bytes
             type: gauge
-            valuekey: bytes
+            valueKey: bytes
             labels:
               - srcAddr
               - dstAddr
               - srcPort
           - name: Packets
             type: counter
-            valuekey: packets
+            valueKey: packets
             labels:
               - srcAddr
               - dstAddr
@@ -632,6 +632,7 @@ Develop
   docs                  Update flowlogs-pipeline documentation  
   clean                 Clean  
   tests-unit            Unit tests  
+  tests-fast            Fast unit tests (no race test)  
   tests-e2e             End-to-end tests  
   tests-all             All tests  
   benchmarks            Benchmark  

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -74,83 +74,82 @@ parameters:
       - input: dstIP
         output: dstLocation
         type: add_location
-        parameters: ""
     type: network
 - extract:
     aggregates:
-    - Name: bandwidth_network_service
-      By:
+    - name: bandwidth_network_service
+      by:
       - service
-      Operation: sum
-      RecordKey: bytes
-    - Name: bandwidth_source_destination_subnet
-      By:
+      operation: sum
+      recordKey: bytes
+    - name: bandwidth_source_destination_subnet
+      by:
       - dstSubnet24
       - srcSubnet24
-      Operation: sum
-      RecordKey: bytes
-    - Name: bandwidth_source_subnet
-      By:
+      operation: sum
+      recordKey: bytes
+    - name: bandwidth_source_subnet
+      by:
       - srcSubnet
-      Operation: sum
-      RecordKey: bytes
-    - Name: dest_connection_subnet_count
-      By:
+      operation: sum
+      recordKey: bytes
+    - name: dest_connection_subnet_count
+      by:
       - dstSubnet
-      Operation: sum
-      RecordKey: isNewFlow
-    - Name: src_connection_count
-      By:
+      operation: sum
+      recordKey: isNewFlow
+    - name: src_connection_count
+      by:
       - srcSubnet
-      Operation: count
-      RecordKey: ""
-    - Name: TCPFlags_count
-      By:
+      operation: count
+      recordKey: ""
+    - name: TCPFlags_count
+      by:
       - TCPFlags
-      Operation: count
-      RecordKey: ""
-    - Name: dst_as_connection_count
-      By:
+      operation: count
+      recordKey: ""
+    - name: dst_as_connection_count
+      by:
       - dstAS
-      Operation: count
-      RecordKey: ""
-    - Name: src_as_connection_count
-      By:
+      operation: count
+      recordKey: ""
+    - name: src_as_connection_count
+      by:
       - srcAS
-      Operation: count
-      RecordKey: ""
-    - Name: count_source_destination_subnet
-      By:
+      operation: count
+      recordKey: ""
+    - name: count_source_destination_subnet
+      by:
       - dstSubnet24
       - srcSubnet24
-      Operation: count
-      RecordKey: ""
-    - Name: bandwidth_destination_subnet
-      By:
+      operation: count
+      recordKey: ""
+    - name: bandwidth_destination_subnet
+      by:
       - dstSubnet
-      Operation: sum
-      RecordKey: bytes
-    - Name: bandwidth_namespace
-      By:
+      operation: sum
+      recordKey: bytes
+    - name: bandwidth_namespace
+      by:
       - srcK8S_Namespace
       - srcK8S_Type
-      Operation: sum
-      RecordKey: bytes
-    - Name: flows_bytes_hist
-      By:
+      operation: sum
+      recordKey: bytes
+    - name: flows_bytes_hist
+      by:
       - all_Evaluate
-      Operation: raw_values
-      RecordKey: bytes
-    - Name: dest_connection_location_count
-      By:
+      operation: raw_values
+      recordKey: bytes
+    - name: dest_connection_location_count
+      by:
       - dstLocation_CountryName
-      Operation: count
-      RecordKey: ""
-    - Name: dest_service_count
-      By:
+      operation: count
+      recordKey: ""
+    - name: dest_service_count
+      by:
       - service
-      Operation: count
-      RecordKey: ""
+      operation: count
+      recordKey: ""
     type: aggregates
   name: extract_aggregate
 - encode:
@@ -161,7 +160,7 @@ parameters:
         filter:
           key: name
           value: bandwidth_network_service
-        valuekey: recent_op_value
+        valueKey: recent_op_value
         labels:
         - by
         - aggregate
@@ -171,7 +170,7 @@ parameters:
         filter:
           key: name
           value: bandwidth_source_destination_subnet
-        valuekey: recent_op_value
+        valueKey: recent_op_value
         labels:
         - by
         - aggregate
@@ -181,7 +180,7 @@ parameters:
         filter:
           key: name
           value: bandwidth_source_subnet
-        valuekey: recent_op_value
+        valueKey: recent_op_value
         labels:
         - by
         - aggregate
@@ -191,7 +190,7 @@ parameters:
         filter:
           key: name
           value: dest_connection_subnet_count
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
         - by
         - aggregate
@@ -201,7 +200,7 @@ parameters:
         filter:
           key: name
           value: src_connection_count
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
         - by
         - aggregate
@@ -211,7 +210,7 @@ parameters:
         filter:
           key: name
           value: TCPFlags_count
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
         - by
         - aggregate
@@ -221,7 +220,7 @@ parameters:
         filter:
           key: name
           value: dst_as_connection_count
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
         - by
         - aggregate
@@ -231,7 +230,7 @@ parameters:
         filter:
           key: name
           value: src_as_connection_count
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
         - by
         - aggregate
@@ -241,7 +240,7 @@ parameters:
         filter:
           key: name
           value: count_source_destination_subnet
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
         - by
         - aggregate
@@ -251,7 +250,7 @@ parameters:
         filter:
           key: name
           value: bandwidth_destination_subnet
-        valuekey: recent_op_value
+        valueKey: recent_op_value
         labels:
         - by
         - aggregate
@@ -261,7 +260,7 @@ parameters:
         filter:
           key: name
           value: bandwidth_namespace
-        valuekey: recent_op_value
+        valueKey: recent_op_value
         labels:
         - by
         - aggregate
@@ -271,7 +270,7 @@ parameters:
         filter:
           key: name
           value: flows_bytes_hist
-        valuekey: recent_raw_values
+        valueKey: recent_raw_values
         labels:
         - by
         - aggregate
@@ -286,7 +285,7 @@ parameters:
         filter:
           key: name
           value: dest_connection_location_count
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
         - by
         - aggregate
@@ -296,7 +295,7 @@ parameters:
         filter:
           key: name
           value: dest_service_count
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
         - by
         - aggregate

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -82,74 +82,88 @@ parameters:
       - service
       operation: sum
       recordKey: bytes
+      topK: 0
     - name: bandwidth_source_destination_subnet
       by:
       - dstSubnet24
       - srcSubnet24
       operation: sum
       recordKey: bytes
+      topK: 0
     - name: bandwidth_source_subnet
       by:
       - srcSubnet
       operation: sum
       recordKey: bytes
+      topK: 0
     - name: dest_connection_subnet_count
       by:
       - dstSubnet
       operation: sum
       recordKey: isNewFlow
+      topK: 0
     - name: src_connection_count
       by:
       - srcSubnet
       operation: count
       recordKey: ""
+      topK: 0
     - name: TCPFlags_count
       by:
       - TCPFlags
       operation: count
       recordKey: ""
+      topK: 0
     - name: dst_as_connection_count
       by:
       - dstAS
       operation: count
       recordKey: ""
+      topK: 0
     - name: src_as_connection_count
       by:
       - srcAS
       operation: count
       recordKey: ""
+      topK: 0
     - name: count_source_destination_subnet
       by:
       - dstSubnet24
       - srcSubnet24
       operation: count
       recordKey: ""
+      topK: 0
     - name: bandwidth_destination_subnet
       by:
       - dstSubnet
       operation: sum
       recordKey: bytes
+      topK: 0
     - name: bandwidth_namespace
       by:
       - srcK8S_Namespace
       - srcK8S_Type
       operation: sum
       recordKey: bytes
+      topK: 0
     - name: flows_bytes_hist
       by:
       - all_Evaluate
       operation: raw_values
       recordKey: bytes
+      topK: 0
     - name: dest_connection_location_count
       by:
       - dstLocation_CountryName
       operation: count
       recordKey: ""
+      topK: 0
     - name: dest_service_count
       by:
       - service
       operation: count
       recordKey: ""
+      topK: 0
     type: aggregates
   name: extract_aggregate
 - encode:

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,19 +13,19 @@ Following is the supported API format for prometheus encode:
                  filter: the criterion to filter entries by
                      key: the key to match and filter by
                      value: the value to match and filter by
-                 valuekey: entry key from which to resolve metric value
+                 valueKey: entry key from which to resolve metric value
                  labels: labels to be associated with the metric
                  buckets: histogram buckets
          port: port number to expose "/metrics" endpoint
          prefix: prefix added to each metric name
-         expirytime: seconds of no-flow to wait before deleting prometheus data item
+         expiryTime: seconds of no-flow to wait before deleting prometheus data item
 </pre>
 ## Kafka encode API
 Following is the supported API format for kafka encode:
 
 <pre>
  kafka:
-         addr: address of kafka server
+         address: address of kafka server
          topic: kafka topic to write to
          balancer: (enum) one of the following:
              roundRobin: RoundRobin balancer
@@ -56,9 +56,9 @@ Following is the supported API format for the kafka ingest:
          brokers: list of kafka broker addresses
          topic: kafka topic to listen on
          groupid: separate groupid for each consumer on specified topic
-         groupbalancers: list of balancing strategies (range, roundRobin, rackAffinity)
-         startoffset: FirstOffset (least recent - default) or LastOffset (most recent) offset available for a partition
-         batchreadtimeout: how often (in milliseconds) to process input
+         groupBalancers: list of balancing strategies (range, roundRobin, rackAffinity)
+         startOffset: FirstOffset (least recent - default) or LastOffset (most recent) offset available for a partition
+         batchReadTimeout: how often (in milliseconds) to process input
 </pre>
 ## Ingest GRPC from Network Observability eBPF Agent
 Following is the supported API format for the Network Observability eBPF ingest:
@@ -66,7 +66,7 @@ Following is the supported API format for the Network Observability eBPF ingest:
 <pre>
  grpc:
          port: the port number to listen on
-         buffer_length: the length of the ingest channel buffer, in groups of flows, containing each group hundreds of flows (default: 100)
+         bufferLength: the length of the ingest channel buffer, in groups of flows, containing each group hundreds of flows (default: 100)
 </pre>
 ## Aws ingest API
 Following is the supported API format for Aws flow entries:
@@ -95,7 +95,6 @@ Following is the supported API format for filter transformations:
          rules: list of filter rules, each includes:
                  input: entry input field
                  type: (enum) one of the following:
-                     remove_field: removes the field from the entry
                      remove_entry_if_exists: removes the entry if the field exists
                      remove_entry_if_doesnt_exist: removes the entry if the field doesnt exist
 </pre>
@@ -116,9 +115,9 @@ Following is the supported API format for network transformations:
                      add_service: add output network service field from input port and parameters protocol field
                      add_kubernetes: add output kubernetes fields from input
                  parameters: parameters specific to type
-         kubeconfigpath: path to kubeconfig file (optional)
-         servicesfile: path to services file (optional, default: /etc/services)
-         protocolsfile: path to protocols file (optional, default: /etc/protocols)
+         kubeConfigPath: path to kubeconfig file (optional)
+         servicesFile: path to services file (optional, default: /etc/services)
+         protocolsFile: path to protocols file (optional, default: /etc/protocols)
 </pre>
 ## Write Loki API
 Following is the supported API format for writing to loki:
@@ -152,9 +151,9 @@ Following is the supported API format for specifying metrics aggregations:
 
 <pre>
  aggregates:
-         Name: description of aggregation result
-         By: list of fields on which to aggregate
-         Operation: sum, min, max, avg or raw_values
-         RecordKey: internal field on which to perform the operation
-         TopK: number of highest incidence to report (default - report all)
+         name: description of aggregation result
+         by: list of fields on which to aggregate
+         operation: sum, min, max, avg or raw_values
+         recordKey: internal field on which to perform the operation
+         topK: number of highest incidence to report (default - report all)
 </pre>

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,6 +95,7 @@ Following is the supported API format for filter transformations:
          rules: list of filter rules, each includes:
                  input: entry input field
                  type: (enum) one of the following:
+                     remove_field: removes the field from the entry
                      remove_entry_if_exists: removes the entry if the field exists
                      remove_entry_if_doesnt_exist: removes the entry if the field doesnt exist
 </pre>

--- a/docs/confGenerator.md
+++ b/docs/confGenerator.md
@@ -105,7 +105,7 @@ encode: (9)
       - name: metricName (9.2)
         type: metricType (9.3)
         filter: {key: myKey, value: myValue} (9.4)
-        valuekey: value (9.5)
+        valueKey: value (9.5)
         labels: (9.6)
           - by
           - aggregate

--- a/docs/images/animated-gif-images/image (20).png:Zone.Identifier
+++ b/docs/images/animated-gif-images/image (20).png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://files.slack.com/files-pri/T27SFGS2W-F036A8Y0K4J/download/image.png

--- a/docs/images/animated-gif-images/image (21).png:Zone.Identifier
+++ b/docs/images/animated-gif-images/image (21).png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://files.slack.com/files-pri/T27SFGS2W-F035VP2TB7H/download/image.png

--- a/docs/images/animated-gif-images/image (22).png:Zone.Identifier
+++ b/docs/images/animated-gif-images/image (22).png:Zone.Identifier
@@ -1,3 +1,0 @@
-[ZoneTransfer]
-ZoneId=3
-HostUrl=https://files.slack.com/files-pri/T27SFGS2W-F036ABDH39R/download/image.png

--- a/network_definitions/bandwidth_per_network_service.yaml
+++ b/network_definitions/bandwidth_per_network_service.yaml
@@ -30,7 +30,7 @@ encode:
       - name: bandwidth_per_network_service
         type: counter
         filter: {key: name, value: bandwidth_network_service}
-        valuekey: recent_op_value
+        valueKey: recent_op_value
         labels:
           - by
           - aggregate

--- a/network_definitions/bandwidth_per_src_dest_subnet.yaml
+++ b/network_definitions/bandwidth_per_src_dest_subnet.yaml
@@ -35,7 +35,7 @@ encode:
       - name: bandwidth_per_source_destination_subnet
         type: counter
         filter: {key: name, value: bandwidth_source_destination_subnet}
-        valuekey: recent_op_value
+        valueKey: recent_op_value
         labels:
           - by
           - aggregate

--- a/network_definitions/bandwidth_per_src_subnet.yaml
+++ b/network_definitions/bandwidth_per_src_subnet.yaml
@@ -30,7 +30,7 @@ encode:
       - name: bandwidth_per_source_subnet
         type: counter
         filter: {key: name, value: bandwidth_source_subnet}
-        valuekey: recent_op_value
+        valueKey: recent_op_value
         labels:
           - by
           - aggregate

--- a/network_definitions/connection_rate_per_dest_subnet.yaml
+++ b/network_definitions/connection_rate_per_dest_subnet.yaml
@@ -33,7 +33,7 @@ encode:
       - name: connections_per_destination_subnet
         type: counter
         filter: {key: name, value: dest_connection_subnet_count}
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
           - by
           - aggregate

--- a/network_definitions/connection_rate_per_src_subnet.yaml
+++ b/network_definitions/connection_rate_per_src_subnet.yaml
@@ -28,7 +28,7 @@ encode:
       - name: connections_per_source_subnet
         type: counter
         filter: {key: name, value: src_connection_count}
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
           - by
           - aggregate

--- a/network_definitions/connection_rate_per_tcp_flags.yaml
+++ b/network_definitions/connection_rate_per_tcp_flags.yaml
@@ -22,7 +22,7 @@ encode:
       - name: connections_per_tcp_flags
         type: counter
         filter: { key: name, value: TCPFlags_count }
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
           - by
           - aggregate

--- a/network_definitions/connections_per_dst_as.yaml
+++ b/network_definitions/connections_per_dst_as.yaml
@@ -23,7 +23,7 @@ encode:
       - name: connections_per_destination_as
         type: counter
         filter: { key: name, value: dst_as_connection_count }
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
           - by
           - aggregate

--- a/network_definitions/connections_per_src_as.yaml
+++ b/network_definitions/connections_per_src_as.yaml
@@ -23,7 +23,7 @@ encode:
       - name: connections_per_source_as
         type: counter
         filter: { key: name, value: src_as_connection_count }
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
           - by
           - aggregate

--- a/network_definitions/count_per_src_dest_subnet.yaml
+++ b/network_definitions/count_per_src_dest_subnet.yaml
@@ -34,7 +34,7 @@ encode:
       - name: count_per_source_destination_subnet
         type: counter
         filter: { key: name, value: count_source_destination_subnet }
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
           - by
           - aggregate

--- a/network_definitions/egress_bandwidth_per_dest_subnet.yaml
+++ b/network_definitions/egress_bandwidth_per_dest_subnet.yaml
@@ -30,7 +30,7 @@ encode:
       - name: egress_per_destination_subnet
         type: counter
         filter: { key: name, value: bandwidth_destination_subnet }
-        valuekey: recent_op_value
+        valueKey: recent_op_value
         labels:
           - by
           - aggregate

--- a/network_definitions/egress_bandwidth_per_namespace.yaml
+++ b/network_definitions/egress_bandwidth_per_namespace.yaml
@@ -30,7 +30,7 @@ encode:
       - name: egress_per_namespace
         type: counter
         filter: { key: name, value: bandwidth_namespace }
-        valuekey: recent_op_value
+        valueKey: recent_op_value
         labels:
           - by
           - aggregate

--- a/network_definitions/flows_length_histogram.yaml
+++ b/network_definitions/flows_length_histogram.yaml
@@ -30,7 +30,7 @@ encode:
       - name: flows_length_histogram
         type: histogram
         filter: { key: name, value: flows_bytes_hist }
-        valuekey: recent_raw_values
+        valueKey: recent_raw_values
         labels:
           - by
           - aggregate

--- a/network_definitions/geo-location_rate_per_dest.yaml
+++ b/network_definitions/geo-location_rate_per_dest.yaml
@@ -29,7 +29,7 @@ encode:
       - name: connections_per_destination_location
         type: counter
         filter: { key: name, value: dest_connection_location_count }
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
           - by
           - aggregate

--- a/network_definitions/network_services_count.yaml
+++ b/network_definitions/network_services_count.yaml
@@ -30,7 +30,7 @@ encode:
       - name: service_count
         type: counter
         filter: { key: name, value: dest_service_count }
-        valuekey: recent_count
+        valueKey: recent_count
         labels:
           - by
           - aggregate

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -17,9 +17,36 @@
 
 package api
 
-const TagYaml = "yaml"
-const TagDoc = "doc"
-const TagEnum = "enum"
+const (
+	FileType              = "file"
+	FileLoopType          = "file_loop"
+	FileChunksType        = "file_chunks"
+	CollectorType         = "collector"
+	GRPCType              = "grpc"
+	KafkaType             = "kafka"
+	JSONType              = "json"
+	PBType                = "protobuf"
+	AWSType               = "aws"
+	StdoutType            = "stdout"
+	LokiType              = "loki"
+	AggregateType         = "aggregates"
+	PromType              = "prom"
+	GenericType           = "generic"
+	NetworkType           = "network"
+	FilterType            = "filter"
+	NoneType              = "none"
+	ConnTrackingRuleType  = "conn_tracking"
+	AddRegExIfRuleType    = "add_regex_if"
+	AddIfRuleType         = "add_if"
+	AddSubnetRuleType     = "add_subnet"
+	AddLocationRuleType   = "add_location"
+	AddServiceRuleType    = "add_service"
+	AddKubernetesRuleType = "add_kubernetes"
+
+	TagYaml = "yaml"
+	TagDoc  = "doc"
+	TagEnum = "enum"
+)
 
 // Note: items beginning with doc: "## title" are top level items that get divided into sections inside api.md.
 

--- a/pkg/api/decode_aws.go
+++ b/pkg/api/decode_aws.go
@@ -18,5 +18,5 @@
 package api
 
 type DecodeAws struct {
-	Fields []string `yaml:"fields" doc:"list of aws flow log fields"`
+	Fields []string `yaml:"fields" json:"fields" doc:"list of aws flow log fields"`
 }

--- a/pkg/api/encode_kafka.go
+++ b/pkg/api/encode_kafka.go
@@ -18,21 +18,21 @@
 package api
 
 type EncodeKafka struct {
-	Address      string `yaml:"addr" doc:"address of kafka server"`
-	Topic        string `yaml:"topic" doc:"kafka topic to write to"`
-	Balancer     string `yaml:"balancer" enum:"KafkaEncodeBalancerEnum" doc:"one of the following:"`
-	WriteTimeout int64  `yaml:"writeTimeout" doc:"timeout (in seconds) for write operation performed by the Writer"`
-	ReadTimeout  int64  `yaml:"readTimeout" doc:"timeout (in seconds) for read operation performed by the Writer"`
-	BatchBytes   int64  `yaml:"batchBytes" doc:"limit the maximum size of a request in bytes before being sent to a partition"`
-	BatchSize    int    `yaml:"batchSize" doc:"limit on how many messages will be buffered before being sent to a partition"`
+	Address      string `yaml:"address" json:"address" doc:"address of kafka server"`
+	Topic        string `yaml:"topic" json:"topic" doc:"kafka topic to write to"`
+	Balancer     string `yaml:"balancer" json:"balancer" enum:"KafkaEncodeBalancerEnum" doc:"one of the following:"`
+	WriteTimeout int64  `yaml:"writeTimeout" json:"writeTimeout" doc:"timeout (in seconds) for write operation performed by the Writer"`
+	ReadTimeout  int64  `yaml:"readTimeout" json:"readTimeout" doc:"timeout (in seconds) for read operation performed by the Writer"`
+	BatchBytes   int64  `yaml:"batchBytes" json:"batchBytes" doc:"limit the maximum size of a request in bytes before being sent to a partition"`
+	BatchSize    int    `yaml:"batchSize" json:"batchSize" doc:"limit on how many messages will be buffered before being sent to a partition"`
 }
 
 type KafkaEncodeBalancerEnum struct {
-	RoundRobin string `yaml:"roundRobin" doc:"RoundRobin balancer"`
-	LeastBytes string `yaml:"leastBytes" doc:"LeastBytes balancer"`
-	Hash       string `yaml:"hash" doc:"Hash balancer"`
-	Crc32      string `yaml:"crc32" doc:"Crc32 balancer"`
-	Murmur2    string `yaml:"murmur2" doc:"Murmur2 balancer"`
+	RoundRobin string `yaml:"roundRobin" json:"roundRobin" doc:"RoundRobin balancer"`
+	LeastBytes string `yaml:"leastBytes" json:"leastBytes" doc:"LeastBytes balancer"`
+	Hash       string `yaml:"hash" json:"hash" doc:"Hash balancer"`
+	Crc32      string `yaml:"crc32" json:"crc32" doc:"Crc32 balancer"`
+	Murmur2    string `yaml:"murmur2" json:"murmur2" doc:"Murmur2 balancer"`
 }
 
 func KafkaEncodeBalancerName(operation string) string {

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -18,16 +18,16 @@
 package api
 
 type PromEncode struct {
-	Metrics    PromMetricsItems `yaml:"metrics" doc:"list of prometheus metric definitions, each includes:"`
-	Port       int              `yaml:"port" doc:"port number to expose \"/metrics\" endpoint"`
-	Prefix     string           `yaml:"prefix" doc:"prefix added to each metric name"`
-	ExpiryTime int              `yaml:"expirytime" doc:"seconds of no-flow to wait before deleting prometheus data item"`
+	Metrics    PromMetricsItems `yaml:"metrics" json:"metrics" doc:"list of prometheus metric definitions, each includes:"`
+	Port       int              `yaml:"port" json:"port" doc:"port number to expose \"/metrics\" endpoint"`
+	Prefix     string           `yaml:"prefix" json:"prefix" doc:"prefix added to each metric name"`
+	ExpiryTime int              `yaml:"expiryTime" json:"expiryTime" doc:"seconds of no-flow to wait before deleting prometheus data item"`
 }
 
 type PromEncodeOperationEnum struct {
-	Gauge     string `yaml:"gauge" doc:"single numerical value that can arbitrarily go up and down"`
-	Counter   string `yaml:"counter" doc:"monotonically increasing counter whose value can only increase"`
-	Histogram string `yaml:"histogram" doc:"counts samples in configurable buckets"`
+	Gauge     string `yaml:"gauge" json:"gauge" doc:"single numerical value that can arbitrarily go up and down"`
+	Counter   string `yaml:"counter" json:"counter" doc:"monotonically increasing counter whose value can only increase"`
+	Histogram string `yaml:"histogram" json:"histogram" doc:"counts samples in configurable buckets"`
 }
 
 func PromEncodeOperationName(operation string) string {
@@ -35,17 +35,17 @@ func PromEncodeOperationName(operation string) string {
 }
 
 type PromMetricsItem struct {
-	Name     string            `yaml:"name" doc:"the metric name"`
-	Type     string            `yaml:"type" enum:"PromEncodeOperationEnum" doc:"one of the following:"`
-	Filter   PromMetricsFilter `yaml:"filter" doc:"the criterion to filter entries by"`
-	ValueKey string            `yaml:"valuekey" doc:"entry key from which to resolve metric value"`
-	Labels   []string          `yaml:"labels" doc:"labels to be associated with the metric"`
-	Buckets  []float64         `yaml:"buckets" doc:"histogram buckets"`
+	Name     string            `yaml:"name" json:"name" doc:"the metric name"`
+	Type     string            `yaml:"type" json:"type" enum:"PromEncodeOperationEnum" doc:"one of the following:"`
+	Filter   PromMetricsFilter `yaml:"filter" json:"filter" doc:"the criterion to filter entries by"`
+	ValueKey string            `yaml:"valueKey" json:"valueKey" doc:"entry key from which to resolve metric value"`
+	Labels   []string          `yaml:"labels" json:"labels" doc:"labels to be associated with the metric"`
+	Buckets  []float64         `yaml:"buckets" json:"buckets" doc:"histogram buckets"`
 }
 
 type PromMetricsItems []PromMetricsItem
 
 type PromMetricsFilter struct {
-	Key   string `yaml:"key" doc:"the key to match and filter by"`
-	Value string `yaml:"value" doc:"the value to match and filter by"`
+	Key   string `yaml:"key" json:"key" doc:"the key to match and filter by"`
+	Value string `yaml:"value" json:"value" doc:"the value to match and filter by"`
 }

--- a/pkg/api/extract_aggregate.go
+++ b/pkg/api/extract_aggregate.go
@@ -4,9 +4,9 @@ type AggregateBy []string
 type AggregateOperation string
 
 type AggregateDefinition struct {
-	Name      string             `yaml:"Name" doc:"description of aggregation result"`
-	By        AggregateBy        `yaml:"By" doc:"list of fields on which to aggregate"`
-	Operation AggregateOperation `yaml:"Operation" doc:"sum, min, max, avg or raw_values"`
-	RecordKey string             `yaml:"RecordKey" doc:"internal field on which to perform the operation"`
-	TopK      int                `yaml:"TopK" doc:"number of highest incidence to report (default - report all)"`
+	Name      string             `yaml:"name" json:"name" doc:"description of aggregation result"`
+	By        AggregateBy        `yaml:"by" json:"by" doc:"list of fields on which to aggregate"`
+	Operation AggregateOperation `yaml:"operation" json:"operation" doc:"sum, min, max, avg or raw_values"`
+	RecordKey string             `yaml:"recordKey" json:"recordKey" doc:"internal field on which to perform the operation"`
+	TopK      int                `yaml:"topK" json:"topK" doc:"number of highest incidence to report (default - report all)"`
 }

--- a/pkg/api/ingest_collector.go
+++ b/pkg/api/ingest_collector.go
@@ -18,8 +18,8 @@
 package api
 
 type IngestCollector struct {
-	HostName    string `yaml:"hostName" doc:"the hostname to listen on"`
-	Port        int    `yaml:"port" doc:"the port number to listen on, for IPFIX/NetFlow v9. Omit or set to 0 to disable IPFIX/NetFlow v9 ingestion"`
-	PortLegacy  int    `yaml:"portLegacy" doc:"the port number to listen on, for legacy NetFlow v5. Omit or set to 0 to disable NetFlow v5 ingestion"`
-	BatchMaxLen int    `yaml:"batchMaxLen" doc:"the number of accumulated flows before being forwarded for processing"`
+	HostName    string `yaml:"hostName" json:"hostName" doc:"the hostname to listen on"`
+	Port        int    `yaml:"port" json:"port" doc:"the port number to listen on, for IPFIX/NetFlow v9. Omit or set to 0 to disable IPFIX/NetFlow v9 ingestion"`
+	PortLegacy  int    `yaml:"portLegacy" json:"portLegacy" doc:"the port number to listen on, for legacy NetFlow v5. Omit or set to 0 to disable NetFlow v5 ingestion"`
+	BatchMaxLen int    `yaml:"batchMaxLen" json:"batchMaxLen" doc:"the number of accumulated flows before being forwarded for processing"`
 }

--- a/pkg/api/ingest_grpc.go
+++ b/pkg/api/ingest_grpc.go
@@ -1,6 +1,6 @@
 package api
 
 type IngestGRPCProto struct {
-	Port      int `yaml:"port" doc:"the port number to listen on"`
-	BufferLen int `yaml:"buffer_length" doc:"the length of the ingest channel buffer, in groups of flows, containing each group hundreds of flows (default: 100)"`
+	Port      int `yaml:"port" json:"port" doc:"the port number to listen on"`
+	BufferLen int `yaml:"bufferLength" json:"bufferLength" doc:"the length of the ingest channel buffer, in groups of flows, containing each group hundreds of flows (default: 100)"`
 }

--- a/pkg/api/ingest_kafka.go
+++ b/pkg/api/ingest_kafka.go
@@ -18,10 +18,10 @@
 package api
 
 type IngestKafka struct {
-	Brokers          []string `yaml:"brokers" doc:"list of kafka broker addresses"`
-	Topic            string   `yaml:"topic" doc:"kafka topic to listen on"`
-	GroupId          string   `yaml:"groupid" doc:"separate groupid for each consumer on specified topic"`
-	GroupBalancers   []string `yaml:"groupbalancers" doc:"list of balancing strategies (range, roundRobin, rackAffinity)"`
-	StartOffset      string   `yaml:"startoffset" doc:"FirstOffset (least recent - default) or LastOffset (most recent) offset available for a partition"`
-	BatchReadTimeout int64    `yaml:"batchreadtimeout" doc:"how often (in milliseconds) to process input"`
+	Brokers          []string `yaml:"brokers" json:"brokers" doc:"list of kafka broker addresses"`
+	Topic            string   `yaml:"topic" json:"topic" doc:"kafka topic to listen on"`
+	GroupId          string   `yaml:"groupid" json:"groupid" doc:"separate groupid for each consumer on specified topic"`
+	GroupBalancers   []string `yaml:"groupBalancers" json:"groupBalancers" doc:"list of balancing strategies (range, roundRobin, rackAffinity)"`
+	StartOffset      string   `yaml:"startOffset" json:"startOffset" doc:"FirstOffset (least recent - default) or LastOffset (most recent) offset available for a partition"`
+	BatchReadTimeout int64    `yaml:"batchReadTimeout" json:"batchReadTimeout" doc:"how often (in milliseconds) to process input"`
 }

--- a/pkg/api/transform_filter.go
+++ b/pkg/api/transform_filter.go
@@ -22,7 +22,7 @@ type TransformFilter struct {
 }
 
 type TransformFilterOperationEnum struct {
-	RemoveField              string `yaml:"remove_field" json:"remove_field field from the entry"`
+	RemoveField              string `yaml:"remove_field" json:"remove_field" doc:"removes the field from the entry"`
 	RemoveEntryIfExists      string `yaml:"remove_entry_if_exists" json:"remove_entry_if_exists" doc:"removes the entry if the field exists"`
 	RemoveEntryIfDoesntExist string `yaml:"remove_entry_if_doesnt_exist" json:"remove_entry_if_doesnt_exist" doc:"removes the entry if the field doesnt exist"`
 }

--- a/pkg/api/transform_filter.go
+++ b/pkg/api/transform_filter.go
@@ -18,13 +18,13 @@
 package api
 
 type TransformFilter struct {
-	Rules []TransformFilterRule `yaml:"rules" doc:"list of filter rules, each includes:"`
+	Rules []TransformFilterRule `yaml:"rules" json:"rules" doc:"list of filter rules, each includes:"`
 }
 
 type TransformFilterOperationEnum struct {
-	RemoveField              string `yaml:"remove_field" doc:"removes the field from the entry"`
-	RemoveEntryIfExists      string `yaml:"remove_entry_if_exists" doc:"removes the entry if the field exists"`
-	RemoveEntryIfDoesntExist string `yaml:"remove_entry_if_doesnt_exist" doc:"removes the entry if the field doesnt exist"`
+	RemoveField              string `yaml:"remove_field" json:"remove_field field from the entry"`
+	RemoveEntryIfExists      string `yaml:"remove_entry_if_exists" json:"remove_entry_if_exists" doc:"removes the entry if the field exists"`
+	RemoveEntryIfDoesntExist string `yaml:"remove_entry_if_doesnt_exist" json:"remove_entry_if_doesnt_exist" doc:"removes the entry if the field doesnt exist"`
 }
 
 func TransformFilterOperationName(operation string) string {
@@ -32,6 +32,6 @@ func TransformFilterOperationName(operation string) string {
 }
 
 type TransformFilterRule struct {
-	Input string `yaml:"input" doc:"entry input field"`
-	Type  string `yaml:"type" enum:"TransformFilterOperationEnum" doc:"one of the following:"`
+	Input string `yaml:"input" json:"input" doc:"entry input field"`
+	Type  string `yaml:"type" json:"type" enum:"TransformFilterOperationEnum" doc:"one of the following:"`
 }

--- a/pkg/api/transform_generic.go
+++ b/pkg/api/transform_generic.go
@@ -23,8 +23,8 @@ type TransformGeneric struct {
 }
 
 type TransformGenericOperationEnum struct {
-	PreserveOriginalKeys string `yaml:"preserve_original_keys" json:"preserveOriginalKeys" doc:"adds new keys in addition to existing keys (default)"`
-	ReplaceKeys          string `yaml:"replace_keys" json:"replaceKeys" doc:"removes all old keys and uses only the new keys"`
+	PreserveOriginalKeys string `yaml:"preserve_original_keys" json:"preserve_original_keys" doc:"adds new keys in addition to existing keys (default)"`
+	ReplaceKeys          string `yaml:"replace_keys" json:"replace_keys" doc:"removes all old keys and uses only the new keys"`
 }
 
 func TransformGenericOperationName(operation string) string {

--- a/pkg/api/transform_generic.go
+++ b/pkg/api/transform_generic.go
@@ -18,13 +18,13 @@
 package api
 
 type TransformGeneric struct {
-	Policy string                 `yaml:"policy" enum:"TransformGenericOperationEnum" doc:"key replacement policy; may be one of the following:"`
-	Rules  []GenericTransformRule `yaml:"rules" doc:"list of transform rules, each includes:"`
+	Policy string                 `yaml:"policy" json:"policy" enum:"TransformGenericOperationEnum" doc:"key replacement policy; may be one of the following:"`
+	Rules  []GenericTransformRule `yaml:"rules" json:"rules" doc:"list of transform rules, each includes:"`
 }
 
 type TransformGenericOperationEnum struct {
-	PreserveOriginalKeys string `yaml:"preserve_original_keys" doc:"adds new keys in addition to existing keys (default)"`
-	ReplaceKeys          string `yaml:"replace_keys" doc:"removes all old keys and uses only the new keys"`
+	PreserveOriginalKeys string `yaml:"preserve_original_keys" json:"preserveOriginalKeys" doc:"adds new keys in addition to existing keys (default)"`
+	ReplaceKeys          string `yaml:"replace_keys" json:"replaceKeys" doc:"removes all old keys and uses only the new keys"`
 }
 
 func TransformGenericOperationName(operation string) string {
@@ -32,8 +32,8 @@ func TransformGenericOperationName(operation string) string {
 }
 
 type GenericTransformRule struct {
-	Input  string `yaml:"input" doc:"entry input field"`
-	Output string `yaml:"output" doc:"entry output field"`
+	Input  string `yaml:"input" json:"input" doc:"entry input field"`
+	Output string `yaml:"output" json:"output" doc:"entry output field"`
 }
 
 type GenericTransform []GenericTransformRule

--- a/pkg/api/transform_network.go
+++ b/pkg/api/transform_network.go
@@ -18,20 +18,20 @@
 package api
 
 type TransformNetwork struct {
-	Rules          NetworkTransformRules `yaml:"rules" doc:"list of transform rules, each includes:"`
-	KubeConfigPath string                `yaml:"kubeconfigpath" doc:"path to kubeconfig file (optional)"`
-	ServicesFile   string                `yaml:"servicesfile" doc:"path to services file (optional, default: /etc/services)"`
-	ProtocolsFile  string                `yaml:"protocolsfile" doc:"path to protocols file (optional, default: /etc/protocols)"`
+	Rules          NetworkTransformRules `yaml:"rules" json:"rules" doc:"list of transform rules, each includes:"`
+	KubeConfigPath string                `yaml:"kubeConfigPath,omitempty" json:"kubeConfigPath,omitempty" doc:"path to kubeconfig file (optional)"`
+	ServicesFile   string                `yaml:"servicesFile,omitempty" json:"servicesFile,omitempty" doc:"path to services file (optional, default: /etc/services)"`
+	ProtocolsFile  string                `yaml:"protocolsFile,omitempty" json:"protocolsFile,omitempty" doc:"path to protocols file (optional, default: /etc/protocols)"`
 }
 
 type TransformNetworkOperationEnum struct {
-	ConnTracking  string `yaml:"conn_tracking" doc:"set output field to value of parameters field only for new flows by matching template in input field"`
-	AddRegExIf    string `yaml:"add_regex_if" doc:"add output field if input field satisfies regex pattern from parameters field"`
-	AddIf         string `yaml:"add_if" doc:"add output field if input field satisfies criteria from parameters field"`
-	AddSubnet     string `yaml:"add_subnet" doc:"add output subnet field from input field and prefix length from parameters field"`
-	AddLocation   string `yaml:"add_location" doc:"add output location fields from input"`
-	AddService    string `yaml:"add_service" doc:"add output network service field from input port and parameters protocol field"`
-	AddKubernetes string `yaml:"add_kubernetes" doc:"add output kubernetes fields from input"`
+	ConnTracking  string `yaml:"conn_tracking" json:"conn_tracking" doc:"set output field to value of parameters field only for new flows by matching template in input field"`
+	AddRegExIf    string `yaml:"add_regex_if" json:"add_regex_if" doc:"add output field if input field satisfies regex pattern from parameters field"`
+	AddIf         string `yaml:"add_if" json:"add_if" doc:"add output field if input field satisfies criteria from parameters field"`
+	AddSubnet     string `yaml:"add_subnet" json:"add_subnet" doc:"add output subnet field from input field and prefix length from parameters field"`
+	AddLocation   string `yaml:"add_location" json:"add_location" doc:"add output location fields from input"`
+	AddService    string `yaml:"add_service" json:"add_service" doc:"add output network service field from input port and parameters protocol field"`
+	AddKubernetes string `yaml:"add_kubernetes" json:"add_kubernetes" doc:"add output kubernetes fields from input"`
 }
 
 func TransformNetworkOperationName(operation string) string {
@@ -39,10 +39,10 @@ func TransformNetworkOperationName(operation string) string {
 }
 
 type NetworkTransformRule struct {
-	Input      string `yaml:"input" doc:"entry input field"`
-	Output     string `yaml:"output" doc:"entry output field"`
-	Type       string `yaml:"type" enum:"TransformNetworkOperationEnum" doc:"one of the following:"`
-	Parameters string `yaml:"parameters" doc:"parameters specific to type"`
+	Input      string `yaml:"input" json:"input" doc:"entry input field"`
+	Output     string `yaml:"output" json:"output" doc:"entry output field"`
+	Type       string `yaml:"type" json:"type" enum:"TransformNetworkOperationEnum" doc:"one of the following:"`
+	Parameters string `yaml:"parameters,omitempty" json:"parameters,omitempty" doc:"parameters specific to type"`
 }
 
 type NetworkTransformRules []NetworkTransformRule

--- a/pkg/api/write_loki.go
+++ b/pkg/api/write_loki.go
@@ -26,19 +26,19 @@ import (
 )
 
 type WriteLoki struct {
-	URL            string                      `yaml:"url,omitempty" json:"url,omitempty" doc:"the address of an existing Loki service to push the flows to"`
-	TenantID       string                      `yaml:"tenantID,omitempty" json:"tenantID,omitempty" doc:"identifies the tenant for the request"`
-	BatchWait      string                      `yaml:"batchWait,omitempty" json:"batchWait,omitempty" doc:"maximum amount of time to wait before sending a batch"`
-	BatchSize      int                         `yaml:"batchSize,omitempty" json:"batchSize,omitempty" doc:"maximum batch size (in bytes) of logs to accumulate before sending"`
-	Timeout        string                      `yaml:"timeout,omitempty" json:"timeout,omitempty" doc:"maximum time to wait for a server to respond to a request"`
-	MinBackoff     string                      `yaml:"minBackoff,omitempty" json:"minBackoff,omitempty" doc:"initial backoff time for client connection between retries"`
-	MaxBackoff     string                      `yaml:"maxBackoff,omitempty" json:"maxBackoff,omitempty" doc:"maximum backoff time for client connection between retries"`
-	MaxRetries     int                         `yaml:"maxRetries,omitempty" json:"maxRetries,omitempty" doc:"maximum number of retries for client connections"`
-	Labels         []string                    `yaml:"labels,omitempty" json:"labels,omitempty" doc:"map of record fields to be used as labels"`
-	StaticLabels   model.LabelSet              `yaml:"staticLabels,omitempty" json:"staticLabels,omitempty" doc:"map of common labels to set on each flow"`
-	IgnoreList     []string                    `yaml:"ignoreList,omitempty" json:"ignoreList,omitempty" doc:"map of record fields to be removed from the record"`
-	ClientConfig   promConfig.HTTPClientConfig `yaml:"clientConfig,omitempty" json:"clientConfig,omitempty" doc:"clientConfig"`
-	TimestampLabel model.LabelName             `yaml:"timestampLabel,omitempty" json:"timestampLabel,omitempty" doc:"label to use for time indexing"`
+	URL            string                       `yaml:"url,omitempty" json:"url,omitempty" doc:"the address of an existing Loki service to push the flows to"`
+	TenantID       string                       `yaml:"tenantID,omitempty" json:"tenantID,omitempty" doc:"identifies the tenant for the request"`
+	BatchWait      string                       `yaml:"batchWait,omitempty" json:"batchWait,omitempty" doc:"maximum amount of time to wait before sending a batch"`
+	BatchSize      int                          `yaml:"batchSize,omitempty" json:"batchSize,omitempty" doc:"maximum batch size (in bytes) of logs to accumulate before sending"`
+	Timeout        string                       `yaml:"timeout,omitempty" json:"timeout,omitempty" doc:"maximum time to wait for a server to respond to a request"`
+	MinBackoff     string                       `yaml:"minBackoff,omitempty" json:"minBackoff,omitempty" doc:"initial backoff time for client connection between retries"`
+	MaxBackoff     string                       `yaml:"maxBackoff,omitempty" json:"maxBackoff,omitempty" doc:"maximum backoff time for client connection between retries"`
+	MaxRetries     int                          `yaml:"maxRetries,omitempty" json:"maxRetries,omitempty" doc:"maximum number of retries for client connections"`
+	Labels         []string                     `yaml:"labels,omitempty" json:"labels,omitempty" doc:"map of record fields to be used as labels"`
+	StaticLabels   model.LabelSet               `yaml:"staticLabels,omitempty" json:"staticLabels,omitempty" doc:"map of common labels to set on each flow"`
+	IgnoreList     []string                     `yaml:"ignoreList,omitempty" json:"ignoreList,omitempty" doc:"map of record fields to be removed from the record"`
+	ClientConfig   *promConfig.HTTPClientConfig `yaml:"clientConfig,omitempty" json:"clientConfig,omitempty" doc:"clientConfig"`
+	TimestampLabel model.LabelName              `yaml:"timestampLabel,omitempty" json:"timestampLabel,omitempty" doc:"label to use for time indexing"`
 	// TimestampScale provides the scale in time of the units from the timestamp
 	// E.g. UNIX timescale is '1s' (one second) while other clock sources might have
 	// scales of '1ms' (one millisecond) or just '1' (one nanosecond)

--- a/pkg/api/write_loki.go
+++ b/pkg/api/write_loki.go
@@ -26,24 +26,24 @@ import (
 )
 
 type WriteLoki struct {
-	URL            string                      `yaml:"url,omitempty" doc:"the address of an existing Loki service to push the flows to"`
-	TenantID       string                      `yaml:"tenantID,omitempty" doc:"identifies the tenant for the request"`
-	BatchWait      string                      `yaml:"batchWait,omitempty" doc:"maximum amount of time to wait before sending a batch"`
-	BatchSize      int                         `yaml:"batchSize,omitempty" doc:"maximum batch size (in bytes) of logs to accumulate before sending"`
-	Timeout        string                      `yaml:"timeout,omitempty" doc:"maximum time to wait for a server to respond to a request"`
-	MinBackoff     string                      `yaml:"minBackoff,omitempty" doc:"initial backoff time for client connection between retries"`
-	MaxBackoff     string                      `yaml:"maxBackoff,omitempty" doc:"maximum backoff time for client connection between retries"`
-	MaxRetries     int                         `yaml:"maxRetries,omitempty" doc:"maximum number of retries for client connections"`
-	Labels         []string                    `yaml:"labels,omitempty" doc:"map of record fields to be used as labels"`
-	StaticLabels   model.LabelSet              `yaml:"staticLabels,omitempty" doc:"map of common labels to set on each flow"`
-	IgnoreList     []string                    `yaml:"ignoreList,omitempty" doc:"map of record fields to be removed from the record"`
-	ClientConfig   promConfig.HTTPClientConfig `yaml:"clientConfig,omitempty" doc:"clientConfig"`
-	TimestampLabel model.LabelName             `yaml:"timestampLabel,omitempty" doc:"label to use for time indexing"`
+	URL            string                      `yaml:"url,omitempty" json:"url,omitempty" doc:"the address of an existing Loki service to push the flows to"`
+	TenantID       string                      `yaml:"tenantID,omitempty" json:"tenantID,omitempty" doc:"identifies the tenant for the request"`
+	BatchWait      string                      `yaml:"batchWait,omitempty" json:"batchWait,omitempty" doc:"maximum amount of time to wait before sending a batch"`
+	BatchSize      int                         `yaml:"batchSize,omitempty" json:"batchSize,omitempty" doc:"maximum batch size (in bytes) of logs to accumulate before sending"`
+	Timeout        string                      `yaml:"timeout,omitempty" json:"timeout,omitempty" doc:"maximum time to wait for a server to respond to a request"`
+	MinBackoff     string                      `yaml:"minBackoff,omitempty" json:"minBackoff,omitempty" doc:"initial backoff time for client connection between retries"`
+	MaxBackoff     string                      `yaml:"maxBackoff,omitempty" json:"maxBackoff,omitempty" doc:"maximum backoff time for client connection between retries"`
+	MaxRetries     int                         `yaml:"maxRetries,omitempty" json:"maxRetries,omitempty" doc:"maximum number of retries for client connections"`
+	Labels         []string                    `yaml:"labels,omitempty" json:"labels,omitempty" doc:"map of record fields to be used as labels"`
+	StaticLabels   model.LabelSet              `yaml:"staticLabels,omitempty" json:"staticLabels,omitempty" doc:"map of common labels to set on each flow"`
+	IgnoreList     []string                    `yaml:"ignoreList,omitempty" json:"ignoreList,omitempty" doc:"map of record fields to be removed from the record"`
+	ClientConfig   promConfig.HTTPClientConfig `yaml:"clientConfig,omitempty" json:"clientConfig,omitempty" doc:"clientConfig"`
+	TimestampLabel model.LabelName             `yaml:"timestampLabel,omitempty" json:"timestampLabel,omitempty" doc:"label to use for time indexing"`
 	// TimestampScale provides the scale in time of the units from the timestamp
 	// E.g. UNIX timescale is '1s' (one second) while other clock sources might have
 	// scales of '1ms' (one millisecond) or just '1' (one nanosecond)
 	// Default value is '1s'
-	TimestampScale string `yaml:"timestampScale,omitempty" doc:"timestamp units scale (e.g. for UNIX = 1s)"`
+	TimestampScale string `yaml:"timestampScale,omitempty" json:"timestampScale,omitempty" doc:"timestamp units scale (e.g. for UNIX = 1s)"`
 }
 
 func GetWriteLokiDefaults() WriteLoki {

--- a/pkg/api/write_stdout.go
+++ b/pkg/api/write_stdout.go
@@ -1,5 +1,5 @@
 package api
 
 type WriteStdout struct {
-	Format string `yaml:"format" doc:"the format of each line: printf (default) or json"`
+	Format string `yaml:"format" json:"format" doc:"the format of each line: printf (default) or json"`
 }

--- a/pkg/confgen/confgen_test.go
+++ b/pkg/confgen/confgen_test.go
@@ -78,7 +78,7 @@ encode:
     metrics:
       - name: test_metric
         type: gauge
-        valuekey: test_aggregates_value
+        valueKey: test_aggregates_value
         labels:
           - by
           - aggregate

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -43,65 +43,61 @@ type Health struct {
 }
 
 type Stage struct {
-	Name    string
-	Follows string
+	Name    string `json:"name"`
+	Follows string `json:"follows,omitempty"`
 }
 
 type StageParam struct {
-	Name      string
-	Ingest    Ingest
-	Decode    Decode
-	Transform Transform
-	Extract   Extract
-	Encode    Encode
-	Write     Write
+	Name      string     `json:"name"`
+	Ingest    *Ingest    `json:"ingest,omitempty"`
+	Decode    *Decode    `json:"decode,omitempty"`
+	Transform *Transform `json:"transform,omitempty"`
+	Extract   *Extract   `json:"extract,omitempty"`
+	Encode    *Encode    `json:"encode,omitempty"`
+	Write     *Write     `json:"write,omitempty"`
 }
 
 type Ingest struct {
-	Type      string
-	File      File
-	Collector api.IngestCollector
-	Kafka     api.IngestKafka
-	GRPC      api.IngestGRPCProto
+	Type      string               `json:"type"`
+	File      *File                `json:"file,omitempty"`
+	Collector *api.IngestCollector `json:"collector,omitempty"`
+	Kafka     *api.IngestKafka     `json:"kafka,omitempty"`
+	GRPC      *api.IngestGRPCProto `json:"grpc,omitempty"`
 }
 
 type File struct {
-	Filename string
-	Loop     bool
-	Chunks   int
-}
-
-type Aws struct {
-	Fields []string
+	Filename string `json:"filename"`
+	Loop     bool   `json:"loop"`
+	Chunks   int    `json:"chunks"`
 }
 
 type Decode struct {
-	Type string
-	Aws  api.DecodeAws
+	Type string         `json:"type"`
+	Aws  *api.DecodeAws `json:"aws,omitempty"`
 }
 
 type Transform struct {
-	Type    string
-	Generic api.TransformGeneric
-	Filter  api.TransformFilter
-	Network api.TransformNetwork
+	Type    string                `json:"type"`
+	Generic *api.TransformGeneric `json:"generic,omitempty"`
+	Filter  *api.TransformFilter  `json:"filter,omitempty"`
+	Network *api.TransformNetwork `json:"network,omitempty"`
 }
 
 type Extract struct {
-	Type       string
-	Aggregates []api.AggregateDefinition
+	Type       string                    `json:"type"`
+	Aggregates []api.AggregateDefinition `json:"aggregates,omitempty"`
 }
 
 type Encode struct {
-	Type  string
-	Prom  api.PromEncode
-	Kafka api.EncodeKafka
+	Type  string           `json:"type"`
+	Prom  *api.PromEncode  `json:"prom,omitempty"`
+	Kafka *api.EncodeKafka `json:"kafka,omitempty"`
 }
 
 type Write struct {
-	Type   string
-	Loki   api.WriteLoki
-	Stdout api.WriteStdout
+	Type   string           `json:"type"`
+	Loki   *api.WriteLoki   `json:"loki,omitempty"`
+	Stdout *api.WriteStdout `json:"stdout,omitempty"`
 }
 
 // ParseConfig creates the internal unmarshalled representation from the Pipeline and Parameters json

--- a/pkg/config/pipeline_builder.go
+++ b/pkg/config/pipeline_builder.go
@@ -1,97 +1,144 @@
+/*
+ * Copyright (C) 2021 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package config
 
 import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 )
 
-type Pipeline struct {
+type pipeline struct {
 	stages []Stage
 	config []StageParam
 }
 
-type PipelineBuilder struct {
+// PipelineBuilderStage holds information about a created pipeline stage. This stage can be used to chain a following stage, or several of them (resulting in a fork).
+// Example:
+// 	firstStage := NewCollectorPipeline("first stage", ...)
+// 	secondStage := firstStage.DecodeJSON("second stage")
+// 	thirdStage := secondStage.WriteLoki("third stage", ...)
+// 	forkedStage := secondStage.WriteStdout("fork following second stage", ...)
+//
+// All created stages hold a pointer to the whole pipeline, so that the resulting pipeline can be retrieve from any of the stages:
+//
+// 	forkedStage.GetStages()
+// 	forkedStage.GetStageParams()
+//	// is equivalent to:
+// 	firstStage.GetStages()
+// 	firstStage.GetStageParams()
+type PipelineBuilderStage struct {
 	lastStage string
-	pipeline  *Pipeline
+	pipeline  *pipeline
 }
 
-func NewCollectorPipeline(name string, ingest api.IngestCollector) PipelineBuilder {
-	p := Pipeline{
+// NewCollectorPipeline creates a new pipeline from an `IngestCollector` initial stage (listening for NetFlows / IPFIX)
+func NewCollectorPipeline(name string, ingest api.IngestCollector) PipelineBuilderStage {
+	p := pipeline{
 		stages: []Stage{{Name: name}},
 		config: []StageParam{{Name: name, Ingest: &Ingest{Type: api.CollectorType, Collector: &ingest}}},
 	}
-	return PipelineBuilder{pipeline: &p, lastStage: name}
+	return PipelineBuilderStage{pipeline: &p, lastStage: name}
 }
 
-func NewGRPCPipeline(name string, ingest api.IngestGRPCProto) PipelineBuilder {
-	p := Pipeline{
+// NewGRPCPipeline creates a new pipeline from an `IngestGRPCProto` initial stage (listening for NetObserv's eBPF agent protobuf)
+func NewGRPCPipeline(name string, ingest api.IngestGRPCProto) PipelineBuilderStage {
+	p := pipeline{
 		stages: []Stage{{Name: name}},
 		config: []StageParam{{Name: name, Ingest: &Ingest{Type: api.GRPCType, GRPC: &ingest}}},
 	}
-	return PipelineBuilder{pipeline: &p, lastStage: name}
+	return PipelineBuilderStage{pipeline: &p, lastStage: name}
 }
 
-func NewKafkaPipeline(name string, ingest api.IngestKafka) PipelineBuilder {
-	p := Pipeline{
+// NewKafkaPipeline creates a new pipeline from an `IngestKafka` initial stage (listening for flow events on Kafka)
+func NewKafkaPipeline(name string, ingest api.IngestKafka) PipelineBuilderStage {
+	p := pipeline{
 		stages: []Stage{{Name: name}},
 		config: []StageParam{{Name: name, Ingest: &Ingest{Type: api.KafkaType, Kafka: &ingest}}},
 	}
-	return PipelineBuilder{pipeline: &p, lastStage: name}
+	return PipelineBuilderStage{pipeline: &p, lastStage: name}
 }
 
-func (b *PipelineBuilder) next(name string, param StageParam) PipelineBuilder {
+func (b *PipelineBuilderStage) next(name string, param StageParam) PipelineBuilderStage {
 	b.pipeline.stages = append(b.pipeline.stages, Stage{Name: name, Follows: b.lastStage})
 	b.pipeline.config = append(b.pipeline.config, param)
-	return PipelineBuilder{pipeline: b.pipeline, lastStage: name}
+	return PipelineBuilderStage{pipeline: b.pipeline, lastStage: name}
 }
 
-func (b *PipelineBuilder) DecodeJSON(name string) PipelineBuilder {
+// DecodeJSON chains the current stage with a JSON decode stage and returns that new stage
+func (b *PipelineBuilderStage) DecodeJSON(name string) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Decode: &Decode{Type: api.JSONType}})
 }
 
-func (b *PipelineBuilder) DecodeProtobuf(name string) PipelineBuilder {
+// DecodeProtobuf chains the current stage with a protobuf decode stage and returns that new stage
+func (b *PipelineBuilderStage) DecodeProtobuf(name string) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Decode: &Decode{Type: api.PBType}})
 }
 
-func (b *PipelineBuilder) DecodeAWS(name string, aws api.DecodeAws) PipelineBuilder {
+// DecodeAWS chains the current stage with an AWS decode stage and returns that new stage
+func (b *PipelineBuilderStage) DecodeAWS(name string, aws api.DecodeAws) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Decode: &Decode{Type: api.AWSType, Aws: &aws}})
 }
 
-func (b *PipelineBuilder) Aggregate(name string, aggs []api.AggregateDefinition) PipelineBuilder {
+// Aggregate chains the current stage with an aggregate stage and returns that new stage
+func (b *PipelineBuilderStage) Aggregate(name string, aggs []api.AggregateDefinition) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Extract: &Extract{Type: api.AggregateType, Aggregates: aggs}})
 }
 
-func (b *PipelineBuilder) TransformGeneric(name string, gen api.TransformGeneric) PipelineBuilder {
+// TransformGeneric chains the current stage with a TransformGeneric stage and returns that new stage
+func (b *PipelineBuilderStage) TransformGeneric(name string, gen api.TransformGeneric) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Transform: &Transform{Type: api.GenericType, Generic: &gen}})
 }
 
-func (b *PipelineBuilder) TransformFilter(name string, filter api.TransformFilter) PipelineBuilder {
+// TransformFilter chains the current stage with a TransformFilter stage and returns that new stage
+func (b *PipelineBuilderStage) TransformFilter(name string, filter api.TransformFilter) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Transform: &Transform{Type: api.FilterType, Filter: &filter}})
 }
 
-func (b *PipelineBuilder) TransformNetwork(name string, nw api.TransformNetwork) PipelineBuilder {
+// TransformNetwork chains the current stage with a TransformNetwork stage and returns that new stage
+func (b *PipelineBuilderStage) TransformNetwork(name string, nw api.TransformNetwork) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Transform: &Transform{Type: api.NetworkType, Network: &nw}})
 }
 
-func (b *PipelineBuilder) EncodePrometheus(name string, prom api.PromEncode) PipelineBuilder {
+// EncodePrometheus chains the current stage with a PromEncode stage (to expose metrics in Prometheus format) and returns that new stage
+func (b *PipelineBuilderStage) EncodePrometheus(name string, prom api.PromEncode) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Encode: &Encode{Type: api.PromType, Prom: &prom}})
 }
 
-func (b *PipelineBuilder) EncodeKafka(name string, kafka api.EncodeKafka) PipelineBuilder {
+// EncodeKafka chains the current stage with an EncodeKafka stage (writing to a Kafka topic) and returns that new stage
+func (b *PipelineBuilderStage) EncodeKafka(name string, kafka api.EncodeKafka) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Encode: &Encode{Type: api.KafkaType, Kafka: &kafka}})
 }
 
-func (b *PipelineBuilder) WriteStdout(name string, stdout api.WriteStdout) PipelineBuilder {
+// WriteStdout chains the current stage with a WriteStdout stage and returns that new stage
+func (b *PipelineBuilderStage) WriteStdout(name string, stdout api.WriteStdout) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Write: &Write{Type: api.StdoutType, Stdout: &stdout}})
 }
 
-func (b *PipelineBuilder) WriteLoki(name string, loki api.WriteLoki) PipelineBuilder {
+// WriteLoki chains the current stage with a WriteLoki stage and returns that new stage
+func (b *PipelineBuilderStage) WriteLoki(name string, loki api.WriteLoki) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Write: &Write{Type: api.LokiType, Loki: &loki}})
 }
 
-func (b *PipelineBuilder) GetStages() []Stage {
+// GetStages returns the current pipeline stages. It can be called from any of the stages, they share the same pipeline reference.
+func (b *PipelineBuilderStage) GetStages() []Stage {
 	return b.pipeline.stages
 }
 
-func (b *PipelineBuilder) GetStageParams() []StageParam {
+// GetStageParams returns the current pipeline stage params. It can be called from any of the stages, they share the same pipeline reference.
+func (b *PipelineBuilderStage) GetStageParams() []StageParam {
 	return b.pipeline.config
 }

--- a/pkg/config/pipeline_builder.go
+++ b/pkg/config/pipeline_builder.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+)
+
+type Pipeline struct {
+	stages []Stage
+	config []StageParam
+}
+
+type PipelineBuilder struct {
+	lastStage string
+	pipeline  *Pipeline
+}
+
+func NewCollectorPipeline(name string, ingest api.IngestCollector) PipelineBuilder {
+	p := Pipeline{
+		stages: []Stage{{Name: name}},
+		config: []StageParam{{Name: name, Ingest: &Ingest{Type: api.CollectorType, Collector: &ingest}}},
+	}
+	return PipelineBuilder{pipeline: &p, lastStage: name}
+}
+
+func NewGRPCPipeline(name string, ingest api.IngestGRPCProto) PipelineBuilder {
+	p := Pipeline{
+		stages: []Stage{{Name: name}},
+		config: []StageParam{{Name: name, Ingest: &Ingest{Type: api.GRPCType, GRPC: &ingest}}},
+	}
+	return PipelineBuilder{pipeline: &p, lastStage: name}
+}
+
+func NewKafkaPipeline(name string, ingest api.IngestKafka) PipelineBuilder {
+	p := Pipeline{
+		stages: []Stage{{Name: name}},
+		config: []StageParam{{Name: name, Ingest: &Ingest{Type: api.KafkaType, Kafka: &ingest}}},
+	}
+	return PipelineBuilder{pipeline: &p, lastStage: name}
+}
+
+func (b *PipelineBuilder) next(name string, param StageParam) PipelineBuilder {
+	b.pipeline.stages = append(b.pipeline.stages, Stage{Name: name, Follows: b.lastStage})
+	b.pipeline.config = append(b.pipeline.config, param)
+	return PipelineBuilder{pipeline: b.pipeline, lastStage: name}
+}
+
+func (b *PipelineBuilder) DecodeJSON(name string) PipelineBuilder {
+	return b.next(name, StageParam{Name: name, Decode: &Decode{Type: api.JSONType}})
+}
+
+func (b *PipelineBuilder) DecodeProtobuf(name string) PipelineBuilder {
+	return b.next(name, StageParam{Name: name, Decode: &Decode{Type: api.PBType}})
+}
+
+func (b *PipelineBuilder) DecodeAWS(name string, aws api.DecodeAws) PipelineBuilder {
+	return b.next(name, StageParam{Name: name, Decode: &Decode{Type: api.AWSType, Aws: &aws}})
+}
+
+func (b *PipelineBuilder) Aggregate(name string, aggs []api.AggregateDefinition) PipelineBuilder {
+	return b.next(name, StageParam{Name: name, Extract: &Extract{Type: api.AggregateType, Aggregates: aggs}})
+}
+
+func (b *PipelineBuilder) TransformGeneric(name string, gen api.TransformGeneric) PipelineBuilder {
+	return b.next(name, StageParam{Name: name, Transform: &Transform{Type: api.GenericType, Generic: &gen}})
+}
+
+func (b *PipelineBuilder) TransformFilter(name string, filter api.TransformFilter) PipelineBuilder {
+	return b.next(name, StageParam{Name: name, Transform: &Transform{Type: api.FilterType, Filter: &filter}})
+}
+
+func (b *PipelineBuilder) TransformNetwork(name string, nw api.TransformNetwork) PipelineBuilder {
+	return b.next(name, StageParam{Name: name, Transform: &Transform{Type: api.NetworkType, Network: &nw}})
+}
+
+func (b *PipelineBuilder) EncodePrometheus(name string, prom api.PromEncode) PipelineBuilder {
+	return b.next(name, StageParam{Name: name, Encode: &Encode{Type: api.PromType, Prom: &prom}})
+}
+
+func (b *PipelineBuilder) EncodeKafka(name string, kafka api.EncodeKafka) PipelineBuilder {
+	return b.next(name, StageParam{Name: name, Encode: &Encode{Type: api.KafkaType, Kafka: &kafka}})
+}
+
+func (b *PipelineBuilder) WriteStdout(name string, stdout api.WriteStdout) PipelineBuilder {
+	return b.next(name, StageParam{Name: name, Write: &Write{Type: api.StdoutType, Stdout: &stdout}})
+}
+
+func (b *PipelineBuilder) WriteLoki(name string, loki api.WriteLoki) PipelineBuilder {
+	return b.next(name, StageParam{Name: name, Write: &Write{Type: api.LokiType, Loki: &loki}})
+}
+
+func (b *PipelineBuilder) GetStages() []Stage {
+	return b.pipeline.stages
+}
+
+func (b *PipelineBuilder) GetStageParams() []StageParam {
+	return b.pipeline.config
+}

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -112,7 +112,7 @@ func TestKafkaPromPipeline(t *testing.T) {
 
 	b, err = json.Marshal(params[2])
 	require.NoError(t, err)
-	require.Equal(t, `{"name":"aggregate","extract":{"type":"aggregates","aggregates":[{"name":"src_as_connection_count","by":["srcAS"],"operation":"count","recordKey":""}]}}`, string(b))
+	require.Equal(t, `{"name":"aggregate","extract":{"type":"aggregates","aggregates":[{"name":"src_as_connection_count","by":["srcAS"],"operation":"count","recordKey":"","topK":0}]}}`, string(b))
 
 	b, err = json.Marshal(params[3])
 	require.NoError(t, err)

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -57,7 +57,7 @@ func TestLokiPipeline(t *testing.T) {
 
 	b, err = json.Marshal(params[2])
 	require.NoError(t, err)
-	require.Equal(t, `{"name":"loki","write":{"type":"loki","loki":{"url":"http://loki:3100/","batchWait":"1s","batchSize":102400,"timeout":"10s","minBackoff":"1s","maxBackoff":"5m","maxRetries":10,"clientConfig":{"proxy_url":null,"tls_config":{"insecure_skip_verify":false},"follow_redirects":false},"timestampLabel":"TimeReceived","timestampScale":"1s"}}}`, string(b))
+	require.Equal(t, `{"name":"loki","write":{"type":"loki","loki":{"url":"http://loki:3100/","batchWait":"1s","batchSize":102400,"timeout":"10s","minBackoff":"1s","maxBackoff":"5m","maxRetries":10,"timestampLabel":"TimeReceived","timestampScale":"1s"}}}`, string(b))
 }
 
 func TestKafkaPromPipeline(t *testing.T) {
@@ -139,7 +139,7 @@ func TestForkPipeline(t *testing.T) {
 
 	b, err = json.Marshal(params[1])
 	require.NoError(t, err)
-	require.Equal(t, `{"name":"loki","write":{"type":"loki","loki":{"url":"http://loki:3100/","batchWait":"1s","batchSize":102400,"timeout":"10s","minBackoff":"1s","maxBackoff":"5m","maxRetries":10,"clientConfig":{"proxy_url":null,"tls_config":{"insecure_skip_verify":false},"follow_redirects":false},"timestampLabel":"TimeReceived","timestampScale":"1s"}}}`, string(b))
+	require.Equal(t, `{"name":"loki","write":{"type":"loki","loki":{"url":"http://loki:3100/","batchWait":"1s","batchSize":102400,"timeout":"10s","minBackoff":"1s","maxBackoff":"5m","maxRetries":10,"timestampLabel":"TimeReceived","timestampScale":"1s"}}}`, string(b))
 
 	b, err = json.Marshal(params[2])
 	require.NoError(t, err)

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2022 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLokiPipeline(t *testing.T) {
+	pl := NewCollectorPipeline("ingest", api.IngestCollector{HostName: "127.0.0.1", Port: 9999})
+	pl = pl.TransformNetwork("enrich", api.TransformNetwork{Rules: api.NetworkTransformRules{{
+		Type:   api.AddKubernetesRuleType,
+		Input:  "SrcAddr",
+		Output: "SrcK8S",
+	}, {
+		Type:   api.AddKubernetesRuleType,
+		Input:  "DstAddr",
+		Output: "DstK8S",
+	}}})
+	pl = pl.WriteLoki("loki", api.GetWriteLokiDefaults())
+	stages := pl.GetStages()
+	require.Len(t, stages, 3)
+
+	b, err := json.Marshal(stages)
+	require.NoError(t, err)
+	require.Equal(t, `[{"name":"ingest"},{"name":"enrich","follows":"ingest"},{"name":"loki","follows":"enrich"}]`, string(b))
+
+	params := pl.GetStageParams()
+	require.Len(t, params, 3)
+
+	b, err = json.Marshal(params[0])
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"ingest","ingest":{"type":"collector","collector":{"hostName":"127.0.0.1","port":9999,"portLegacy":0,"batchMaxLen":0}}}`, string(b))
+
+	b, err = json.Marshal(params[1])
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"enrich","transform":{"type":"network","network":{"rules":[{"input":"SrcAddr","output":"SrcK8S","type":"add_kubernetes"},{"input":"DstAddr","output":"DstK8S","type":"add_kubernetes"}]}}}`, string(b))
+
+	b, err = json.Marshal(params[2])
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"loki","write":{"type":"loki","loki":{"url":"http://loki:3100/","batchWait":"1s","batchSize":102400,"timeout":"10s","minBackoff":"1s","maxBackoff":"5m","maxRetries":10,"clientConfig":{"proxy_url":null,"tls_config":{"insecure_skip_verify":false},"follow_redirects":false},"timestampLabel":"TimeReceived","timestampScale":"1s"}}}`, string(b))
+}
+
+func TestKafkaPromPipeline(t *testing.T) {
+	pl := NewKafkaPipeline("ingest", api.IngestKafka{
+		Brokers: []string{"http://kafka"},
+		Topic:   "netflows",
+		GroupId: "my-group",
+	})
+	pl = pl.TransformFilter("filter", api.TransformFilter{
+		Rules: []api.TransformFilterRule{{
+			Type:  "remove_entry_if_doesnt_exist",
+			Input: "doesnt_exist",
+		}},
+	})
+	pl = pl.Aggregate("aggregate", []api.AggregateDefinition{{
+		Name:      "src_as_connection_count",
+		By:        api.AggregateBy{"srcAS"},
+		Operation: "count",
+	}})
+	pl = pl.EncodePrometheus("prom", api.PromEncode{
+		Metrics: api.PromMetricsItems{{
+			Name: "connections_per_source_as",
+			Type: "counter",
+			Filter: api.PromMetricsFilter{
+				Key:   "name",
+				Value: "src_as_connection_count",
+			},
+			ValueKey: "recent_count",
+			Labels:   []string{"by", "aggregate"},
+			Buckets:  []float64{},
+		}},
+		Port:   9090,
+		Prefix: "flp_",
+	})
+	stages := pl.GetStages()
+	require.Len(t, stages, 4)
+
+	b, err := json.Marshal(stages)
+	require.NoError(t, err)
+	require.Equal(t, `[{"name":"ingest"},{"name":"filter","follows":"ingest"},{"name":"aggregate","follows":"filter"},{"name":"prom","follows":"aggregate"}]`, string(b))
+
+	params := pl.GetStageParams()
+	require.Len(t, params, 4)
+
+	b, err = json.Marshal(params[0])
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"ingest","ingest":{"type":"kafka","kafka":{"brokers":["http://kafka"],"topic":"netflows","groupid":"my-group","groupBalancers":null,"startOffset":"","batchReadTimeout":0}}}`, string(b))
+
+	b, err = json.Marshal(params[1])
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"filter","transform":{"type":"filter","filter":{"rules":[{"input":"doesnt_exist","type":"remove_entry_if_doesnt_exist"}]}}}`, string(b))
+
+	b, err = json.Marshal(params[2])
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"aggregate","extract":{"type":"aggregates","aggregates":[{"name":"src_as_connection_count","by":["srcAS"],"operation":"count","recordKey":""}]}}`, string(b))
+
+	b, err = json.Marshal(params[3])
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"prom","encode":{"type":"prom","prom":{"metrics":[{"name":"connections_per_source_as","type":"counter","filter":{"key":"name","value":"src_as_connection_count"},"valueKey":"recent_count","labels":["by","aggregate"],"buckets":[]}],"port":9090,"prefix":"flp_","expiryTime":0}}}`, string(b))
+}
+
+func TestForkPipeline(t *testing.T) {
+	plFork := NewCollectorPipeline("ingest", api.IngestCollector{HostName: "127.0.0.1", Port: 9999})
+	plFork.WriteLoki("loki", api.GetWriteLokiDefaults())
+	plFork.WriteStdout("stdout", api.WriteStdout{})
+	stages := plFork.GetStages()
+	require.Len(t, stages, 3)
+
+	b, err := json.Marshal(stages)
+	require.NoError(t, err)
+	require.Equal(t, `[{"name":"ingest"},{"name":"loki","follows":"ingest"},{"name":"stdout","follows":"ingest"}]`, string(b))
+
+	params := plFork.GetStageParams()
+	require.Len(t, params, 3)
+
+	b, err = json.Marshal(params[0])
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"ingest","ingest":{"type":"collector","collector":{"hostName":"127.0.0.1","port":9999,"portLegacy":0,"batchMaxLen":0}}}`, string(b))
+
+	b, err = json.Marshal(params[1])
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"loki","write":{"type":"loki","loki":{"url":"http://loki:3100/","batchWait":"1s","batchSize":102400,"timeout":"10s","minBackoff":"1s","maxBackoff":"5m","maxRetries":10,"clientConfig":{"proxy_url":null,"tls_config":{"insecure_skip_verify":false},"follow_redirects":false},"timestampLabel":"TimeReceived","timestampScale":"1s"}}}`, string(b))
+
+	b, err = json.Marshal(params[2])
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"stdout","write":{"type":"stdout","stdout":{"format":""}}}`, string(b))
+}

--- a/pkg/pipeline/aggregate_prom_test.go
+++ b/pkg/pipeline/aggregate_prom_test.go
@@ -74,26 +74,26 @@ parameters:
      prom:
        port: 9103
        prefix: test_
-       expirytime: 1
+       expiryTime: 1
        metrics:
          - name: flow_count
            type: counter
            filter: {key: name, value: bandwidth_count}
-           valuekey: recent_count
+           valueKey: recent_count
            labels:
              - service
 
          - name: bytes_sum
            type: counter
            filter: {key: name, value: bandwidth_sum}
-           valuekey: recent_op_value
+           valueKey: recent_op_value
            labels:
              - service
 
          - name: bytes_histogram
            type: histogram
            filter: {key: name, value: bandwidth_raw_values}
-           valuekey: recent_raw_values
+           valueKey: recent_raw_values
            labels:
              - service
 `

--- a/pkg/pipeline/decode/decode_aws.go
+++ b/pkg/pipeline/decode/decode_aws.go
@@ -73,9 +73,9 @@ func (c *decodeAws) Decode(in []interface{}) []config.GenericMap {
 // NewDecodeAws create a new decode
 func NewDecodeAws(params config.StageParam) (Decoder, error) {
 	log.Debugf("entering NewDecodeAws")
-	recordKeys := params.Decode.Aws.Fields
-	if len(recordKeys) == 0 {
-		recordKeys = defaultKeys
+	recordKeys := defaultKeys
+	if params.Decode != nil && params.Decode.Aws != nil && len(params.Decode.Aws.Fields) > 0 {
+		recordKeys = params.Decode.Aws.Fields
 	}
 	log.Debugf("recordKeys = %v", recordKeys)
 	return &decodeAws{

--- a/pkg/pipeline/encode/encode_kafka.go
+++ b/pkg/pipeline/encode/encode_kafka.go
@@ -66,7 +66,10 @@ func (r *encodeKafka) Encode(in []config.GenericMap) {
 // NewEncodeKafka create a new writer to kafka
 func NewEncodeKafka(params config.StageParam) (Encoder, error) {
 	log.Debugf("entering NewEncodeKafka")
-	jsonEncodeKafka := params.Encode.Kafka
+	jsonEncodeKafka := api.EncodeKafka{}
+	if params.Encode != nil && params.Encode.Kafka != nil {
+		jsonEncodeKafka = *params.Encode.Kafka
+	}
 
 	var balancer kafkago.Balancer
 	switch jsonEncodeKafka.Balancer {

--- a/pkg/pipeline/encode/encode_prom.go
+++ b/pkg/pipeline/encode/encode_prom.go
@@ -279,7 +279,11 @@ func startPrometheusInterface(w *EncodeProm) {
 }
 
 func NewEncodeProm(params config.StageParam) (Encoder, error) {
-	jsonEncodeProm := params.Encode.Prom
+	jsonEncodeProm := api.PromEncode{}
+	if params.Encode != nil && params.Encode.Prom != nil {
+		jsonEncodeProm = *params.Encode.Prom
+	}
+
 	portNum := jsonEncodeProm.Port
 	promPrefix := jsonEncodeProm.Prefix
 	expiryTime := int64(jsonEncodeProm.ExpiryTime)

--- a/pkg/pipeline/encode/encode_prom_test.go
+++ b/pkg/pipeline/encode/encode_prom_test.go
@@ -40,12 +40,12 @@ parameters:
       prom:
         port: 9103
         prefix: test_
-        expirytime: 1
+        expiryTime: 1
         metrics:
           - name: Bytes
             type: gauge
             filter: {key: dstAddr, value: 10.1.2.4}
-            valuekey: bytes
+            valueKey: bytes
             labels:
               - srcAddr
               - dstAddr
@@ -53,14 +53,14 @@ parameters:
           - name: Packets
             type: counter
             filter: {key: dstAddr, value: 10.1.2.4}
-            valuekey: packets
+            valueKey: packets
             labels:
               - srcAddr
               - dstAddr
               - dstPort
           - name: subnetHistogram
             type: histogram
-            valuekey: aggregate
+            valueKey: aggregate
             labels:
 `
 

--- a/pkg/pipeline/extract/extract_aggregate.go
+++ b/pkg/pipeline/extract/extract_aggregate.go
@@ -18,6 +18,7 @@
 package extract
 
 import (
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/extract/aggregate"
 	log "github.com/sirupsen/logrus"
@@ -42,7 +43,11 @@ func (ea *ExtractAggregate) Extract(entries []config.GenericMap) []config.Generi
 // NewExtractAggregate creates a new extractor
 func NewExtractAggregate(params config.StageParam) (Extractor, error) {
 	log.Debugf("entering NewExtractAggregate")
-	aggregates, err := aggregate.NewAggregatesFromConfig(params.Extract.Aggregates)
+	aggConfig := []api.AggregateDefinition{}
+	if params.Extract != nil {
+		aggConfig = params.Extract.Aggregates
+	}
+	aggregates, err := aggregate.NewAggregatesFromConfig(aggConfig)
 	if err != nil {
 		log.Errorf("error in NewAggregatesFromConfig: %v", err)
 		return nil, err

--- a/pkg/pipeline/ingest/ingest_collector.go
+++ b/pkg/pipeline/ingest/ingest_collector.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	ms "github.com/mitchellh/mapstructure"
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	operationalMetrics "github.com/netobserv/flowlogs-pipeline/pkg/operational/metrics"
 	pUtils "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
@@ -191,8 +192,10 @@ func (ingestC *ingestCollector) processLogLines(out chan<- []interface{}) {
 
 // NewIngestCollector create a new ingester
 func NewIngestCollector(params config.StageParam) (Ingester, error) {
-	jsonIngestCollector := params.Ingest.Collector
-
+	jsonIngestCollector := api.IngestCollector{}
+	if params.Ingest != nil && params.Ingest.Collector != nil {
+		jsonIngestCollector = *params.Ingest.Collector
+	}
 	if jsonIngestCollector.HostName == "" {
 		return nil, fmt.Errorf("ingest hostname not specified")
 	}

--- a/pkg/pipeline/ingest/ingest_file.go
+++ b/pkg/pipeline/ingest/ingest_file.go
@@ -42,8 +42,12 @@ const (
 
 // Ingest ingests entries from a file and resends the same data every delaySeconds seconds
 func (ingestF *IngestFile) Ingest(out chan<- []interface{}) {
+	var filename string
+	if ingestF.params.File != nil {
+		filename = ingestF.params.File.Filename
+	}
 	lines := make([]interface{}, 0)
-	file, err := os.Open(ingestF.params.File.Filename)
+	file, err := os.Open(filename)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -58,7 +62,7 @@ func (ingestF *IngestFile) Ingest(out chan<- []interface{}) {
 		lines = append(lines, text)
 	}
 
-	log.Debugf("Ingesting %d log lines from %s", len(lines), ingestF.params.File.Filename)
+	log.Debugf("Ingesting %d log lines from %s", len(lines), filename)
 	switch ingestF.params.Type {
 	case "file":
 		ingestF.PrevRecords = lines
@@ -98,14 +102,14 @@ func (ingestF *IngestFile) Ingest(out chan<- []interface{}) {
 // NewIngestFile create a new ingester
 func NewIngestFile(params config.StageParam) (Ingester, error) {
 	log.Debugf("entering NewIngestFile")
-	if params.Ingest.File.Filename == "" {
+	if params.Ingest == nil || params.Ingest.File == nil || params.Ingest.File.Filename == "" {
 		return nil, fmt.Errorf("ingest filename not specified")
 	}
 
 	log.Debugf("input file name = %s", params.Ingest.File.Filename)
 
 	return &IngestFile{
-		params:   params.Ingest,
+		params:   *params.Ingest,
 		exitChan: utils.ExitChannel(),
 	}, nil
 }

--- a/pkg/pipeline/ingest/ingest_grpc.go
+++ b/pkg/pipeline/ingest/ingest_grpc.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"fmt"
 
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"github.com/netobserv/netobserv-agent/pkg/grpc"
@@ -18,7 +19,10 @@ type GRPCProtobuf struct {
 }
 
 func NewGRPCProtobuf(params config.StageParam) (*GRPCProtobuf, error) {
-	netObserv := params.Ingest.GRPC
+	netObserv := api.IngestGRPCProto{}
+	if params.Ingest != nil && params.Ingest.GRPC != nil {
+		netObserv = *params.Ingest.GRPC
+	}
 	if netObserv.Port == 0 {
 		return nil, fmt.Errorf("ingest port not specified")
 	}

--- a/pkg/pipeline/ingest/ingest_kafka.go
+++ b/pkg/pipeline/ingest/ingest_kafka.go
@@ -104,7 +104,10 @@ func (ingestK *ingestKafka) processLogLines(out chan<- []interface{}) {
 // NewIngestKafka create a new ingester
 func NewIngestKafka(params config.StageParam) (Ingester, error) {
 	log.Debugf("entering NewIngestKafka")
-	jsonIngestKafka := params.Ingest.Kafka
+	jsonIngestKafka := api.IngestKafka{}
+	if params.Ingest != nil && params.Ingest.Kafka != nil {
+		jsonIngestKafka = *params.Ingest.Kafka
+	}
 
 	// connect to the kafka server
 	startOffsetString := jsonIngestKafka.StartOffset

--- a/pkg/pipeline/ingest/ingest_kafka_test.go
+++ b/pkg/pipeline/ingest/ingest_kafka_test.go
@@ -41,8 +41,8 @@ parameters:
         brokers: ["1.1.1.1:9092"]
         topic: topic1
         groupid: group1
-        startoffset: FirstOffset
-        groupbalancers: ["range", "roundRobin"]
+        startOffset: FirstOffset
+        groupBalancers: ["range", "roundRobin"]
         batchReadTimeout: 300
 `
 
@@ -58,8 +58,8 @@ parameters:
         brokers: ["1.1.1.2:9092"]
         topic: topic2
         groupid: group2
-        startoffset: LastOffset
-        groupbalancers: ["rackAffinity"]
+        startOffset: LastOffset
+        groupBalancers: ["rackAffinity"]
 `
 
 func initNewIngestKafka(t *testing.T, configTemplate string) Ingester {

--- a/pkg/pipeline/transform/transform.go
+++ b/pkg/pipeline/transform/transform.go
@@ -48,10 +48,3 @@ type Definition struct {
 }
 
 type Definitions []Definition
-
-const (
-	OperationGeneric = "generic"
-	OperationNetwork = "network"
-	OperationFilter  = "filter"
-	OperationNone    = "none"
-)

--- a/pkg/pipeline/transform/transform_filter.go
+++ b/pkg/pipeline/transform/transform_filter.go
@@ -62,8 +62,12 @@ func (f *Filter) Transform(input []config.GenericMap) []config.GenericMap {
 // NewTransformFilter create a new filter transform
 func NewTransformFilter(params config.StageParam) (Transformer, error) {
 	log.Debugf("entering NewTransformFilter")
+	rules := []api.TransformFilterRule{}
+	if params.Transform != nil && params.Transform.Filter != nil {
+		rules = params.Transform.Filter.Rules
+	}
 	transformFilter := &Filter{
-		Rules: params.Transform.Filter.Rules,
+		Rules: rules,
 	}
 	return transformFilter, nil
 }

--- a/pkg/pipeline/transform/transform_generic.go
+++ b/pkg/pipeline/transform/transform_generic.go
@@ -54,9 +54,13 @@ func (g *Generic) Transform(input []config.GenericMap) []config.GenericMap {
 // NewTransformGeneric create a new transform
 func NewTransformGeneric(params config.StageParam) (Transformer, error) {
 	log.Debugf("entering NewTransformGeneric")
-	log.Debugf("params.Transform.Generic = %v", params.Transform.Generic)
-	rules := params.Transform.Generic.Rules
-	policy := params.Transform.Generic.Policy
+	genConfig := api.TransformGeneric{}
+	if params.Transform != nil && params.Transform.Generic != nil {
+		genConfig = *params.Transform.Generic
+	}
+	log.Debugf("params.Transform.Generic = %v", genConfig)
+	rules := genConfig.Rules
+	policy := genConfig.Policy
 	switch policy {
 	case "replace_keys", "preserve_original_keys", "":
 		// valid; nothing to do

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -173,7 +173,10 @@ func NewTransformNetwork(params config.StageParam) (Transformer, error) {
 	var needToInitConnectionTracking = false
 	var needToInitNetworkServices = false
 
-	jsonNetworkTransform := params.Transform.Network
+	jsonNetworkTransform := api.TransformNetwork{}
+	if params.Transform != nil && params.Transform.Network != nil {
+		jsonNetworkTransform = *params.Transform.Network
+	}
 	for _, rule := range jsonNetworkTransform.Rules {
 		switch rule.Type {
 		case api.TransformNetworkOperationName("AddLocation"):

--- a/pkg/pipeline/transform_topk_test.go
+++ b/pkg/pipeline/transform_topk_test.go
@@ -87,13 +87,13 @@ parameters:
       type: network
   - extract:
       aggregates:
-      - Name: count_source_destination_subnet
-        By:
+      - name: count_source_destination_subnet
+        by:
         - dstSubnet24
         - srcSubnet24
-        Operation: count
-        RecordKey: ""
-        TopK: 4
+        operation: count
+        recordKey: ""
+        topK: 4
       type: aggregates
     name: extract_aggregate
   - name: write_none

--- a/pkg/pipeline/write/write_loki.go
+++ b/pkg/pipeline/write/write_loki.go
@@ -95,7 +95,9 @@ func buildLokiConfig(c *api.WriteLoki) (loki.Config, error) {
 			MaxBackoff: maxBackoff,
 			MaxRetries: c.MaxRetries,
 		},
-		Client: c.ClientConfig,
+	}
+	if c.ClientConfig != nil {
+		cfg.Client = *c.ClientConfig
 	}
 	var clientURL urlutil.URLValue
 	err = clientURL.Set(strings.TrimSuffix(c.URL, "/") + "/loki/api/v1/push")

--- a/pkg/pipeline/write/write_stdout.go
+++ b/pkg/pipeline/write/write_stdout.go
@@ -49,7 +49,9 @@ func (t *writeStdout) Write(in []config.GenericMap) {
 // NewWriteStdout create a new write
 func NewWriteStdout(params config.StageParam) (Writer, error) {
 	log.Debugf("entering NewWriteStdout")
-	return &writeStdout{
-		format: params.Write.Stdout.Format,
-	}, nil
+	writeStdout := &writeStdout{}
+	if params.Write != nil && params.Write.Stdout != nil {
+		writeStdout.format = params.Write.Stdout.Format
+	}
+	return writeStdout, nil
 }

--- a/pkg/test/e2e/pipline/flp-config.yaml
+++ b/pkg/test/e2e/pipline/flp-config.yaml
@@ -86,84 +86,84 @@ data:
           type: network
       - extract:
           aggregates:
-            - Name: bandwidth_network_service
-              By:
+            - name: bandwidth_network_service
+              by:
                 - service
-              Operation: sum
-              RecordKey: bytes
-            - Name: bandwidth_source_destination_subnet
-              By:
+              operation: sum
+              recordKey: bytes
+            - name: bandwidth_source_destination_subnet
+              by:
                 - dstSubnet24
                 - srcSubnet24
-              Operation: sum
-              RecordKey: bytes
-            - Name: bandwidth_source_subnet
-              By:
+              operation: sum
+              recordKey: bytes
+            - name: bandwidth_source_subnet
+              by:
                 - srcSubnet
-              Operation: sum
-              RecordKey: bytes
-            - Name: dest_connection_subnet_count
-              By:
+              operation: sum
+              recordKey: bytes
+            - name: dest_connection_subnet_count
+              by:
                 - dstSubnet
-              Operation: sum
-              RecordKey: isNewFlow
-            - Name: src_connection_count
-              By:
+              operation: sum
+              recordKey: isNewFlow
+            - name: src_connection_count
+              by:
                 - srcSubnet
-              Operation: count
-              RecordKey: ""
-            - Name: TCPFlags_count
-              By:
+              operation: count
+              recordKey: ""
+            - name: TCPFlags_count
+              by:
                 - TCPFlags
-              Operation: count
-              RecordKey: ""
-            - Name: dst_as_connection_count
-              By:
+              operation: count
+              recordKey: ""
+            - name: dst_as_connection_count
+              by:
                 - dstAS
-              Operation: count
-              RecordKey: ""
-            - Name: src_as_connection_count
-              By:
+              operation: count
+              recordKey: ""
+            - name: src_as_connection_count
+              by:
                 - srcAS
-              Operation: count
-              RecordKey: ""
-            - Name: count_source_destination_subnet
-              By:
+              operation: count
+              recordKey: ""
+            - name: count_source_destination_subnet
+              by:
                 - dstSubnet24
                 - srcSubnet24
-              Operation: count
-              RecordKey: ""
-            - Name: bandwidth_destination_subnet
-              By:
+              operation: count
+              recordKey: ""
+            - name: bandwidth_destination_subnet
+              by:
                 - dstSubnet
-              Operation: sum
-              RecordKey: bytes
-            - Name: bandwidth_namespace
-              By:
+              operation: sum
+              recordKey: bytes
+            - name: bandwidth_namespace
+              by:
                 - srcK8S_Namespace
                 - srcK8S_Type
-              Operation: sum
-              RecordKey: bytes
-            - Name: dest_connection_location_count
-              By:
+              operation: sum
+              recordKey: bytes
+            - name: dest_connection_location_count
+              by:
                 - dstLocation_CountryName
-              Operation: count
-              RecordKey: ""
-            - Name: mice_count
-              By:
+              operation: count
+              recordKey: ""
+            - name: mice_count
+              by:
                 - mice_Evaluate
-              Operation: count
-              RecordKey: ""
-            - Name: elephant_count
-              By:
+              operation: count
+              recordKey: ""
+            - name: elephant_count
+              by:
                 - elephant_Evaluate
-              Operation: count
-              RecordKey: ""
-            - Name: dest_service_count
-              By:
+              operation: count
+              recordKey: ""
+            - name: dest_service_count
+              by:
                 - service
-              Operation: count
-              RecordKey: ""
+              operation: count
+              recordKey: ""
           type: aggregates
         name: extract_aggregate
       - encode:
@@ -171,105 +171,105 @@ data:
             metrics:
               - name: bandwidth_per_network_service
                 type: counter
-                valuekey: bandwidth_network_service_value
+                valueKey: bandwidth_network_service_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: bandwidth_per_source_destination_subnet
                 type: counter
-                valuekey: bandwidth_source_destination_subnet_value
+                valueKey: bandwidth_source_destination_subnet_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: bandwidth_per_source_subnet
                 type: counter
-                valuekey: bandwidth_source_subnet_value
+                valueKey: bandwidth_source_subnet_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: connections_per_destination_subnet
                 type: counter
-                valuekey: dest_connection_subnet_count_value
+                valueKey: dest_connection_subnet_count_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: connections_per_source_subnet
                 type: counter
-                valuekey: src_connection_count_value
+                valueKey: src_connection_count_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: connections_per_tcp_flags
                 type: counter
-                valuekey: TCPFlags_count_value
+                valueKey: TCPFlags_count_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: connections_per_destination_as
                 type: counter
-                valuekey: dst_as_connection_count_value
+                valueKey: dst_as_connection_count_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: connections_per_source_as
                 type: counter
-                valuekey: src_as_connection_count_value
+                valueKey: src_as_connection_count_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: count_per_source_destination_subnet
                 type: counter
-                valuekey: count_source_destination_subnet_value
+                valueKey: count_source_destination_subnet_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: egress_per_destination_subnet
                 type: counter
-                valuekey: bandwidth_destination_subnet_value
+                valueKey: bandwidth_destination_subnet_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: egress_per_namespace
                 type: counter
-                valuekey: bandwidth_namespace_value
+                valueKey: bandwidth_namespace_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: connections_per_destination_location
                 type: counter
-                valuekey: dest_connection_location_count_value
+                valueKey: dest_connection_location_count_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: mice_count
                 type: counter
-                valuekey: mice_count_value
+                valueKey: mice_count_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: elephant_count
                 type: counter
-                valuekey: elephant_count_value
+                valueKey: elephant_count_value
                 labels:
                   - by
                   - aggregate
                 buckets: []
               - name: service_count
                 type: counter
-                valuekey: dest_service_count_value
+                valueKey: dest_service_count_value
                 labels:
                   - by
                   - aggregate

--- a/playground/prom1.yml
+++ b/playground/prom1.yml
@@ -47,25 +47,25 @@ parameters:
       prom:
         port: 9102
         prefix: fl2m_
-        expirytime: 15
+        expiryTime: 15
         metrics:
           - name: totalBytes
             type: gauge
-            valuekey: bytes
+            valueKey: bytes
             labels:
               - srcAddr
               - dstAddr
               - srcPort
           - name: totalPackets
             type: gauge
-            valuekey: packets
+            valueKey: packets
             labels:
               - srcAddr
               - dstAddr
               - dstPort
           - name: subnetHistogram
             type: histogram
-            valuekey: aggregate
+            valueKey: aggregate
             labels:
   - name: write1
     write:


### PR DESCRIPTION
- More consistent naming (camel-case) cf #206
- Add json bindings
- New pipeline builder to make it easier to consume and reuse API model
- Remove garbage files (?) that prevents importing as lib from another
  project

Summary of renamings:
```
prom.metrics.valuekey => prom.metrics.valueKey
prom.expirytime => prom.expiryTime
kafka.addr => kafka.address
kafka.groupbalancers => kafka.groupBalancers
kafka.startoffset => kafka.startOffset
kafka.batchreadtimeout => kafka.batchReadTimeout
grpc.buffer_length => grpc.bufferLength
network.kubeconfigpath => network.kubeConfigPath
network.servicesfile => network.servicesFile
network.protocolsfile => network.protocolsFile
aggregates.Name => aggregates.name
aggregates.By => aggregates.by
aggregates.Operation => aggregates.operation
aggregates.RecordKey => aggregates.recordKey
aggregates.TopK => aggregates.topK
```