### PR TITLE
Kafka ingestor fix

### DIFF
--- a/pkg/pipeline/encode/encode_kafka.go
+++ b/pkg/pipeline/encode/encode_kafka.go
@@ -106,6 +106,9 @@ func NewEncodeKafka(params config.StageParam) (Encoder, error) {
 		WriteTimeout: time.Duration(writeTimeoutSecs) * time.Second,
 		BatchSize:    jsonEncodeKafka.BatchSize,
 		BatchBytes:   jsonEncodeKafka.BatchBytes,
+		// Temporary fix may be we should implement a batching systems
+		// https://github.com/segmentio/kafka-go/issues/326#issuecomment-519375403
+		BatchTimeout: time.Nanosecond,
 	}
 
 	return &encodeKafka{

--- a/pkg/pipeline/ingest/ingest_collector.go
+++ b/pkg/pipeline/ingest/ingest_collector.go
@@ -99,6 +99,10 @@ func (w *TransportWrapper) Send(_, data []byte) error {
 	message := goflowpb.FlowMessage{}
 	err := proto.Unmarshal(data, &message)
 	if err != nil {
+		// temporary fix
+		// A PR was submitted to log this error from goflow2:
+		// https://github.com/netsampler/goflow2/pull/86
+		log.Error(err)
 		return err
 	}
 	renderedMsg, err := RenderMessage(&message)


### PR DESCRIPTION
3 different things in this patch:
- kafka configuration tuning for performances
- transformer wrapper error handling
- fix ingestor_collector bug when out channel is full resulting in the ingester sending single batch flow while many flows are waiting