### PR TITLE
create custom flp image with custom metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,10 @@ run: build ## Run
 build-image:
 	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) build -t $(DOCKER_IMG):$(DOCKER_TAG) -f contrib/docker/Dockerfile .
 
+.PHONY: build-image-custom
+build-image-custom:
+	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) build -t $(DOCKER_IMG):$(DOCKER_TAG) -f contrib/docker/custom.Dockerfile .
+
 .PHONY: build-ci-images
 build-ci-images:
 ifeq ($(DOCKER_TAG), main)
@@ -243,6 +247,14 @@ endif
 generate-configuration: $(KIND) ## Generate metrics configuration
 	go build "${CMD_DIR}${CG_BIN_FILE}"
 	./${CG_BIN_FILE} --log-level debug --srcFolder network_definitions \
+					--destConfFile $(FLP_CONF_FILE) \
+					--destDocFile docs/metrics.md \
+					--destGrafanaJsonnetFolder contrib/dashboards/jsonnet/
+
+.PHONY: generate-configuration-custom
+generate-configuration-custom: $(KIND)
+	go build "${CMD_DIR}${CG_BIN_FILE}"
+	./${CG_BIN_FILE} --log-level debug --srcFolder network_definitions_custom \
 					--destConfFile $(FLP_CONF_FILE) \
 					--destDocFile docs/metrics.md \
 					--destGrafanaJsonnetFolder contrib/dashboards/jsonnet/

--- a/flowlogs-docker.sh
+++ b/flowlogs-docker.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "======> running confgenerator"
+/app/confgenerator --srcFolder /app/network_definitions_custom \
+                   --destConfFile /app/flowlogs-pipeline.conf.yaml
+echo "======> running flowlogs-pipeline"
+/app/flowlogs-pipeline --config /app/flowlogs-pipeline.conf.yaml

--- a/network_definitions_custom/bandwidth_per_network_service.yaml
+++ b/network_definitions_custom/bandwidth_per_network_service.yaml
@@ -1,0 +1,45 @@
+#flp_confgen
+description:
+  This metric observes the network bandwidth per network service
+details:
+  Sum bytes for all traffic per network service
+usage:
+  Evaluate network usage breakdown per network service
+labels:
+  - bandwidth
+  - graph
+  - rate
+  - network-service
+  - kubernetes
+transform:
+  rules:
+    - input: dstPort
+      output: service
+      type: add_service
+      parameters: proto
+extract:
+  aggregates:
+    - name: bandwidth_network_service
+      by:
+        - service
+      operation: sum
+      recordKey: bytes
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: bandwidth_per_network_service
+        type: counter
+        filter: {key: name, value: bandwidth_network_service}
+        valuekey: recent_op_value
+        labels:
+          - by
+          - aggregate
+visualization:
+  type: grafana
+  grafana:
+    - expr: 'topk(10,rate(flp_bandwidth_per_network_service[1m]))'
+      type: graphPanel
+      dashboard: details
+      title:
+        Bandwidth per network service

--- a/network_definitions_custom/bandwidth_per_network_service_per_namespace.yaml
+++ b/network_definitions_custom/bandwidth_per_network_service_per_namespace.yaml
@@ -1,0 +1,50 @@
+#flp_confgen
+description:
+  This metric observes the network bandwidth per network service per namespace
+details:
+  Sum bytes for all traffic per network service and namespace
+usage:
+  Evaluate network usage breakdown per network service and namespace
+labels:
+  - bandwidth
+  - graph
+  - rate
+  - network-service
+  - kubernetes
+transform:
+  rules:
+    - input: dstPort
+      output: service
+      type: add_service
+      parameters: proto
+    - input: srcIP
+      output: srcK8S
+      type: add_kubernetes
+      parameters: srcK8S_labels
+extract:
+  aggregates:
+    - name: bandwidth_network_service_namespace
+      by:
+        - service
+        - srcK8S_Namespace
+      operation: sum
+      recordKey: bytes
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: bandwidth_per_network_service_per_namespace
+        type: counter
+        filter: {key: name, value: bandwidth_network_service_namespace}
+        valuekey: recent_op_value
+        labels:
+          - by
+          - aggregate
+visualization:
+  type: grafana
+  grafana:
+    - expr: 'topk(10,rate(flp_bandwidth_per_network_service_per_namespace[1m]))'
+      type: graphPanel
+      dashboard: details
+      title:
+        Bandwidth per network service per namespace

--- a/network_definitions_custom/config.yaml
+++ b/network_definitions_custom/config.yaml
@@ -1,0 +1,55 @@
+## This is the main configuration file for flowlogs-pipeline. It holds
+## all parameters needed for the creation of the configuration
+##
+description:
+  general configuration for all metrics
+ingest:
+  collector:
+    port: 2055
+    portLegacy: 2056
+    hostName: 0.0.0.0
+transform:
+  generic:
+    rules:
+      - input: SrcAddr
+        output: srcIP
+      - input: SrcPort
+        output: srcPort
+      - input: DstAddr
+        output: dstIP
+      - input: DstPort
+        output: dstPort
+      - input: Proto
+        output: proto
+      - input: Bytes
+        output: bytes
+      - input: TCPFlags
+        output: TCPFlags
+      - input: SrcAS
+        output: srcAS
+      - input: DstAS
+        output: dstAS
+encode:
+  prom:
+    prefix: flp_
+    port: 9102
+write:
+  type: loki
+  loki:
+    url: http://loki.default.svc.cluster.local:3100
+    staticLabels:
+      job: flowlogs-pipeline
+visualization:
+  grafana:
+    dashboards:
+      - name: "totals"
+        title: "Flow-Logs to Metrics - Totals"
+        time_from: "now"
+        tags: "['flp','grafana','dashboard','total']"
+        schemaVersion: "16"
+      - name: "details"
+        title: "Flow-Logs to Metrics - Details"
+        time_from: "now-15m"
+        tags: "['flp','grafana','dashboard','details']"
+        schemaVersion: "16"
+

--- a/network_definitions_custom/network_services_count.yaml
+++ b/network_definitions_custom/network_services_count.yaml
@@ -1,0 +1,49 @@
+#flp_confgen
+description:
+  This metric observes network services rate (total)
+details:
+  Counts the number of connections per network service based on destination port number and protocol
+usage:
+  Evaluate network services
+labels:
+  - rate
+  - network-services
+  - destination-port
+  - destination-protocol
+transform:
+  rules:
+    - input: dstPort
+      output: service
+      type: add_service
+      parameters: proto
+extract:
+  type: aggregates
+  aggregates:
+    - name: dest_service_count
+      by:
+        - service
+      operation: count
+encode:
+  type: prom
+  prom:
+    metrics:
+      - name: service_count
+        type: counter
+        filter: { key: name, value: dest_service_count }
+        valuekey: recent_count
+        labels:
+          - by
+          - aggregate
+visualization:
+  type: grafana
+  grafana:
+    - expr: 'topk(10,rate(flp_service_count[1m]))'
+      type: graphPanel
+      dashboard: details
+      title:
+        Network services connections rate
+    - expr: 'count(flp_service_count)'
+      type: singleStat
+      dashboard: totals
+      title:
+        Number of network services


### PR DESCRIPTION
Perform the following operations:

make create-kind-cluster
make build-image-custom
make kind-load-image
make deploy
make deploy-prometheus
make deploy-netflow-simulator

The metrics defined in the directory `network_definitions_custom` will be run through the confgenerator and built into a container extracted from git.
The next step is to do this in the network-observability-operator repository and integrate it with the operator.