### PR TITLE
Conntrack: Add RecordType and HashId fields

### DIFF
--- a/pkg/api/conn_track.go
+++ b/pkg/api/conn_track.go
@@ -19,6 +19,8 @@ package api
 
 import "time"
 
+const HashIdFieldName = "HashId"
+
 type ConnTrack struct {
 	// TODO: should by a pointer instead?
 	KeyDefinition        KeyDefinition `yaml:"keyDefinition" doc:"fields that are used to identify the connection"`

--- a/pkg/api/conn_track.go
+++ b/pkg/api/conn_track.go
@@ -19,7 +19,10 @@ package api
 
 import "time"
 
-const HashIdFieldName = "HashId"
+const (
+	HashIdFieldName     = "HashId"
+	RecordTypeFieldName = "RecordType"
+)
 
 type ConnTrack struct {
 	// TODO: should by a pointer instead?

--- a/pkg/api/conn_track.go
+++ b/pkg/api/conn_track.go
@@ -20,8 +20,8 @@ package api
 import "time"
 
 const (
-	HashIdFieldName     = "HashId"
-	RecordTypeFieldName = "RecordType"
+	HashIdFieldName     = "NetObs-HashId"
+	RecordTypeFieldName = "NetObs-RecordType"
 )
 
 type ConnTrack struct {

--- a/pkg/api/conn_track.go
+++ b/pkg/api/conn_track.go
@@ -20,8 +20,8 @@ package api
 import "time"
 
 const (
-	HashIdFieldName     = "NetObs-HashId"
-	RecordTypeFieldName = "NetObs-RecordType"
+	HashIdFieldName     = "_HashId"
+	RecordTypeFieldName = "_RecordType"
 )
 
 type ConnTrack struct {

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -144,6 +144,7 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 			if ct.shouldOutputNewConnection {
 				record := conn.toGenericMap()
 				addHashField(record, computedHash.hashTotal)
+				addTypeField(record, api.ConnTrackOutputRecordTypeName("NewConnection"))
 				outputRecords = append(outputRecords, record)
 			}
 		} else {
@@ -153,6 +154,7 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 		if ct.shouldOutputFlowLogs {
 			record := fl.Copy()
 			addHashField(record, computedHash.hashTotal)
+			addTypeField(record, api.ConnTrackOutputRecordTypeName("FlowLog"))
 			outputRecords = append(outputRecords, record)
 		}
 	}
@@ -174,6 +176,7 @@ func (ct *conntrackImpl) popEndConnections() []config.GenericMap {
 			// The last update time of this connection is too old. We want to pop it.
 			record := conn.toGenericMap()
 			addHashField(record, conn.getHash().hashTotal)
+			addTypeField(record, api.ConnTrackOutputRecordTypeName("EndConnection"))
 			outputRecords = append(outputRecords, record)
 			shouldDelete, shouldStop = true, false
 		} else {
@@ -248,4 +251,8 @@ func NewConnectionTrack(config api.ConnTrack, clock clock.Clock) (ConnectionTrac
 
 func addHashField(record config.GenericMap, hashId uint64) {
 	record[api.HashIdFieldName] = strconv.FormatUint(hashId, 16)
+}
+
+func addTypeField(record config.GenericMap, recordType string) {
+	record[api.RecordTypeFieldName] = recordType
 }

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"hash"
 	"hash/fnv"
+	"strconv"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -141,14 +142,18 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 			ct.connStore.addConnection(computedHash.hashTotal, conn)
 			ct.updateConnection(conn, fl, computedHash)
 			if ct.shouldOutputNewConnection {
-				outputRecords = append(outputRecords, conn.toGenericMap())
+				record := conn.toGenericMap()
+				addHashField(record, computedHash.hashTotal)
+				outputRecords = append(outputRecords, record)
 			}
 		} else {
 			ct.updateConnection(conn, fl, computedHash)
 		}
 
 		if ct.shouldOutputFlowLogs {
-			outputRecords = append(outputRecords, fl)
+			record := fl.Copy()
+			addHashField(record, computedHash.hashTotal)
+			outputRecords = append(outputRecords, record)
 		}
 	}
 
@@ -167,7 +172,9 @@ func (ct *conntrackImpl) popEndConnections() []config.GenericMap {
 		lastUpdate := conn.getLastUpdate()
 		if lastUpdate.Before(expireTime) {
 			// The last update time of this connection is too old. We want to pop it.
-			outputRecords = append(outputRecords, conn.toGenericMap())
+			record := conn.toGenericMap()
+			addHashField(record, conn.getHash().hashTotal)
+			outputRecords = append(outputRecords, record)
 			shouldDelete, shouldStop = true, false
 		} else {
 			// No more expired connections
@@ -237,4 +244,8 @@ func NewConnectionTrack(config api.ConnTrack, clock clock.Clock) (ConnectionTrac
 		shouldOutputEndConnection: shouldOutputEndConnection,
 	}
 	return conntrack, nil
+}
+
+func addHashField(record config.GenericMap, hashId uint64) {
+	record[api.HashIdFieldName] = strconv.FormatUint(hashId, 16)
 }

--- a/pkg/pipeline/conntrack/conntrack_test.go
+++ b/pkg/pipeline/conntrack/conntrack_test.go
@@ -102,7 +102,7 @@ func TestTrack(t *testing.T) {
 			buildMockConnTrackConfig(true, []string{"newConnection"}),
 			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
-				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1).withHash(hashId).get(),
+				newMockRecordNewConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1).withHash(hashId).get(),
 			},
 		},
 		{
@@ -110,7 +110,7 @@ func TestTrack(t *testing.T) {
 			buildMockConnTrackConfig(true, []string{"newConnection", "flowLog"}),
 			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
-				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1).withHash(hashId).get(),
+				newMockRecordNewConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1).withHash(hashId).get(),
 				newMockRecordFromFlowLog(flAB1).withHash(hashId).get(),
 				newMockRecordFromFlowLog(flAB2).withHash(hashId).get(),
 				newMockRecordFromFlowLog(flBA3).withHash(hashId).get(),
@@ -122,8 +122,8 @@ func TestTrack(t *testing.T) {
 			buildMockConnTrackConfig(false, []string{"newConnection"}),
 			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
-				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1).withHash(hashIdAB).get(),
-				newMockRecordConn(ipB, portB, ipA, portA, protocol, 333, 33, 1).withHash(hashIdBA).get(),
+				newMockRecordNewConn(ipA, portA, ipB, portB, protocol, 111, 11, 1).withHash(hashIdAB).get(),
+				newMockRecordNewConn(ipB, portB, ipA, portA, protocol, 333, 33, 1).withHash(hashIdBA).get(),
 			},
 		},
 		{
@@ -131,10 +131,10 @@ func TestTrack(t *testing.T) {
 			buildMockConnTrackConfig(false, []string{"newConnection", "flowLog"}),
 			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
-				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1).withHash(hashIdAB).get(),
+				newMockRecordNewConn(ipA, portA, ipB, portB, protocol, 111, 11, 1).withHash(hashIdAB).get(),
 				newMockRecordFromFlowLog(flAB1).withHash(hashIdAB).get(),
 				newMockRecordFromFlowLog(flAB2).withHash(hashIdAB).get(),
-				newMockRecordConn(ipB, portB, ipA, portA, protocol, 333, 33, 1).withHash(hashIdBA).get(),
+				newMockRecordNewConn(ipB, portB, ipA, portA, protocol, 333, 33, 1).withHash(hashIdBA).get(),
 				newMockRecordFromFlowLog(flBA3).withHash(hashIdBA).get(),
 				newMockRecordFromFlowLog(flBA4).withHash(hashIdBA).get(),
 			},
