### PR TITLE
NETOBSERV-334 concurrent map iteration & write fix

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,8 +24,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type GenericMap map[string]interface{}
-
 var (
 	Opt        = Options{}
 	PipeLine   []Stage
@@ -117,15 +115,4 @@ func ParseConfig() error {
 	}
 	logrus.Debugf("params = %v ", Parameters)
 	return nil
-}
-
-// Copy will create a flat copy of GenericMap
-func (m GenericMap) Copy() map[string]interface{} {
-	result := map[string]interface{}{}
-
-	for k, v := range m {
-		result[k] = v
-	}
-
-	return result
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -118,3 +118,14 @@ func ParseConfig() error {
 	logrus.Debugf("params = %v ", Parameters)
 	return nil
 }
+
+// Copy will create a flat copy of GenericMap
+func (m GenericMap) Copy() map[string]interface{} {
+	result := map[string]interface{}{}
+
+	for k, v := range m {
+		result[k] = v
+	}
+
+	return result
+}

--- a/pkg/config/generic_map.go
+++ b/pkg/config/generic_map.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package config
+
+type GenericMap map[string]interface{}
+
+// Copy will create a flat copy of GenericMap
+func (m GenericMap) Copy() GenericMap {
+	result := GenericMap{}
+
+	for k, v := range m {
+		result[k] = v
+	}
+
+	return result
+}

--- a/pkg/pipeline/write/write_loki.go
+++ b/pkg/pipeline/write/write_loki.go
@@ -231,7 +231,8 @@ func (l *Loki) processRecords() {
 			log.Debugf("exiting writeLoki because of signal")
 			return
 		case record := <-l.in:
-			err := l.ProcessRecord(record)
+			// copy record before process to avoid alteration on parallel stages
+			err := l.ProcessRecord(record.Copy())
 			if err != nil {
 				log.Errorf("Write (Loki) error %v", err)
 			}


### PR DESCRIPTION
This fix `fatal error: concurrent map iteration and map write` when calling `stdout` and `loki` stages in parallel