### PR TITLE
conntrack: Implement connection end records

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible
+	github.com/benbjohnson/clock v1.3.0
 	github.com/go-kit/kit v0.12.0
 	github.com/golang/snappy v0.0.4
 	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQ
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.35.5/go.mod h1:tlPOdRjfxPBpNIwqDj61rmsnA85v9jc0Ps9+muhnW+k=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/api/conn_track.go
+++ b/pkg/api/conn_track.go
@@ -17,15 +17,19 @@
 
 package api
 
+import "time"
+
 type ConnTrack struct {
 	// TODO: should by a pointer instead?
-	KeyDefinition     KeyDefinition `yaml:"keyDefinition" doc:"fields that are used to identify the connection"`
-	OutputRecordTypes []string      `yaml:"outputRecordTypes" enum:"ConnTrackOutputRecordTypeEnum" doc:"output record types to emit"`
-	OutputFields      []OutputField `yaml:"outputFields" doc:"list of output fields"`
+	KeyDefinition        KeyDefinition `yaml:"keyDefinition" doc:"fields that are used to identify the connection"`
+	OutputRecordTypes    []string      `yaml:"outputRecordTypes" enum:"ConnTrackOutputRecordTypeEnum" doc:"output record types to emit"`
+	OutputFields         []OutputField `yaml:"outputFields" doc:"list of output fields"`
+	EndConnectionTimeout time.Duration `yaml:"endConnectionTimeout" doc:"duration of time to wait from the last flow log to end a connection"`
 }
 
 type ConnTrackOutputRecordTypeEnum struct {
 	NewConnection string `yaml:"newConnection" doc:"New connection"`
+	EndConnection string `yaml:"endConnection" doc:"End connection"`
 	FlowLog       string `yaml:"flowLog" doc:"Flow log"`
 }
 