@@ -184,7 +184,7 @@ func TestEndConn_Bidirectional(t *testing.T) {
 			startTime.Add(0 * time.Second),
 			[]config.GenericMap{flAB1},
 			[]config.GenericMap{
-				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1).withHash(hashId).get(),
+				newMockRecordNewConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1).withHash(hashId).get(),
 				newMockRecordFromFlowLog(flAB1).withHash(hashId).get(),
 			},
 		},
@@ -216,7 +216,7 @@ func TestEndConn_Bidirectional(t *testing.T) {
 			startTime.Add(51 * time.Second),
 			nil,
 			[]config.GenericMap{
-				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 333, 777, 33, 77, 4).withHash(hashId).get(),
+				newMockRecordEndConnAB(ipA, portA, ipB, portB, protocol, 333, 777, 33, 77, 4).withHash(hashId).get(),
 			},
 		},
 	}
@@ -267,7 +267,7 @@ func TestEndConn_Unidirectional(t *testing.T) {
 			startTime.Add(0 * time.Second),
 			[]config.GenericMap{flAB1},
 			[]config.GenericMap{
-				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1).withHash(hashIdAB).get(),
+				newMockRecordNewConn(ipA, portA, ipB, portB, protocol, 111, 11, 1).withHash(hashIdAB).get(),
 				newMockRecordFromFlowLog(flAB1).withHash(hashIdAB).get(),
 			},
 		},
