### PR TITLE
Add tabulated output to write_stdout

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -142,7 +142,8 @@ Following is the supported API format for writing to standard output:
 
 <pre>
  stdout:
-         format: the format of each line: printf (default), fields or json
+         format: the format of each line: printf (default - writes using golang's default map printing), fields (writes one key and value field per line) or json
+
 </pre>
 ## Aggregate metrics API
 Following is the supported API format for specifying metrics aggregations:

--- a/docs/api.md
+++ b/docs/api.md
@@ -142,7 +142,7 @@ Following is the supported API format for writing to standard output:
 
 <pre>
  stdout:
-         format: the format of each line: printf (default) or json
+         format: the format of each line: printf (default), fields or json
 </pre>
 ## Aggregate metrics API
 Following is the supported API format for specifying metrics aggregations:

--- a/pkg/api/write_stdout.go
+++ b/pkg/api/write_stdout.go
@@ -1,5 +1,5 @@
 package api
 
 type WriteStdout struct {
-	Format string `yaml:"format,omitempty" json:"format,omitempty" doc:"the format of each line: printf (default), fields or json"`
+	Format string `yaml:"format,omitempty" json:"format,omitempty" doc:"the format of each line: printf (default - writes using golang's default map printing), fields (writes one key and value field per line) or json"`
 }

--- a/pkg/api/write_stdout.go
+++ b/pkg/api/write_stdout.go
@@ -1,5 +1,5 @@
 package api
 
 type WriteStdout struct {
-	Format string `yaml:"format,omitempty" json:"format,omitempty" doc:"the format of each line: printf (default) or json"`
+	Format string `yaml:"format,omitempty" json:"format,omitempty" doc:"the format of each line: printf (default), fields or json"`
 }

--- a/pkg/pipeline/write/write_stdout.go
+++ b/pkg/pipeline/write/write_stdout.go
@@ -20,6 +20,9 @@ package write
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"sort"
+	"text/tabwriter"
 	"time"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
@@ -38,6 +41,20 @@ func (t *writeStdout) Write(in []config.GenericMap) {
 		for _, v := range in {
 			txt, _ := json.Marshal(v)
 			fmt.Println(string(txt))
+		}
+	} else if t.format == "fields" {
+		for _, v := range in {
+			var order sort.StringSlice
+			for fieldName := range v {
+				order = append(order, fieldName)
+			}
+			order.Sort()
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+			fmt.Fprintf(w, "\n\nFlow record at %s:\n", time.Now().Format(time.StampMilli))
+			for _, field := range order {
+				fmt.Fprintf(w, "%v\t=\t%v\n", field, v[field])
+			}
+			w.Flush()
 		}
 	} else {
 		for _, v := range in {


### PR DESCRIPTION
Add a new format to `write_stdout` module called `fields` that can be used to print tabulated output which is slightly easier to read than raw json or text outputs.