--- a/pkg/pipeline/conntrack/conn.go
+++ b/pkg/pipeline/conntrack/conn.go
@@ -30,17 +30,17 @@ type connection interface {
 	addAgg(fieldName string, initValue float64)
 	getAggValue(fieldName string) (float64, bool)
 	updateAggValue(fieldName string, newValueFn func(curr float64) float64)
-	setLastUpdateTime(t time.Time)
-	getLastUpdateTime() time.Time
+	setLastUpdate(t time.Time)
+	getLastUpdate() time.Time
 	toGenericMap() config.GenericMap
 	getHash() totalHashType
 }
 
 type connType struct {
-	hash           totalHashType
-	keys           config.GenericMap
-	aggFields      map[string]float64
-	lastUpdateTime time.Time
+	hash       totalHashType
+	keys       config.GenericMap
+	aggFields  map[string]float64
+	lastUpdate time.Time
 }
 
 func (c *connType) addAgg(fieldName string, initValue float64) {
@@ -60,12 +60,12 @@ func (c *connType) updateAggValue(fieldName string, newValueFn func(curr float64
 	c.aggFields[fieldName] = newValueFn(v)
 }
 
-func (c *connType) setLastUpdateTime(t time.Time) {
-	c.lastUpdateTime = t
+func (c *connType) setLastUpdate(t time.Time) {
+	c.lastUpdate = t
 }
 
-func (c *connType) getLastUpdateTime() time.Time {
-	return c.lastUpdateTime
+func (c *connType) getLastUpdate() time.Time {
+	return c.lastUpdate
 }
 
 func (c *connType) toGenericMap() config.GenericMap {

--- a/pkg/pipeline/conntrack/conn.go
+++ b/pkg/pipeline/conntrack/conn.go
@@ -18,6 +18,8 @@
 package conntrack
 
 import (
+	"time"
+
 	log "github.com/sirupsen/logrus"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
@@ -28,14 +30,17 @@ type connection interface {
 	addAgg(fieldName string, initValue float64)
 	getAggValue(fieldName string) (float64, bool)
 	updateAggValue(fieldName string, newValueFn func(curr float64) float64)
+	setLastUpdateTime(t time.Time)
+	getLastUpdateTime() time.Time
 	toGenericMap() config.GenericMap
 	getHash() totalHashType
 }
 
 type connType struct {
-	hash      totalHashType
-	keys      config.GenericMap
-	aggFields map[string]float64
+	hash           totalHashType
+	keys           config.GenericMap
+	aggFields      map[string]float64
+	lastUpdateTime time.Time
 }
 
 func (c *connType) addAgg(fieldName string, initValue float64) {
@@ -55,6 +60,14 @@ func (c *connType) updateAggValue(fieldName string, newValueFn func(curr float64
 	c.aggFields[fieldName] = newValueFn(v)
 }
 
+func (c *connType) setLastUpdateTime(t time.Time) {
+	c.lastUpdateTime = t
+}
+
+func (c *connType) getLastUpdateTime() time.Time {
+	return c.lastUpdateTime
+}
+
 func (c *connType) toGenericMap() config.GenericMap {
 	gm := config.GenericMap{}
 	for k, v := range c.aggFields {
@@ -64,6 +77,8 @@ func (c *connType) toGenericMap() config.GenericMap {
 	for k, v := range c.keys {
 		gm[k] = v
 	}
+	// TODO: Add hash field
+	// TODO: Should this method add recordTypeField?
 	return gm
 }
 

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -113,7 +113,7 @@ func newConnectionStore() *connectionStore {
 type conntrackImpl struct {
 	clock                     clock.Clock
 	config                    api.ConnTrack
-	hasher                    hash.Hash
+	hashProvider              func() hash.Hash32
 	connStore                 *connectionStore
 	aggregators               []aggregator
 	shouldOutputFlowLogs      bool
@@ -127,7 +127,7 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 
 	var outputRecords []config.GenericMap
 	for _, fl := range flowLogs {
-		computedHash, err := ComputeHash(fl, ct.config.KeyDefinition, ct.hasher)
+		computedHash, err := ComputeHash(fl, ct.config.KeyDefinition, ct.hashProvider())
 		if err != nil {
 			log.Warningf("skipping flow log %v: %v", fl, err)
 			continue
@@ -233,7 +233,7 @@ func NewConnectionTrack(config api.ConnTrack, clock clock.Clock) (ConnectionTrac
 		clock:                     clock,
 		connStore:                 newConnectionStore(),
 		config:                    config,
-		hasher:                    fnv.New32a(),
+		hashProvider:              fnv.New32a,
 		aggregators:               aggregators,
 		shouldOutputFlowLogs:      shouldOutputFlowLogs,
 		shouldOutputNewConnection: shouldOutputNewConnection,

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -82,7 +82,7 @@ func (ct *connectionStore) updateConnectionTime(hashStr string, t time.Time) {
 	if !ok {
 		log.Errorf("BUG. connection hash %v doesn't exist", hashStr)
 	}
-	elem.Value.(connection).setLastUpdateTime(t)
+	elem.Value.(connection).setLastUpdate(t)
 	// move to end of list
 	ct.connList.MoveToBack(elem)
 }
@@ -167,8 +167,8 @@ func (ct *conntrackImpl) popEndConnections() []config.GenericMap {
 	var outputRecords []config.GenericMap
 	ct.connStore.iterateOldToNew(func(conn connection) (shouldDelete, shouldStop bool) {
 		expireTime := ct.clock.Now().Add(-ct.config.EndConnectionTimeout)
-		lastUpdateTime := conn.getLastUpdateTime()
-		if lastUpdateTime.Before(expireTime) {
+		lastUpdate := conn.getLastUpdate()
+		if lastUpdate.Before(expireTime) {
 			// The last update time of this connection is too old. We want to pop it.
 			outputRecords = append(outputRecords, conn.toGenericMap())
 			shouldDelete, shouldStop = true, false

--- a/pkg/pipeline/conntrack/conntrack_test.go
+++ b/pkg/pipeline/conntrack/conntrack_test.go
@@ -19,7 +19,9 @@ package conntrack
 
 import (
 	"testing"
+	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/stretchr/testify/require"
@@ -70,7 +72,8 @@ func buildMockConnTrackConfig(isBidirectional bool, outputRecordType []string) *
 			{Name: "Packets", Operation: "sum", SplitAB: splitAB},
 			{Name: "numFlowLogs", Operation: "count", SplitAB: false},
 		},
-		OutputRecordTypes: outputRecordType,
+		OutputRecordTypes:    outputRecordType,
+		EndConnectionTimeout: 30 * time.Second,
 	}
 }
 
@@ -103,7 +106,6 @@ func newMockRecordConn(srcIP string, srcPort int, dstIP string, dstPort int, pro
 }
 
 func TestTrack(t *testing.T) {
-
 	ipA := "10.0.0.1"
 	ipB := "10.0.0.2"
 	portA := 9001
@@ -166,8 +168,185 @@ func TestTrack(t *testing.T) {
 
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
-			ct, err := NewConnectionTrack(*test.conf)
+			ct, err := NewConnectionTrack(*test.conf, clock.NewMock())
 			require.NoError(t, err)
+			actual := ct.Track(test.inputFlowLogs)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+// TestEndConn_Bidirectional tests that end connection records are outputted correctly and in the right time in
+// bidirectional setting.
+// The test simulates 2 flow logs from A to B and 2 from B to A in different timestamps.
+// Then the test verifies that an end connection record is outputted only after 30 seconds from the last flow log.
+func TestEndConn_Bidirectional(t *testing.T) {
+	clk := clock.NewMock()
+	conf := buildMockConnTrackConfig(true, []string{"newConnection", "flowLog", "endConnection"})
+	ct, err := NewConnectionTrack(*conf, clk)
+	require.NoError(t, err)
+
+	ipA := "10.0.0.1"
+	ipB := "10.0.0.2"
+	portA := 9001
+	portB := 9002
+	protocol := 6
+
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
+	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22)
+	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33)
+	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 444, 44)
+	startTime := clk.Now()
+	table := []struct {
+		name          string
+		time          time.Time
+		inputFlowLogs []config.GenericMap
+		expected      []config.GenericMap
+	}{
+		{
+			"start: flow AB",
+			startTime.Add(0 * time.Second),
+			[]config.GenericMap{flAB1},
+			[]config.GenericMap{
+				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1),
+				flAB1,
+			},
+		},
+		{
+			"10s: flow AB and BA",
+			startTime.Add(10 * time.Second),
+			[]config.GenericMap{flAB2, flBA3},
+			[]config.GenericMap{
+				flAB2,
+				flBA3,
+			},
+		},
+		{
+			"20s: flow BA",
+			startTime.Add(20 * time.Second),
+			[]config.GenericMap{flBA4},
+			[]config.GenericMap{
+				flBA4,
+			},
+		},
+		{
+			"49s: no end conn",
+			startTime.Add(49 * time.Second),
+			nil,
+			nil,
+		},
+		{
+			"51s: end conn BA",
+			startTime.Add(51 * time.Second),
+			nil,
+			[]config.GenericMap{
+				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 333, 777, 33, 77, 4),
+			},
+		},
+	}
+
+	for _, test := range table {
+		var prevTime time.Time
+		t.Run(test.name, func(t *testing.T) {
+			require.Less(t, prevTime, test.time)
+			prevTime = test.time
+			clk.Set(test.time)
+			actual := ct.Track(test.inputFlowLogs)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+// TestEndConn_Unidirectional tests that end connection records are outputted correctly and in the right time in
+// unidirectional setting.
+// The test simulates 2 flow logs from A to B and 2 from B to A in different timestamps.
+// Then the test verifies that an end connection record is outputted only after 30 seconds from the last flow log.
+func TestEndConn_Unidirectional(t *testing.T) {
+	clk := clock.NewMock()
+	conf := buildMockConnTrackConfig(false, []string{"newConnection", "flowLog", "endConnection"})
+	ct, err := NewConnectionTrack(*conf, clk)
+	require.NoError(t, err)
+
+	ipA := "10.0.0.1"
+	ipB := "10.0.0.2"
+	portA := 9001
+	portB := 9002
+	protocol := 6
+
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
+	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22)
+	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33)
+	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 444, 44)
+	startTime := clk.Now()
+	table := []struct {
+		name          string
+		time          time.Time
+		inputFlowLogs []config.GenericMap
+		expected      []config.GenericMap
+	}{
+		{
+			"start: flow AB",
+			startTime.Add(0 * time.Second),
+			[]config.GenericMap{flAB1},
+			[]config.GenericMap{
+				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1),
+				flAB1,
+			},
+		},
+		{
+			"10s: flow AB and BA",
+			startTime.Add(10 * time.Second),
+			[]config.GenericMap{flAB2, flBA3},
+			[]config.GenericMap{
+				flAB2,
+				newMockRecordConn(ipB, portB, ipA, portA, protocol, 333, 33, 1),
+				flBA3,
+			},
+		},
+		{
+			"20s: flow BA",
+			startTime.Add(20 * time.Second),
+			[]config.GenericMap{flBA4},
+			[]config.GenericMap{
+				flBA4,
+			},
+		},
+		{
+			"39s: no end conn",
+			startTime.Add(39 * time.Second),
+			nil,
+			nil,
+		},
+		{
+			"41s: end conn AB",
+			startTime.Add(41 * time.Second),
+			nil,
+			[]config.GenericMap{
+				newMockRecordConn(ipA, portA, ipB, portB, protocol, 333, 33, 2),
+			},
+		},
+		{
+			"49s: no end conn",
+			startTime.Add(49 * time.Second),
+			nil,
+			nil,
+		},
+		{
+			"51s: end conn BA",
+			startTime.Add(51 * time.Second),
+			nil,
+			[]config.GenericMap{
+				newMockRecordConn(ipB, portB, ipA, portA, protocol, 777, 77, 2),
+			},
+		},
+	}
+
+	for _, test := range table {
+		var prevTime time.Time
+		t.Run(test.name, func(t *testing.T) {
+			require.Less(t, prevTime, test.time)
+			prevTime = test.time
+			clk.Set(test.time)
 			actual := ct.Track(test.inputFlowLogs)
 			require.Equal(t, test.expected, actual)
 		})

--- a/pkg/pipeline/conntrack/hash.go
+++ b/pkg/pipeline/conntrack/hash.go
@@ -37,6 +37,18 @@ type totalHashType struct {
 	hashTotal hashType
 }
 
+func areHashEqual(h1, h2 hashType) bool {
+	if len(h1) != len(h2) {
+		return false
+	}
+	for i := range h1 {
+		if h1[i] != h2[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func copyTotalHash(h totalHashType) totalHashType {
 	newHashA := make([]byte, len(h.hashA))
 	newHashB := make([]byte, len(h.hashB))


### PR DESCRIPTION
- Add a connection store that stores the connections sorted by last update time
- Add a dependency on github.com/benbjohnson/clock to allow mocking time

Notes for reviewer:
- Please start reviewing from the added tests
- Does `connectionStore` deserve a file of its own?