@@ -277,7 +277,7 @@ func TestEndConn_Unidirectional(t *testing.T) {
 			[]config.GenericMap{flAB2, flBA3},
 			[]config.GenericMap{
 				newMockRecordFromFlowLog(flAB2).withHash(hashIdAB).get(),
-				newMockRecordConn(ipB, portB, ipA, portA, protocol, 333, 33, 1).withHash(hashIdBA).get(),
+				newMockRecordNewConn(ipB, portB, ipA, portA, protocol, 333, 33, 1).withHash(hashIdBA).get(),
 				newMockRecordFromFlowLog(flBA3).withHash(hashIdBA).get(),
 			},
 		},
@@ -300,7 +300,7 @@ func TestEndConn_Unidirectional(t *testing.T) {
 			startTime.Add(41 * time.Second),
 			nil,
 			[]config.GenericMap{
-				newMockRecordConn(ipA, portA, ipB, portB, protocol, 333, 33, 2).withHash(hashIdAB).get(),
+				newMockRecordEndConn(ipA, portA, ipB, portB, protocol, 333, 33, 2).withHash(hashIdAB).get(),
 			},
 		},
 		{
@@ -314,7 +314,7 @@ func TestEndConn_Unidirectional(t *testing.T) {
 			startTime.Add(51 * time.Second),
 			nil,
 			[]config.GenericMap{
-				newMockRecordConn(ipB, portB, ipA, portA, protocol, 777, 77, 2).withHash(hashIdBA).get(),
+				newMockRecordEndConn(ipB, portB, ipA, portA, protocol, 777, 77, 2).withHash(hashIdBA).get(),
 			},
 		},
 	}

--- a/pkg/pipeline/conntrack/conntrack_test.go
+++ b/pkg/pipeline/conntrack/conntrack_test.go
@@ -77,40 +77,15 @@ func buildMockConnTrackConfig(isBidirectional bool, outputRecordType []string) *
 	}
 }
 
-func newMockRecordConnAB(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytesAB, bytesBA, packetsAB, packetsBA, numFlowLogs float64) config.GenericMap {
-	return config.GenericMap{
-		"SrcAddr":     srcIP,
-		"SrcPort":     srcPort,
-		"DstAddr":     dstIP,
-		"DstPort":     dstPort,
-		"Proto":       protocol,
-		"Bytes_AB":    bytesAB,
-		"Bytes_BA":    bytesBA,
-		"Packets_AB":  packetsAB,
-		"Packets_BA":  packetsBA,
-		"numFlowLogs": numFlowLogs,
-	}
-}
-
-func newMockRecordConn(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets, numFlowLogs float64) config.GenericMap {
-	return config.GenericMap{
-		"SrcAddr":     srcIP,
-		"SrcPort":     srcPort,
-		"DstAddr":     dstIP,
-		"DstPort":     dstPort,
-		"Proto":       protocol,
-		"Bytes":       bytes,
-		"Packets":     packets,
-		"numFlowLogs": numFlowLogs,
-	}
-}
-
 func TestTrack(t *testing.T) {
 	ipA := "10.0.0.1"
 	ipB := "10.0.0.2"
 	portA := 9001
 	portB := 9002
 	protocol := 6
+	hashId := "705baa5149302fa1"
+	hashIdAB := "705baa5149302fa1"
+	hashIdBA := "cc40f571f40f3111"
 
 	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
 	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22)
