### PR TITLE
Avoid json encoding on flow ingestion #212 (breaking change)

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -25,6 +25,7 @@ const (
 	GRPCType              = "grpc"
 	KafkaType             = "kafka"
 	JSONType              = "json"
+	CastType              = "cast"
 	PBType                = "protobuf"
 	AWSType               = "aws"
 	StdoutType            = "stdout"

--- a/pkg/config/pipeline_builder.go
+++ b/pkg/config/pipeline_builder.go
@@ -83,6 +83,11 @@ func (b *PipelineBuilderStage) DecodeJSON(name string) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Decode: &Decode{Type: api.JSONType}})
 }
 
+// DecodeCast chains the current stage with a Cast decode stage and returns that new stage.
+func (b *PipelineBuilderStage) DecodeCast(name string) PipelineBuilderStage {
+	return b.next(name, StageParam{Name: name, Decode: &Decode{Type: api.CastType}})
+}
+
 // DecodeProtobuf chains the current stage with a protobuf decode stage and returns that new stage
 func (b *PipelineBuilderStage) DecodeProtobuf(name string) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Decode: &Decode{Type: api.PBType}})

--- a/pkg/pipeline/decode/decode_cast.go
+++ b/pkg/pipeline/decode/decode_cast.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2021 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package decode
+
+import (
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	log "github.com/sirupsen/logrus"
+)
+
+type DecodeCast struct {
+	PrevRecords []interface{}
+}
+
+// Decode casts input as a list of flow entries
+func (c *DecodeCast) Decode(in []interface{}) []config.GenericMap {
+	out := make([]config.GenericMap, 0)
+	for _, line := range in {
+		log.Debugf("decodeCast: line = %v", line)
+		out = append(out, config.GenericMap(line.(map[string]interface{})))
+	}
+	c.PrevRecords = in
+	return out
+}
+
+// NewDecodeCast create a new decode
+func NewDecodeCast() (Decoder, error) {
+	log.Debugf("entering NewDecodeCast")
+	return &DecodeCast{}, nil
+}

--- a/pkg/pipeline/decode/decode_cast_test.go
+++ b/pkg/pipeline/decode/decode_cast_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2022 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package decode
+
+import (
+	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func initNewDecodeCast(t *testing.T) Decoder {
+	newDecode, err := NewDecodeCast()
+	require.Equal(t, nil, err)
+	return newDecode
+}
+
+func TestDecodeCast(t *testing.T) {
+	newDecode := initNewDecodeCast(t)
+	decodeCast := newDecode.(*DecodeCast)
+	inputMap1 := map[string]interface{}{
+		"varInt":    12,
+		"varString": "testString",
+		"varBool":   false,
+	}
+	inputMap2 := map[string]interface{}{
+		"varInt":    14,
+		"varString": "testString2",
+		"varBool":   true,
+	}
+	inputMap3 := map[string]interface{}{}
+	var in []interface{}
+	var out []config.GenericMap
+	out = decodeCast.Decode(in)
+	require.Equal(t, 0, len(out))
+	in = append(in, inputMap1)
+	in = append(in, inputMap2)
+	in = append(in, inputMap3)
+	out = decodeCast.Decode(in)
+	require.Equal(t, len(out), 3)
+	require.Equal(t, 12, out[0]["varInt"])
+	require.Equal(t, "testString", out[0]["varString"])
+	require.Equal(t, false, out[0]["varBool"])
+}

--- a/pkg/pipeline/ingest/ingest_collector.go
+++ b/pkg/pipeline/ingest/ingest_collector.go
@@ -20,7 +20,6 @@ package ingest
 import (
 	"context"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"net"
 	"time"
@@ -166,10 +165,7 @@ func (ingestC *ingestCollector) processLogLines(out chan<- []interface{}) {
 			log.Debugf("exiting ingestCollector because of signal")
 			return
 		case record := <-ingestC.in:
-			// TODO: for efficiency, consider forwarding directly as map,
-			// as this is reverted back from string to map in later pipeline stages
-			recordAsBytes, _ := json.Marshal(record)
-			records = append(records, string(recordAsBytes))
+			records = append(records, record)
 			if len(records) >= ingestC.batchMaxLength {
 				log.Debugf("ingestCollector sending %d entries", len(records))
 				linesProcessed.Add(float64(len(records)))

--- a/pkg/pipeline/ingest/ingest_collector_test.go
+++ b/pkg/pipeline/ingest/ingest_collector_test.go
@@ -1,7 +1,6 @@
 package ingest
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -32,9 +31,9 @@ func TestIngest(t *testing.T) {
 
 	received := waitForFlows(t, client, forwarded)
 	require.NotEmpty(t, received)
-	require.IsType(t, "string", received[0])
 	flow := map[string]interface{}{}
-	require.NoError(t, json.Unmarshal([]byte(received[0].(string)), &flow))
+	require.IsType(t, flow, received[0])
+	flow = received[0].(map[string]interface{})
 	assert.EqualValues(t, 12345678, flow["TimeFlowStart"])
 	assert.EqualValues(t, 12345678, flow["TimeFlowEnd"])
 	assert.Equal(t, "1.2.3.4", flow["SrcAddr"])

--- a/pkg/pipeline/pipeline_builder.go
+++ b/pkg/pipeline/pipeline_builder.go
@@ -288,6 +288,8 @@ func getDecoder(params config.StageParam) (decode.Decoder, error) {
 	var decoder decode.Decoder
 	var err error
 	switch params.Decode.Type {
+	case api.CastType:
+		decoder, err = decode.NewDecodeCast()
 	case api.JSONType:
 		decoder, err = decode.NewDecodeJson()
 	case api.AWSType:


### PR DESCRIPTION
I had to create a "fake" stage `DecodeCast`, just to fix incompatible types `map[string]interface{}` and `GenericMap` (which are actually the same).
However I think we could do better by merging all Ingest and Decode stages (reach out on slack to discuss)