### PR TITLE
Makefile: fix support for golang 1.18

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.17', '1.18']
         
     steps:
     - name: install make

--- a/.github/workflows/pull_request_e2e.yml
+++ b/.github/workflows/pull_request_e2e.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.17', '1.18']
         
     steps:
     - name: install make

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ validate_go:
 lint: $(GOLANGCI_LINT) ## Lint the code
 	@go mod vendor
 	@current_ver=$$(go version | { read _ _ v _; echo $${v#go}; }); \
-	if [[ "$$current_ver" == *"1.18."* ]]; then echo "Linting is not fully supported for golang 1.18. Consider using golang 1.17";\
+	if [[ "$$current_ver" == *"1.18"* ]]; then echo "Linting is not fully supported for golang 1.18. Consider using golang 1.17";\
 		$(GOLANGCI_LINT) run --disable-all --enable goimports --enable gofmt --enable ineffassign --timeout 5m; else \
 		$(GOLANGCI_LINT) run --enable goimports --timeout 5m; \
 	fi


### PR DESCRIPTION
Fix a typo that caused the golang 1.18 bad linting workaround not to
work.
Even if linting is partially disabled, add 1.18 to the CI.

Signed-off-by: Adrian Moreno <amorenoz@redhat.com>