@@ -127,7 +102,7 @@ func TestTrack(t *testing.T) {
 			buildMockConnTrackConfig(true, []string{"newConnection"}),
 			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
-				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1),
+				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1).withHash(hashId).get(),
 			},
 		},
 		{
@@ -135,11 +110,11 @@ func TestTrack(t *testing.T) {
 			buildMockConnTrackConfig(true, []string{"newConnection", "flowLog"}),
 			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
-				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1),
-				flAB1,
-				flAB2,
-				flBA3,
-				flBA4,
+				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1).withHash(hashId).get(),
+				newMockRecordFromFlowLog(flAB1).withHash(hashId).get(),
+				newMockRecordFromFlowLog(flAB2).withHash(hashId).get(),
+				newMockRecordFromFlowLog(flBA3).withHash(hashId).get(),
+				newMockRecordFromFlowLog(flBA4).withHash(hashId).get(),
 			},
 		},
 		{
@@ -147,8 +122,8 @@ func TestTrack(t *testing.T) {
 			buildMockConnTrackConfig(false, []string{"newConnection"}),
 			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
-				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1),
-				newMockRecordConn(ipB, portB, ipA, portA, protocol, 333, 33, 1),
+				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1).withHash(hashIdAB).get(),
+				newMockRecordConn(ipB, portB, ipA, portA, protocol, 333, 33, 1).withHash(hashIdBA).get(),
 			},
 		},
 		{
@@ -156,12 +131,12 @@ func TestTrack(t *testing.T) {
 			buildMockConnTrackConfig(false, []string{"newConnection", "flowLog"}),
 			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
-				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1),
-				flAB1,
-				flAB2,
-				newMockRecordConn(ipB, portB, ipA, portA, protocol, 333, 33, 1),
-				flBA3,
-				flBA4,
+				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1).withHash(hashIdAB).get(),
+				newMockRecordFromFlowLog(flAB1).withHash(hashIdAB).get(),
+				newMockRecordFromFlowLog(flAB2).withHash(hashIdAB).get(),
+				newMockRecordConn(ipB, portB, ipA, portA, protocol, 333, 33, 1).withHash(hashIdBA).get(),
+				newMockRecordFromFlowLog(flBA3).withHash(hashIdBA).get(),
+				newMockRecordFromFlowLog(flBA4).withHash(hashIdBA).get(),
 			},
 		},
 	}
@@ -191,6 +166,7 @@ func TestEndConn_Bidirectional(t *testing.T) {
 	portA := 9001
 	portB := 9002
 	protocol := 6
+	hashId := "705baa5149302fa1"
 
 	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
 	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22)
