### PR TITLE
Refactor hashType: []byte -> uint64

### DIFF
--- a/pkg/pipeline/conntrack/aggregator.go
+++ b/pkg/pipeline/conntrack/aggregator.go
@@ -122,7 +122,7 @@ func (agg *aSum) update(conn connection, flowLog config.GenericMap, d direction)
 	outputField := agg.getOutputField(d)
 	v, err := agg.getInputFieldValue(flowLog)
 	if err != nil {
-		log.Errorf("error updating connection %v: %v", string(conn.getHash().hashTotal), err)
+		log.Errorf("error updating connection %x: %v", conn.getHash().hashTotal, err)
 		return
 	}
 	conn.updateAggValue(outputField, func(curr float64) float64 {
@@ -141,7 +141,7 @@ func (agg *aMin) update(conn connection, flowLog config.GenericMap, d direction)
 	outputField := agg.getOutputField(d)
 	v, err := agg.getInputFieldValue(flowLog)
 	if err != nil {
-		log.Errorf("error updating connection %v: %v", string(conn.getHash().hashTotal), err)
+		log.Errorf("error updating connection %x: %v", conn.getHash().hashTotal, err)
 		return
 	}
 
@@ -154,7 +154,7 @@ func (agg *aMax) update(conn connection, flowLog config.GenericMap, d direction)
 	outputField := agg.getOutputField(d)
 	v, err := agg.getInputFieldValue(flowLog)
 	if err != nil {
-		log.Errorf("error updating connection %v: %v", string(conn.getHash().hashTotal), err)
+		log.Errorf("error updating connection %x: %v", conn.getHash().hashTotal, err)
 		return
 	}
 

--- a/pkg/pipeline/conntrack/conn.go
+++ b/pkg/pipeline/conntrack/conn.go
@@ -83,7 +83,7 @@ func (c *connType) toGenericMap() config.GenericMap {
 }
 
 func (c *connType) getHash() totalHashType {
-	return copyTotalHash(c.hash)
+	return c.hash
 }
 
 // TODO: Should connBuilder get a file of its own?
@@ -100,8 +100,8 @@ func NewConnBuilder() *connBuilder {
 	}
 }
 
-func (cb *connBuilder) Hash(h *totalHashType) *connBuilder {
-	cb.conn.hash = copyTotalHash(*h)
+func (cb *connBuilder) Hash(h totalHashType) *connBuilder {
+	cb.conn.hash = h
 	return cb
 }
 

--- a/pkg/pipeline/conntrack/hash.go
+++ b/pkg/pipeline/conntrack/hash.go
@@ -19,6 +19,7 @@ package conntrack
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/gob"
 	"fmt"
 	"hash"
@@ -28,78 +29,50 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-type hashType []byte
-
 // TODO: what's a better name for this struct?
 type totalHashType struct {
-	hashA     hashType
-	hashB     hashType
-	hashTotal hashType
-}
-
-func areHashEqual(h1, h2 hashType) bool {
-	if len(h1) != len(h2) {
-		return false
-	}
-	for i := range h1 {
-		if h1[i] != h2[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func copyTotalHash(h totalHashType) totalHashType {
-	newHashA := make([]byte, len(h.hashA))
-	newHashB := make([]byte, len(h.hashB))
-	newHashTotal := make([]byte, len(h.hashTotal))
-	copy(newHashA, h.hashA)
-	copy(newHashB, h.hashB)
-	copy(newHashTotal, h.hashTotal)
-	return totalHashType{
-		hashA:     newHashA,
-		hashB:     newHashB,
-		hashTotal: newHashTotal,
-	}
+	hashA     uint64
+	hashB     uint64
+	hashTotal uint64
 }
 
 // ComputeHash computes the hash of a flow log according to keyDefinition.
 // Two flow logs will have the same hash if they belong to the same connection.
-func ComputeHash(flowLog config.GenericMap, keyDefinition api.KeyDefinition, hasher hash.Hash) (*totalHashType, error) {
-	fieldGroup2hash := make(map[string]hashType)
+func ComputeHash(flowLog config.GenericMap, keyDefinition api.KeyDefinition, hasher hash.Hash64) (totalHashType, error) {
+	fieldGroup2hash := make(map[string]uint64)
 
 	// Compute the hash of each field group
 	for _, fg := range keyDefinition.FieldGroups {
 		h, err := computeHashFields(flowLog, fg.Fields, hasher)
 		if err != nil {
-			return nil, fmt.Errorf("compute hash: %w", err)
+			return totalHashType{}, fmt.Errorf("compute hash: %w", err)
 		}
 		fieldGroup2hash[fg.Name] = h
 	}
 
 	// Compute the total hash
-	th := &totalHashType{}
+	th := totalHashType{}
 	hasher.Reset()
 	for _, fgName := range keyDefinition.Hash.FieldGroupRefs {
-		hasher.Write(fieldGroup2hash[fgName])
+		hasher.Write(uint64ToBytes(fieldGroup2hash[fgName]))
 	}
 	if keyDefinition.Hash.FieldGroupARef != "" {
 		th.hashA = fieldGroup2hash[keyDefinition.Hash.FieldGroupARef]
 		th.hashB = fieldGroup2hash[keyDefinition.Hash.FieldGroupBRef]
 		// Determine order between A's and B's hash to get the same hash for both flow logs from A to B and from B to A.
-		if bytes.Compare(th.hashA, th.hashB) < 0 {
-			hasher.Write(th.hashA)
-			hasher.Write(th.hashB)
+		if th.hashA < th.hashB {
+			hasher.Write(uint64ToBytes(th.hashA))
+			hasher.Write(uint64ToBytes(th.hashB))
 		} else {
-			hasher.Write(th.hashB)
-			hasher.Write(th.hashA)
+			hasher.Write(uint64ToBytes(th.hashB))
+			hasher.Write(uint64ToBytes(th.hashA))
 		}
 	}
-	th.hashTotal = hasher.Sum([]byte{})
+	th.hashTotal = hasher.Sum64()
 	return th, nil
 }
 
-func computeHashFields(flowLog config.GenericMap, fieldNames []string, hasher hash.Hash) (hashType, error) {
+func computeHashFields(flowLog config.GenericMap, fieldNames []string, hasher hash.Hash64) (uint64, error) {
 	hasher.Reset()
 	for _, fn := range fieldNames {
 		f, ok := flowLog[fn]
@@ -109,11 +82,17 @@ func computeHashFields(flowLog config.GenericMap, fieldNames []string, hasher ha
 		}
 		bytes, err := toBytes(f)
 		if err != nil {
-			return nil, err
+			return 0, err
 		}
 		hasher.Write(bytes)
 	}
-	return hasher.Sum([]byte{}), nil
+	return hasher.Sum64(), nil
+}
+
+func uint64ToBytes(data uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, data)
+	return b
 }
 
 func toBytes(data interface{}) ([]byte, error) {

--- a/pkg/pipeline/conntrack/hash_test.go
+++ b/pkg/pipeline/conntrack/hash_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var testHasher = fnv.New32a()
+var testHasher = fnv.New64a()
 
 func TestComputeHash_Unidirectional(t *testing.T) {
 	keyDefinition := api.KeyDefinition{


### PR DESCRIPTION
This PR changes the type under the hood of the hash from `[]byte` to `uint64`.

`uint64` simplifies the code since its easier to copy than `[]byte` and can serve as a key in a map (in contrast to `[]byte`)

This PR is a follow up on the 2nd point from this review: https://github.com/netobserv/flowlogs-pipeline/pull/220#discussion_r893270514

I also changed the hash to use 64 bits instead of 32 bits to reduce the chance of collisions (different connections with the same hash).
Assuming a perfect hash function with uniform distribution of the has values,
 for 32 bits we need only 9,300 connections to have 1% chance for collision.
But, for 64 bits we need ~61,000,000 connections to have 1% chance for collision.
I based this on the table from [Birthday attack](https://en.wikipedia.org/wiki/Birthday_attack). @kalman Am I correct with my analysis?