@@ -208,8 +184,8 @@ func TestEndConn_Bidirectional(t *testing.T) {
 			startTime.Add(0 * time.Second),
 			[]config.GenericMap{flAB1},
 			[]config.GenericMap{
-				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1),
-				flAB1,
+				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1).withHash(hashId).get(),
+				newMockRecordFromFlowLog(flAB1).withHash(hashId).get(),
 			},
 		},
 		{
@@ -217,8 +193,8 @@ func TestEndConn_Bidirectional(t *testing.T) {
 			startTime.Add(10 * time.Second),
 			[]config.GenericMap{flAB2, flBA3},
 			[]config.GenericMap{
-				flAB2,
-				flBA3,
+				newMockRecordFromFlowLog(flAB2).withHash(hashId).get(),
+				newMockRecordFromFlowLog(flBA3).withHash(hashId).get(),
 			},
 		},
 		{
@@ -226,7 +202,7 @@ func TestEndConn_Bidirectional(t *testing.T) {
 			startTime.Add(20 * time.Second),
 			[]config.GenericMap{flBA4},
 			[]config.GenericMap{
-				flBA4,
+				newMockRecordFromFlowLog(flBA4).withHash(hashId).get(),
 			},
 		},
 		{
@@ -240,7 +216,7 @@ func TestEndConn_Bidirectional(t *testing.T) {
 			startTime.Add(51 * time.Second),
 			nil,
 			[]config.GenericMap{
-				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 333, 777, 33, 77, 4),
+				newMockRecordConnAB(ipA, portA, ipB, portB, protocol, 333, 777, 33, 77, 4).withHash(hashId).get(),
 			},
 		},
 	}
@@ -272,6 +248,8 @@ func TestEndConn_Unidirectional(t *testing.T) {
 	portA := 9001
 	portB := 9002
 	protocol := 6
+	hashIdAB := "705baa5149302fa1"
+	hashIdBA := "cc40f571f40f3111"
 
 	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
 	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22)
@@ -289,8 +267,8 @@ func TestEndConn_Unidirectional(t *testing.T) {
 			startTime.Add(0 * time.Second),
 			[]config.GenericMap{flAB1},
 			[]config.GenericMap{
-				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1),
-				flAB1,
+				newMockRecordConn(ipA, portA, ipB, portB, protocol, 111, 11, 1).withHash(hashIdAB).get(),
+				newMockRecordFromFlowLog(flAB1).withHash(hashIdAB).get(),
 			},
 		},
 		{
@@ -298,9 +276,9 @@ func TestEndConn_Unidirectional(t *testing.T) {
 			startTime.Add(10 * time.Second),
 			[]config.GenericMap{flAB2, flBA3},
 			[]config.GenericMap{
-				flAB2,
-				newMockRecordConn(ipB, portB, ipA, portA, protocol, 333, 33, 1),
-				flBA3,
+				newMockRecordFromFlowLog(flAB2).withHash(hashIdAB).get(),
+				newMockRecordConn(ipB, portB, ipA, portA, protocol, 333, 33, 1).withHash(hashIdBA).get(),
+				newMockRecordFromFlowLog(flBA3).withHash(hashIdBA).get(),
 			},
 		},
 		{
@@ -308,7 +286,7 @@ func TestEndConn_Unidirectional(t *testing.T) {
 			startTime.Add(20 * time.Second),
 			[]config.GenericMap{flBA4},
 			[]config.GenericMap{
-				flBA4,
+				newMockRecordFromFlowLog(flBA4).withHash(hashIdBA).get(),
 			},
 		},
 		{
@@ -322,7 +300,7 @@ func TestEndConn_Unidirectional(t *testing.T) {
 			startTime.Add(41 * time.Second),
 			nil,
 			[]config.GenericMap{
-				newMockRecordConn(ipA, portA, ipB, portB, protocol, 333, 33, 2),
+				newMockRecordConn(ipA, portA, ipB, portB, protocol, 333, 33, 2).withHash(hashIdAB).get(),
 			},
 		},
 		{
@@ -336,7 +314,7 @@ func TestEndConn_Unidirectional(t *testing.T) {
 			startTime.Add(51 * time.Second),
 			nil,
 			[]config.GenericMap{
-				newMockRecordConn(ipB, portB, ipA, portA, protocol, 777, 77, 2),
+				newMockRecordConn(ipB, portB, ipA, portA, protocol, 777, 77, 2).withHash(hashIdBA).get(),
 			},
 		},
 	}

--- a/pkg/pipeline/conntrack/utils_test.go
+++ b/pkg/pipeline/conntrack/utils_test.go
@@ -1,6 +1,9 @@
 package conntrack
 
-import "github.com/netobserv/flowlogs-pipeline/pkg/config"
+import (
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+)
 
 func newMockFlowLog(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets int) config.GenericMap {
 	return config.GenericMap{
@@ -12,4 +15,61 @@ func newMockFlowLog(srcIP string, srcPort int, dstIP string, dstPort int, protoc
 		"Bytes":   bytes,
 		"Packets": packets,
 	}
+}
+
+type mockRecord struct {
+	record config.GenericMap
+}
+
+func newMockRecordFromFlowLog(fl config.GenericMap) *mockRecord {
+	mock := &mockRecord{
+		record: config.GenericMap{},
+	}
+	for k, v := range fl {
+		mock.record[k] = v
+	}
+	return mock
+}
+
+func newMockRecordConnAB(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytesAB, bytesBA, packetsAB, packetsBA, numFlowLogs float64) *mockRecord {
+	mock := &mockRecord{
+		record: config.GenericMap{
+			"SrcAddr":     srcIP,
+			"SrcPort":     srcPort,
+			"DstAddr":     dstIP,
+			"DstPort":     dstPort,
+			"Proto":       protocol,
+			"Bytes_AB":    bytesAB,
+			"Bytes_BA":    bytesBA,
+			"Packets_AB":  packetsAB,
+			"Packets_BA":  packetsBA,
+			"numFlowLogs": numFlowLogs,
+		},
+	}
+	return mock
+}
+
+func newMockRecordConn(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets, numFlowLogs float64) *mockRecord {
+	mock := &mockRecord{
+		record: config.GenericMap{
+			"SrcAddr":     srcIP,
+			"SrcPort":     srcPort,
+			"DstAddr":     dstIP,
+			"DstPort":     dstPort,
+			"Proto":       protocol,
+			"Bytes":       bytes,
+			"Packets":     packets,
+			"numFlowLogs": numFlowLogs,
+		},
+	}
+	return mock
+}
+
+func (m *mockRecord) withHash(hashStr string) *mockRecord {
+	m.record[api.HashIdFieldName] = hashStr
+	return m
+}
+
+func (m *mockRecord) get() config.GenericMap {
+	return m.record
 }

--- a/pkg/pipeline/conntrack/utils_test.go
+++ b/pkg/pipeline/conntrack/utils_test.go
@@ -28,6 +28,7 @@ func newMockRecordFromFlowLog(fl config.GenericMap) *mockRecord {
 	for k, v := range fl {
 		mock.record[k] = v
 	}
+	mock.withType("flowLog")
 	return mock
 }
 
@@ -49,6 +50,18 @@ func newMockRecordConnAB(srcIP string, srcPort int, dstIP string, dstPort int, p
 	return mock
 }
 
+func newMockRecordNewConnAB(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytesAB, bytesBA, packetsAB, packetsBA, numFlowLogs float64) *mockRecord {
+	return newMockRecordConnAB(srcIP, srcPort, dstIP, dstPort, protocol, bytesAB, bytesBA, packetsAB, packetsBA, numFlowLogs).
+		withType("newConnection")
+
+}
+
+func newMockRecordEndConnAB(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytesAB, bytesBA, packetsAB, packetsBA, numFlowLogs float64) *mockRecord {
+	return newMockRecordConnAB(srcIP, srcPort, dstIP, dstPort, protocol, bytesAB, bytesBA, packetsAB, packetsBA, numFlowLogs).
+		withType("endConnection")
+
+}
+
 func newMockRecordConn(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets, numFlowLogs float64) *mockRecord {
 	mock := &mockRecord{
 		record: config.GenericMap{
@@ -65,8 +78,23 @@ func newMockRecordConn(srcIP string, srcPort int, dstIP string, dstPort int, pro
 	return mock
 }
 
+func newMockRecordNewConn(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets, numFlowLogs float64) *mockRecord {
+	return newMockRecordConn(srcIP, srcPort, dstIP, dstPort, protocol, bytes, packets, numFlowLogs).
+		withType("newConnection")
+}
+
+func newMockRecordEndConn(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets, numFlowLogs float64) *mockRecord {
+	return newMockRecordConn(srcIP, srcPort, dstIP, dstPort, protocol, bytes, packets, numFlowLogs).
+		withType("endConnection")
+}
+
 func (m *mockRecord) withHash(hashStr string) *mockRecord {
 	m.record[api.HashIdFieldName] = hashStr
+	return m
+}
+
+func (m *mockRecord) withType(recordType string) *mockRecord {
+	m.record[api.RecordTypeFieldName] = recordType
 	return m
 }
 


### PR DESCRIPTION
This PR adds 2 fields to the output records of the connection tracking module:
1. connection hash id as a string in hex format (internally, it's stored as uint64 so it's size is 8 bytes)
2. RecordType with 3 value options: `NewConnection`, `EndConnection`, `FlowLog`.

- [x] This PR is based on top of #220 and should be merged after that one is merged.