### PR TITLE
conntrack: Add operational metrics

### DIFF
--- a/docs/operational-metrics.md
+++ b/docs/operational-metrics.md
@@ -16,6 +16,13 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 | **Type** | gauge | 
 
 
+### conntrack_input_records
+| **Name** | conntrack_input_records | 
+|:---|:---|
+| **Description** | The total number of input records per classification. | 
+| **Type** | counter | 
+
+
 ### encode_prom_metrics_processed
 | **Name** | encode_prom_metrics_processed | 
 |:---|:---|

--- a/docs/operational-metrics.md
+++ b/docs/operational-metrics.md
@@ -9,6 +9,13 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 
 	
 
+### conntrack_memory_connections
+| **Name** | conntrack_memory_connections | 
+|:---|:---|
+| **Description** | The total number of tracked connections in memory. | 
+| **Type** | gauge | 
+
+
 ### encode_prom_metrics_processed
 | **Name** | encode_prom_metrics_processed | 
 |:---|:---|

--- a/docs/operational-metrics.md
+++ b/docs/operational-metrics.md
@@ -23,6 +23,13 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 | **Type** | counter | 
 
 
+### conntrack_output_records
+| **Name** | conntrack_output_records | 
+|:---|:---|
+| **Description** | The total number of output records. | 
+| **Type** | counter | 
+
+
 ### encode_prom_metrics_processed
 | **Name** | encode_prom_metrics_processed | 
 |:---|:---|

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -32,6 +32,7 @@ const (
 	GenericType           = "generic"
 	NetworkType           = "network"
 	FilterType            = "filter"
+	ConnTrackType         = "conntrack"
 	NoneType              = "none"
 	ConnTrackingRuleType  = "conn_tracking"
 	AddRegExIfRuleType    = "add_regex_if"

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -23,6 +23,7 @@ const (
 	FileChunksType        = "file_chunks"
 	CollectorType         = "collector"
 	GRPCType              = "grpc"
+	FakeType              = "fake"
 	KafkaType             = "kafka"
 	StdoutType            = "stdout"
 	LokiType              = "loki"

--- a/pkg/api/conn_track.go
+++ b/pkg/api/conn_track.go
@@ -17,8 +17,6 @@
 
 package api
 
-import "time"
-
 const (
 	HashIdFieldName     = "_HashId"
 	RecordTypeFieldName = "_RecordType"
@@ -29,7 +27,7 @@ type ConnTrack struct {
 	KeyDefinition        KeyDefinition `yaml:"keyDefinition,omitempty" doc:"fields that are used to identify the connection"`
 	OutputRecordTypes    []string      `yaml:"outputRecordTypes,omitempty" enum:"ConnTrackOutputRecordTypeEnum" doc:"output record types to emit"`
 	OutputFields         []OutputField `yaml:"outputFields,omitempty" doc:"list of output fields"`
-	EndConnectionTimeout time.Duration `yaml:"endConnectionTimeout,omitempty" doc:"duration of time to wait from the last flow log to end a connection"`
+	EndConnectionTimeout Duration      `yaml:"endConnectionTimeout,omitempty" doc:"duration of time to wait from the last flow log to end a connection"`
 }
 
 type ConnTrackOutputRecordTypeEnum struct {

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// Duration is a wrapper of time.Duration that allows json marshaling.
+// https://stackoverflow.com/a/48051946/2749989
+type Duration struct {
+	time.Duration
+}
+
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+func (d *Duration) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	switch value := v.(type) {
+	case float64:
+		d.Duration = time.Duration(value)
+		return nil
+	case string:
+		var err error
+		d.Duration, err = time.ParseDuration(value)
+		if err != nil {
+			return err
+		}
+		return nil
+	default:
+		return errors.New("invalid duration")
+	}
+}
+
+func (d Duration) MarshalYAML() (interface{}, error) {
+	return d.String(), nil
+}
+
+func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var durationStr string
+	err := unmarshal(&durationStr)
+	if err != nil {
+		return err
+	}
+	d.Duration, err = time.ParseDuration(durationStr)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"encoding/json"
-	"errors"
+	"fmt"
 	"time"
 )
 
@@ -33,7 +33,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 		}
 		return nil
 	default:
-		return errors.New("invalid duration")
+		return fmt.Errorf("invalid duration %v", value)
 	}
 }
 

--- a/pkg/api/utils_test.go
+++ b/pkg/api/utils_test.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+type testMessage struct {
+	Elapsed Duration `json:"elapsed" yaml:"elapsed"`
+}
+
+func TestDuration_MarshalJSON(t *testing.T) {
+	expectedStr := `{"elapsed":"2h0m0s"}`
+	msgStr, err := json.Marshal(testMessage{Elapsed: Duration{2 * time.Hour}})
+	require.NoError(t, err)
+	require.Equal(t, expectedStr, string(msgStr))
+}
+
+func TestDuration_UnmarshalJSON(t *testing.T) {
+	expectedMsg := testMessage{Elapsed: Duration{2 * time.Hour}}
+	var actualMsg testMessage
+	require.NoError(t, json.Unmarshal([]byte(`{"elapsed": "2h"}`), &actualMsg))
+	require.Equal(t, expectedMsg, actualMsg)
+}
+
+func TestDuration_MarshalYAML(t *testing.T) {
+	expectedStr := "elapsed: 2h0m0s\n"
+	msgStr, err := yaml.Marshal(testMessage{Elapsed: Duration{2 * time.Hour}})
+	require.NoError(t, err)
+	require.Equal(t, expectedStr, string(msgStr))
+}
+
+func TestDuration_UnmarshalYAML(t *testing.T) {
+	expectedMsg := testMessage{Elapsed: Duration{2 * time.Hour}}
+	var actualMsg testMessage
+	require.NoError(t, yaml.Unmarshal([]byte("elapsed: 2h\n"), &actualMsg))
+	require.Equal(t, expectedMsg, actualMsg)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,13 +46,13 @@ type Stage struct {
 }
 
 type StageParam struct {
-	Name      string         `json:"name"`
-	Ingest    *Ingest        `json:"ingest,omitempty"`
-	Transform *Transform     `json:"transform,omitempty"`
-	ConnTrack *api.ConnTrack `json:"conntrack,omitempty"`
-	Extract   *Extract       `json:"extract,omitempty"`
-	Encode    *Encode        `json:"encode,omitempty"`
-	Write     *Write         `json:"write,omitempty"`
+	Name      string     `json:"name"`
+	Ingest    *Ingest    `json:"ingest,omitempty"`
+	Transform *Transform `json:"transform,omitempty"`
+	Track     *Track     `json:"track,omitempty"`
+	Extract   *Extract   `json:"extract,omitempty"`
+	Encode    *Encode    `json:"encode,omitempty"`
+	Write     *Write     `json:"write,omitempty"`
 }
 
 type Ingest struct {
@@ -75,6 +75,11 @@ type Transform struct {
 	Generic *api.TransformGeneric `json:"generic,omitempty"`
 	Filter  *api.TransformFilter  `json:"filter,omitempty"`
 	Network *api.TransformNetwork `json:"network,omitempty"`
+}
+
+type Track struct {
+	Type      string         `json:"type"`
+	ConnTrack *api.ConnTrack `json:"conntrack,omitempty"`
 }
 
 type Extract struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -49,6 +49,7 @@ type StageParam struct {
 	Name      string     `json:"name"`
 	Ingest    *Ingest    `json:"ingest,omitempty"`
 	Transform *Transform `json:"transform,omitempty"`
+	ConnTrack *ConnTrack `json:"conntrack,omitempty"`
 	Extract   *Extract   `json:"extract,omitempty"`
 	Encode    *Encode    `json:"encode,omitempty"`
 	Write     *Write     `json:"write,omitempty"`
@@ -74,6 +75,11 @@ type Transform struct {
 	Generic *api.TransformGeneric `json:"generic,omitempty"`
 	Filter  *api.TransformFilter  `json:"filter,omitempty"`
 	Network *api.TransformNetwork `json:"network,omitempty"`
+}
+
+type ConnTrack struct {
+	Type      string         `json:"type"` // TODO: Do we need this?
+	ConnTrack *api.ConnTrack `json:"conntrack,omitempty"`
 }
 
 type Extract struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,13 +46,13 @@ type Stage struct {
 }
 
 type StageParam struct {
-	Name      string     `json:"name"`
-	Ingest    *Ingest    `json:"ingest,omitempty"`
-	Transform *Transform `json:"transform,omitempty"`
-	ConnTrack *ConnTrack `json:"conntrack,omitempty"`
-	Extract   *Extract   `json:"extract,omitempty"`
-	Encode    *Encode    `json:"encode,omitempty"`
-	Write     *Write     `json:"write,omitempty"`
+	Name      string         `json:"name"`
+	Ingest    *Ingest        `json:"ingest,omitempty"`
+	Transform *Transform     `json:"transform,omitempty"`
+	ConnTrack *api.ConnTrack `json:"conntrack,omitempty"`
+	Extract   *Extract       `json:"extract,omitempty"`
+	Encode    *Encode        `json:"encode,omitempty"`
+	Write     *Write         `json:"write,omitempty"`
 }
 
 type Ingest struct {
@@ -75,11 +75,6 @@ type Transform struct {
 	Generic *api.TransformGeneric `json:"generic,omitempty"`
 	Filter  *api.TransformFilter  `json:"filter,omitempty"`
 	Network *api.TransformNetwork `json:"network,omitempty"`
-}
-
-type ConnTrack struct {
-	Type      string         `json:"type"` // TODO: Do we need this?
-	ConnTrack *api.ConnTrack `json:"conntrack,omitempty"`
 }
 
 type Extract struct {

--- a/pkg/config/pipeline_builder.go
+++ b/pkg/config/pipeline_builder.go
@@ -98,6 +98,11 @@ func (b *PipelineBuilderStage) TransformNetwork(name string, nw api.TransformNet
 	return b.next(name, StageParam{Name: name, Transform: &Transform{Type: api.NetworkType, Network: &nw}})
 }
 
+// ConnTrack chains the current stage with a ConnTrack stage and returns that new stage
+func (b *PipelineBuilderStage) ConnTrack(name string, ct api.ConnTrack) PipelineBuilderStage {
+	return b.next(name, StageParam{Name: name, Track: &Track{Type: api.ConnTrackType, ConnTrack: &ct}})
+}
+
 // EncodePrometheus chains the current stage with a PromEncode stage (to expose metrics in Prometheus format) and returns that new stage
 func (b *PipelineBuilderStage) EncodePrometheus(name string, prom api.PromEncode) PipelineBuilderStage {
 	return b.next(name, StageParam{Name: name, Encode: &Encode{Type: api.PromType, Prom: &prom}})

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -105,6 +105,9 @@ func TestKafkaPromPipeline(t *testing.T) {
 			Input: "doesnt_exist",
 		}},
 	})
+	pl = pl.ConnTrack("conntrack", api.ConnTrack{
+		KeyDefinition: api.KeyDefinition{},
+	})
 	pl = pl.Aggregate("aggregate", []api.AggregateDefinition{{
 		Name:      "src_as_connection_count",
 		By:        api.AggregateBy{"srcAS"},
@@ -126,14 +129,14 @@ func TestKafkaPromPipeline(t *testing.T) {
 		Prefix: "flp_",
 	})
 	stages := pl.GetStages()
-	require.Len(t, stages, 4)
+	require.Len(t, stages, 5)
 
 	b, err := json.Marshal(stages)
 	require.NoError(t, err)
-	require.Equal(t, `[{"name":"ingest"},{"name":"filter","follows":"ingest"},{"name":"aggregate","follows":"filter"},{"name":"prom","follows":"aggregate"}]`, string(b))
+	require.Equal(t, `[{"name":"ingest"},{"name":"filter","follows":"ingest"},{"name":"conntrack","follows":"filter"},{"name":"aggregate","follows":"conntrack"},{"name":"prom","follows":"aggregate"}]`, string(b))
 
 	params := pl.GetStageParams()
-	require.Len(t, params, 4)
+	require.Len(t, params, 5)
 
 	b, err = json.Marshal(params[0])
 	require.NoError(t, err)
@@ -145,9 +148,13 @@ func TestKafkaPromPipeline(t *testing.T) {
 
 	b, err = json.Marshal(params[2])
 	require.NoError(t, err)
-	require.Equal(t, `{"name":"aggregate","extract":{"type":"aggregates","aggregates":[{"name":"src_as_connection_count","by":["srcAS"],"operation":"count"}]}}`, string(b))
+	require.Equal(t, `{"name":"conntrack","track":{"type":"conntrack","conntrack":{"KeyDefinition":{"FieldGroups":null,"Hash":{"FieldGroupRefs":null,"FieldGroupARef":"","FieldGroupBRef":""}},"OutputRecordTypes":null,"OutputFields":null,"EndConnectionTimeout":"0s"}}}`, string(b))
 
 	b, err = json.Marshal(params[3])
+	require.NoError(t, err)
+	require.Equal(t, `{"name":"aggregate","extract":{"type":"aggregates","aggregates":[{"name":"src_as_connection_count","by":["srcAS"],"operation":"count"}]}}`, string(b))
+
+	b, err = json.Marshal(params[4])
 	require.NoError(t, err)
 	require.Equal(t, `{"name":"prom","encode":{"type":"prom","prom":{"metrics":[{"name":"connections_per_source_as","type":"counter","filter":{"key":"name","value":"src_as_connection_count"},"valueKey":"recent_count","labels":["by","aggregate"],"buckets":[]}],"port":9090,"prefix":"flp_"}}}`, string(b))
 }

--- a/pkg/operational/metrics/metrics.go
+++ b/pkg/operational/metrics/metrics.go
@@ -41,6 +41,15 @@ func NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
 	return promauto.NewCounter(opts)
 }
 
+func NewCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
+	metricsOpts = append(metricsOpts, metricDefinition{
+		Name: opts.Name,
+		Help: opts.Help,
+		Type: "counter",
+	})
+	return promauto.NewCounterVec(opts, labelNames)
+}
+
 func NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
 	metricsOpts = append(metricsOpts, metricDefinition{
 		Name: opts.Name,

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -174,7 +174,7 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 func (ct *conntrackImpl) popEndConnections() []config.GenericMap {
 	var outputRecords []config.GenericMap
 	ct.connStore.iterateOldToNew(func(conn connection) (shouldDelete, shouldStop bool) {
-		expireTime := ct.clock.Now().Add(-ct.config.EndConnectionTimeout)
+		expireTime := ct.clock.Now().Add(-ct.config.EndConnectionTimeout.Duration)
 		lastUpdate := conn.getLastUpdate()
 		if lastUpdate.Before(expireTime) {
 			// The last update time of this connection is too old. We want to pop it.

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -45,6 +45,20 @@ type ConnectionTracker interface {
 	Track(flowLogs []config.GenericMap) []config.GenericMap
 }
 
+type trackNone struct {
+}
+
+// Track tracks a connection
+func (t *trackNone) Track(flowLogs []config.GenericMap) []config.GenericMap {
+	return flowLogs
+}
+
+// NewTrackNone creates a new track
+func NewTrackNone() (ConnectionTracker, error) {
+	log.Debugf("entering NewTrackNone")
+	return &trackNone{}, nil
+}
+
 //////////////////////////
 
 // TODO: Does connectionStore deserve a file of its own?
@@ -216,7 +230,7 @@ func (ct *conntrackImpl) getFlowLogDirection(conn connection, flowLogHash totalH
 
 // NewConnectionTrack creates a new connection track instance
 func NewConnectionTrack(params config.StageParam, clock clock.Clock) (ConnectionTracker, error) {
-	config := params.ConnTrack
+	config := params.Track.ConnTrack
 	var aggregators []aggregator
 	for _, of := range config.OutputFields {
 		agg, err := newAggregator(of)

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -115,7 +115,7 @@ func newConnectionStore() *connectionStore {
 
 type conntrackImpl struct {
 	clock                     clock.Clock
-	config                    api.ConnTrack
+	config                    *api.ConnTrack
 	hashProvider              func() hash.Hash64
 	connStore                 *connectionStore
 	aggregators               []aggregator
@@ -215,7 +215,8 @@ func (ct *conntrackImpl) getFlowLogDirection(conn connection, flowLogHash totalH
 }
 
 // NewConnectionTrack creates a new connection track instance
-func NewConnectionTrack(config api.ConnTrack, clock clock.Clock) (ConnectionTracker, error) {
+func NewConnectionTrack(params config.StageParam, clock clock.Clock) (ConnectionTracker, error) {
+	config := params.ConnTrack.ConnTrack
 	var aggregators []aggregator
 	for _, of := range config.OutputFields {
 		agg, err := newAggregator(of)

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -216,7 +216,7 @@ func (ct *conntrackImpl) getFlowLogDirection(conn connection, flowLogHash totalH
 
 // NewConnectionTrack creates a new connection track instance
 func NewConnectionTrack(params config.StageParam, clock clock.Clock) (ConnectionTracker, error) {
-	config := params.ConnTrack.ConnTrack
+	config := params.ConnTrack
 	var aggregators []aggregator
 	for _, of := range config.OutputFields {
 		agg, err := newAggregator(of)

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -28,6 +28,8 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	operationalMetrics "github.com/netobserv/flowlogs-pipeline/pkg/operational/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -79,6 +81,7 @@ func (cs *connectionStore) addConnection(hashId uint64, conn connection) {
 	}
 	e := cs.connList.PushBack(conn)
 	cs.hash2conn[hashId] = e
+	connStoreLength.Set(float64(cs.connList.Len()))
 }
 
 func (cs *connectionStore) getConnection(hashId uint64) (connection, bool) {
@@ -111,6 +114,7 @@ func (cs *connectionStore) iterateOldToNew(f processConnF) {
 		if shouldDelete {
 			delete(cs.hash2conn, conn.getHash().hashTotal)
 			cs.connList.Remove(e)
+			connStoreLength.Set(float64(cs.connList.Len()))
 		}
 		if shouldStop {
 			break
@@ -137,6 +141,11 @@ type conntrackImpl struct {
 	shouldOutputNewConnection bool
 	shouldOutputEndConnection bool
 }
+
+var connStoreLength = operationalMetrics.NewGauge(prometheus.GaugeOpts{
+	Name: "conntrack_memory_connections",
+	Help: "The total number of tracked connections in memory.",
+})
 
 func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap {
 	log.Debugf("Entering Track")

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -43,6 +43,10 @@ const (
 	dirBA
 )
 
+const (
+	classificationLabel = "classification"
+)
+
 type ConnectionTracker interface {
 	Track(flowLogs []config.GenericMap) []config.GenericMap
 }
@@ -147,6 +151,11 @@ var connStoreLength = operationalMetrics.NewGauge(prometheus.GaugeOpts{
 	Help: "The total number of tracked connections in memory.",
 })
 
+var inputRecords = operationalMetrics.NewCounterVec(prometheus.CounterOpts{
+	Name: "conntrack_input_records",
+	Help: "The total number of input records per classification.",
+}, []string{classificationLabel})
+
 func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap {
 	log.Debugf("Entering Track")
 	log.Debugf("Track none, in = %v", flowLogs)
@@ -156,6 +165,7 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 		computedHash, err := ComputeHash(fl, ct.config.KeyDefinition, ct.hashProvider())
 		if err != nil {
 			log.Warningf("skipping flow log %v: %v", fl, err)
+			inputRecords.WithLabelValues("rejected").Inc()
 			continue
 		}
 		conn, exists := ct.connStore.getConnection(computedHash.hashTotal)
@@ -168,6 +178,7 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 				Build()
 			ct.connStore.addConnection(computedHash.hashTotal, conn)
 			ct.updateConnection(conn, fl, computedHash)
+			inputRecords.WithLabelValues("newConnection").Inc()
 			if ct.shouldOutputNewConnection {
 				record := conn.toGenericMap()
 				addHashField(record, computedHash.hashTotal)
@@ -176,6 +187,7 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 			}
 		} else {
 			ct.updateConnection(conn, fl, computedHash)
+			inputRecords.WithLabelValues("update").Inc()
 		}
 
 		if ct.shouldOutputFlowLogs {

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -28,8 +28,6 @@ import (
 	"github.com/benbjohnson/clock"
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
-	operationalMetrics "github.com/netobserv/flowlogs-pipeline/pkg/operational/metrics"
-	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -41,11 +39,6 @@ const (
 	dirNA direction = iota
 	dirAB
 	dirBA
-)
-
-const (
-	classificationLabel = "classification"
-	typeLabel           = "type"
 )
 
 type ConnectionTracker interface {
@@ -86,7 +79,7 @@ func (cs *connectionStore) addConnection(hashId uint64, conn connection) {
 	}
 	e := cs.connList.PushBack(conn)
 	cs.hash2conn[hashId] = e
-	connStoreLength.Set(float64(cs.connList.Len()))
+	metrics.connStoreLength.Set(float64(cs.connList.Len()))
 }
 
 func (cs *connectionStore) getConnection(hashId uint64) (connection, bool) {
@@ -119,7 +112,7 @@ func (cs *connectionStore) iterateOldToNew(f processConnF) {
 		if shouldDelete {
 			delete(cs.hash2conn, conn.getHash().hashTotal)
 			cs.connList.Remove(e)
-			connStoreLength.Set(float64(cs.connList.Len()))
+			metrics.connStoreLength.Set(float64(cs.connList.Len()))
 		}
 		if shouldStop {
 			break
@@ -147,21 +140,6 @@ type conntrackImpl struct {
 	shouldOutputEndConnection bool
 }
 
-var connStoreLength = operationalMetrics.NewGauge(prometheus.GaugeOpts{
-	Name: "conntrack_memory_connections",
-	Help: "The total number of tracked connections in memory.",
-})
-
-var inputRecords = operationalMetrics.NewCounterVec(prometheus.CounterOpts{
-	Name: "conntrack_input_records",
-	Help: "The total number of input records per classification.",
-}, []string{classificationLabel})
-
-var outputRecordsMetric = operationalMetrics.NewCounterVec(prometheus.CounterOpts{
-	Name: "conntrack_output_records",
-	Help: "The total number of output records.",
-}, []string{typeLabel})
-
 func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap {
 	log.Debugf("Entering Track")
 	log.Debugf("Track none, in = %v", flowLogs)
@@ -171,7 +149,7 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 		computedHash, err := ComputeHash(fl, ct.config.KeyDefinition, ct.hashProvider())
 		if err != nil {
 			log.Warningf("skipping flow log %v: %v", fl, err)
-			inputRecords.WithLabelValues("rejected").Inc()
+			metrics.inputRecords.WithLabelValues("rejected").Inc()
 			continue
 		}
 		conn, exists := ct.connStore.getConnection(computedHash.hashTotal)
@@ -184,17 +162,17 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 				Build()
 			ct.connStore.addConnection(computedHash.hashTotal, conn)
 			ct.updateConnection(conn, fl, computedHash)
-			inputRecords.WithLabelValues("newConnection").Inc()
+			metrics.inputRecords.WithLabelValues("newConnection").Inc()
 			if ct.shouldOutputNewConnection {
 				record := conn.toGenericMap()
 				addHashField(record, computedHash.hashTotal)
 				addTypeField(record, api.ConnTrackOutputRecordTypeName("NewConnection"))
 				outputRecords = append(outputRecords, record)
-				outputRecordsMetric.WithLabelValues("newConnection").Inc()
+				metrics.outputRecords.WithLabelValues("newConnection").Inc()
 			}
 		} else {
 			ct.updateConnection(conn, fl, computedHash)
-			inputRecords.WithLabelValues("update").Inc()
+			metrics.inputRecords.WithLabelValues("update").Inc()
 		}
 
 		if ct.shouldOutputFlowLogs {
@@ -202,14 +180,14 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 			addHashField(record, computedHash.hashTotal)
 			addTypeField(record, api.ConnTrackOutputRecordTypeName("FlowLog"))
 			outputRecords = append(outputRecords, record)
-			outputRecordsMetric.WithLabelValues("flowLog").Inc()
+			metrics.outputRecords.WithLabelValues("flowLog").Inc()
 		}
 	}
 
 	endConnectionRecords := ct.popEndConnections()
 	if ct.shouldOutputEndConnection {
 		outputRecords = append(outputRecords, endConnectionRecords...)
-		outputRecordsMetric.WithLabelValues("endConnection").Add(float64(len(endConnectionRecords)))
+		metrics.outputRecords.WithLabelValues("endConnection").Add(float64(len(endConnectionRecords)))
 	}
 
 	return outputRecords

--- a/pkg/pipeline/conntrack/conntrack.go
+++ b/pkg/pipeline/conntrack/conntrack.go
@@ -45,6 +45,7 @@ const (
 
 const (
 	classificationLabel = "classification"
+	typeLabel           = "type"
 )
 
 type ConnectionTracker interface {
@@ -156,6 +157,11 @@ var inputRecords = operationalMetrics.NewCounterVec(prometheus.CounterOpts{
 	Help: "The total number of input records per classification.",
 }, []string{classificationLabel})
 
+var outputRecordsMetric = operationalMetrics.NewCounterVec(prometheus.CounterOpts{
+	Name: "conntrack_output_records",
+	Help: "The total number of output records.",
+}, []string{typeLabel})
+
 func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap {
 	log.Debugf("Entering Track")
 	log.Debugf("Track none, in = %v", flowLogs)
@@ -184,6 +190,7 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 				addHashField(record, computedHash.hashTotal)
 				addTypeField(record, api.ConnTrackOutputRecordTypeName("NewConnection"))
 				outputRecords = append(outputRecords, record)
+				outputRecordsMetric.WithLabelValues("newConnection").Inc()
 			}
 		} else {
 			ct.updateConnection(conn, fl, computedHash)
@@ -195,12 +202,14 @@ func (ct *conntrackImpl) Track(flowLogs []config.GenericMap) []config.GenericMap
 			addHashField(record, computedHash.hashTotal)
 			addTypeField(record, api.ConnTrackOutputRecordTypeName("FlowLog"))
 			outputRecords = append(outputRecords, record)
+			outputRecordsMetric.WithLabelValues("flowLog").Inc()
 		}
 	}
 
 	endConnectionRecords := ct.popEndConnections()
 	if ct.shouldOutputEndConnection {
 		outputRecords = append(outputRecords, endConnectionRecords...)
+		outputRecordsMetric.WithLabelValues("endConnection").Add(float64(len(endConnectionRecords)))
 	}
 
 	return outputRecords

--- a/pkg/pipeline/conntrack/conntrack_test.go
+++ b/pkg/pipeline/conntrack/conntrack_test.go
@@ -42,42 +42,40 @@ func buildMockConnTrackConfig(isBidirectional bool, outputRecordType []string) *
 		}
 	}
 	return &config.StageParam{
-		ConnTrack: &config.ConnTrack{
-			ConnTrack: &api.ConnTrack{
-				KeyDefinition: api.KeyDefinition{
-					FieldGroups: []api.FieldGroup{
-						{
-							Name: "src",
-							Fields: []string{
-								"SrcAddr",
-								"SrcPort",
-							},
-						},
-						{
-							Name: "dst",
-							Fields: []string{
-								"DstAddr",
-								"DstPort",
-							},
-						},
-						{
-							Name: "protocol",
-							Fields: []string{
-								"Proto",
-							},
+		ConnTrack: &api.ConnTrack{
+			KeyDefinition: api.KeyDefinition{
+				FieldGroups: []api.FieldGroup{
+					{
+						Name: "src",
+						Fields: []string{
+							"SrcAddr",
+							"SrcPort",
 						},
 					},
-					Hash: hash,
+					{
+						Name: "dst",
+						Fields: []string{
+							"DstAddr",
+							"DstPort",
+						},
+					},
+					{
+						Name: "protocol",
+						Fields: []string{
+							"Proto",
+						},
+					},
 				},
-				OutputFields: []api.OutputField{
-					{Name: "Bytes", Operation: "sum", SplitAB: splitAB},
-					{Name: "Packets", Operation: "sum", SplitAB: splitAB},
-					{Name: "numFlowLogs", Operation: "count", SplitAB: false},
-				},
-				OutputRecordTypes:    outputRecordType,
-				EndConnectionTimeout: 30 * time.Second,
-			}, // end of api.ConnTrack
-		}, // end of config.ConnTrack
+				Hash: hash,
+			},
+			OutputFields: []api.OutputField{
+				{Name: "Bytes", Operation: "sum", SplitAB: splitAB},
+				{Name: "Packets", Operation: "sum", SplitAB: splitAB},
+				{Name: "numFlowLogs", Operation: "count", SplitAB: false},
+			},
+			OutputRecordTypes:    outputRecordType,
+			EndConnectionTimeout: 30 * time.Second,
+		}, // end of api.ConnTrack
 	} // end of config.StageParam
 }
 

--- a/pkg/pipeline/conntrack/conntrack_test.go
+++ b/pkg/pipeline/conntrack/conntrack_test.go
@@ -74,7 +74,7 @@ func buildMockConnTrackConfig(isBidirectional bool, outputRecordType []string) *
 				{Name: "numFlowLogs", Operation: "count", SplitAB: false},
 			},
 			OutputRecordTypes:    outputRecordType,
-			EndConnectionTimeout: api.Duration{30 * time.Second},
+			EndConnectionTimeout: api.Duration{Duration: 30 * time.Second},
 		}, // end of api.ConnTrack
 	} // end of config.StageParam
 }

--- a/pkg/pipeline/conntrack/conntrack_test.go
+++ b/pkg/pipeline/conntrack/conntrack_test.go
@@ -74,7 +74,7 @@ func buildMockConnTrackConfig(isBidirectional bool, outputRecordType []string) *
 				{Name: "numFlowLogs", Operation: "count", SplitAB: false},
 			},
 			OutputRecordTypes:    outputRecordType,
-			EndConnectionTimeout: 30 * time.Second,
+			EndConnectionTimeout: api.Duration{30 * time.Second},
 		}, // end of api.ConnTrack
 	} // end of config.StageParam
 }

--- a/pkg/pipeline/conntrack/conntrack_test.go
+++ b/pkg/pipeline/conntrack/conntrack_test.go
@@ -42,40 +42,43 @@ func buildMockConnTrackConfig(isBidirectional bool, outputRecordType []string) *
 		}
 	}
 	return &config.StageParam{
-		ConnTrack: &api.ConnTrack{
-			KeyDefinition: api.KeyDefinition{
-				FieldGroups: []api.FieldGroup{
-					{
-						Name: "src",
-						Fields: []string{
-							"SrcAddr",
-							"SrcPort",
+		Track: &config.Track{
+			Type: api.ConnTrackType,
+			ConnTrack: &api.ConnTrack{
+				KeyDefinition: api.KeyDefinition{
+					FieldGroups: []api.FieldGroup{
+						{
+							Name: "src",
+							Fields: []string{
+								"SrcAddr",
+								"SrcPort",
+							},
+						},
+						{
+							Name: "dst",
+							Fields: []string{
+								"DstAddr",
+								"DstPort",
+							},
+						},
+						{
+							Name: "protocol",
+							Fields: []string{
+								"Proto",
+							},
 						},
 					},
-					{
-						Name: "dst",
-						Fields: []string{
-							"DstAddr",
-							"DstPort",
-						},
-					},
-					{
-						Name: "protocol",
-						Fields: []string{
-							"Proto",
-						},
-					},
+					Hash: hash,
 				},
-				Hash: hash,
-			},
-			OutputFields: []api.OutputField{
-				{Name: "Bytes", Operation: "sum", SplitAB: splitAB},
-				{Name: "Packets", Operation: "sum", SplitAB: splitAB},
-				{Name: "numFlowLogs", Operation: "count", SplitAB: false},
-			},
-			OutputRecordTypes:    outputRecordType,
-			EndConnectionTimeout: api.Duration{Duration: 30 * time.Second},
-		}, // end of api.ConnTrack
+				OutputFields: []api.OutputField{
+					{Name: "Bytes", Operation: "sum", SplitAB: splitAB},
+					{Name: "Packets", Operation: "sum", SplitAB: splitAB},
+					{Name: "numFlowLogs", Operation: "count", SplitAB: false},
+				},
+				OutputRecordTypes:    outputRecordType,
+				EndConnectionTimeout: api.Duration{Duration: 30 * time.Second},
+			}, // end of api.ConnTrack
+		}, // end of config.Track
 	} // end of config.StageParam
 }
 

--- a/pkg/pipeline/conntrack/metrics.go
+++ b/pkg/pipeline/conntrack/metrics.go
@@ -1,0 +1,40 @@
+package conntrack
+
+import (
+	operationalMetrics "github.com/netobserv/flowlogs-pipeline/pkg/operational/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	classificationLabel = "classification"
+	typeLabel           = "type"
+)
+
+var metrics = newMetrics()
+
+type metricsType struct {
+	connStoreLength prometheus.Gauge
+	inputRecords    *prometheus.CounterVec
+	outputRecords   *prometheus.CounterVec
+}
+
+func newMetrics() *metricsType {
+	var m metricsType
+
+	m.connStoreLength = operationalMetrics.NewGauge(prometheus.GaugeOpts{
+		Name: "conntrack_memory_connections",
+		Help: "The total number of tracked connections in memory.",
+	})
+
+	m.inputRecords = operationalMetrics.NewCounterVec(prometheus.CounterOpts{
+		Name: "conntrack_input_records",
+		Help: "The total number of input records per classification.",
+	}, []string{classificationLabel})
+
+	m.outputRecords = operationalMetrics.NewCounterVec(prometheus.CounterOpts{
+		Name: "conntrack_output_records",
+		Help: "The total number of output records.",
+	}, []string{typeLabel})
+
+	return &m
+}

--- a/pkg/pipeline/conntrack_integ_test.go
+++ b/pkg/pipeline/conntrack_integ_test.go
@@ -44,7 +44,7 @@ parameters:
     name: ingest_fake
   - name: conntrack
     conntrack:
-      endConnectionTimeout: 100000000
+      endConnectionTimeout: 1s
       outputRecordTypes:
         - newConnection
         - endConnection

--- a/pkg/pipeline/conntrack_integ_test.go
+++ b/pkg/pipeline/conntrack_integ_test.go
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2022 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package pipeline
+
+import (
+	"bufio"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/decode"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/ingest"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/write"
+	"github.com/netobserv/flowlogs-pipeline/pkg/test"
+	"github.com/stretchr/testify/require"
+)
+
+const testConfigConntrack = `---
+pipeline:
+  - name: ingest_fake
+  - follows: ingest_fake
+    name: conntrack
+  - follows: conntrack
+    name: write_none
+parameters:
+  - ingest:
+      type: fake
+    name: ingest_fake
+  - name: conntrack 
+    conntrack:
+      conntrack:
+        endConnectionTimeout: 100000000
+        outputRecordTypes:
+          - newConnection
+          - endConnection
+        keyDefinition:
+          fieldGroups:
+            - name: src
+              fields:
+                - SrcAddr
+                - SrcPort
+            - name: dst
+              fields:
+                - DstAddr
+                - DstPort
+            - name: protocol
+              fields:
+                - Proto
+          hash:
+            fieldGroupRefs: [protocol]
+            fieldGroupARef: src 
+            fieldGroupBRef: dst 
+        outputFields:
+          - name: Bytes
+            operation: sum
+            SplitAB: true
+          - name: Packets
+            operation: sum
+            SplitAB: true
+          - name: numFlowLogs
+            operation: count
+          - name: TimeFlowStart
+            operation: min
+            input: TimeReceived
+          - name: TimeFlowEnd
+            operation: max
+            input: TimeReceived
+      type: blabla 
+  - name: write_none
+    write:
+      type: none
+`
+
+func TestConnTrack(t *testing.T) {
+	// This test runs a 3 stage pipeline (Ingester -> ConnTrack -> Write), ingests a file and tests that an end
+	// connection record with specific values was outputted.
+	var mainPipeline *Pipeline
+	var err error
+	v := test.InitConfig(t, testConfigConntrack)
+	require.NotNil(t, v)
+
+	mainPipeline, err = NewPipeline()
+	require.NoError(t, err)
+
+	go mainPipeline.Run()
+
+	in := mainPipeline.pipelineStages[0].Ingester.(*ingest.IngestFake).In
+
+	ingestFile(t, in, "../../hack/examples/ocp-ipfix-flowlogs.json")
+
+	// Wait a moment to make the connections expired
+	time.Sleep(2 * time.Second)
+	// Trigger the ingester and wait awhile to allow the connection tracking output end connection records
+	in <- []config.GenericMap{}
+	time.Sleep(1 * time.Second)
+
+	// Verify that the output records contain an expected end connection record.
+	writer := mainPipeline.pipelineStages[2].Writer.(*write.WriteNone)
+	expected := config.GenericMap{
+		"Bytes_AB":      41_600.0,
+		"Bytes_BA":      5_004_000.0,
+		"DstAddr":       "10.129.0.29",
+		"DstPort":       8443.0,
+		"Packets_AB":    800.0,
+		"Packets_BA":    1200.0,
+		"Proto":         6.0,
+		"SrcAddr":       "10.129.2.11",
+		"SrcPort":       46894.0,
+		"TimeFlowEnd":   1_637_501_829.0,
+		"TimeFlowStart": 1_637_501_079.0,
+		"_HashId":       "d28db42bcd8aea8f",
+		"_RecordType":   "endConnection",
+		"numFlowLogs":   5.0,
+	}
+	require.Containsf(t, writer.AllRecords, expected, "The output records don't include the expected record %v", expected)
+}
+
+func ingestFile(t *testing.T, in chan<- []config.GenericMap, filepath string) {
+	t.Helper()
+	file, err := os.Open(filepath)
+	require.NoError(t, err)
+	defer func() {
+		_ = file.Close()
+	}()
+	lines := make([]interface{}, 0)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		text := scanner.Text()
+		lines = append(lines, text)
+	}
+	decoder, err := decode.NewDecodeJson()
+	require.NoError(t, err)
+	decoded := decoder.Decode(lines)
+	in <- decoded
+}

--- a/pkg/pipeline/conntrack_integ_test.go
+++ b/pkg/pipeline/conntrack_integ_test.go
@@ -42,46 +42,44 @@ parameters:
   - ingest:
       type: fake
     name: ingest_fake
-  - name: conntrack 
+  - name: conntrack
     conntrack:
-      conntrack:
-        endConnectionTimeout: 100000000
-        outputRecordTypes:
-          - newConnection
-          - endConnection
-        keyDefinition:
-          fieldGroups:
-            - name: src
-              fields:
-                - SrcAddr
-                - SrcPort
-            - name: dst
-              fields:
-                - DstAddr
-                - DstPort
-            - name: protocol
-              fields:
-                - Proto
-          hash:
-            fieldGroupRefs: [protocol]
-            fieldGroupARef: src 
-            fieldGroupBRef: dst 
-        outputFields:
-          - name: Bytes
-            operation: sum
-            SplitAB: true
-          - name: Packets
-            operation: sum
-            SplitAB: true
-          - name: numFlowLogs
-            operation: count
-          - name: TimeFlowStart
-            operation: min
-            input: TimeReceived
-          - name: TimeFlowEnd
-            operation: max
-            input: TimeReceived
-      type: blabla 
+      endConnectionTimeout: 100000000
+      outputRecordTypes:
+        - newConnection
+        - endConnection
+      keyDefinition:
+        fieldGroups:
+          - name: src
+            fields:
+              - SrcAddr
+              - SrcPort
+          - name: dst
+            fields:
+              - DstAddr
+              - DstPort
+          - name: protocol
+            fields:
+              - Proto
+        hash:
+          fieldGroupRefs: [protocol]
+          fieldGroupARef: src 
+          fieldGroupBRef: dst 
+      outputFields:
+        - name: Bytes
+          operation: sum
+          SplitAB: true
+        - name: Packets
+          operation: sum
+          SplitAB: true
+        - name: numFlowLogs
+          operation: count
+        - name: TimeFlowStart
+          operation: min
+          input: TimeReceived
+        - name: TimeFlowEnd
+          operation: max
+          input: TimeReceived
   - name: write_none
     write:
       type: none

--- a/pkg/pipeline/ingest/ingest_fake.go
+++ b/pkg/pipeline/ingest/ingest_fake.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2021 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ingest
+
+import (
+	"fmt"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	log "github.com/sirupsen/logrus"
+)
+
+type IngestFake struct {
+	params   config.Ingest
+	In       chan []config.GenericMap
+	exitChan <-chan struct{}
+}
+
+// Ingest reads records from an input channel and writes them as-is to the output channel
+func (inf *IngestFake) Ingest(out chan<- []config.GenericMap) {
+	for {
+		select {
+		case <-inf.exitChan:
+			log.Debugf("exiting IngestFake because of signal")
+			return
+		case records := <-inf.In:
+			out <- records
+		}
+	}
+}
+
+// NewIngestFake creates a new ingester
+func NewIngestFake(params config.StageParam) (Ingester, error) {
+	log.Debugf("entering NewIngestFake")
+	if params.Ingest == nil {
+		return nil, fmt.Errorf("ingest not specified")
+	}
+
+	return &IngestFake{
+		params:   *params.Ingest,
+		In:       make(chan []config.GenericMap), // TODO: should add size?
+		exitChan: utils.ExitChannel(),
+	}, nil
+}

--- a/pkg/pipeline/ingest/ingest_fake.go
+++ b/pkg/pipeline/ingest/ingest_fake.go
@@ -53,7 +53,7 @@ func NewIngestFake(params config.StageParam) (Ingester, error) {
 
 	return &IngestFake{
 		params:   *params.Ingest,
-		In:       make(chan []config.GenericMap), // TODO: should add size?
+		In:       make(chan []config.GenericMap),
 		exitChan: utils.ExitChannel(),
 	}, nil
 }

--- a/pkg/pipeline/ingest/ingest_kafka.go
+++ b/pkg/pipeline/ingest/ingest_kafka.go
@@ -52,7 +52,7 @@ const defaultKafkaCommitInterval = 500
 
 // Ingest ingests entries from kafka topic
 func (ingestK *ingestKafka) Ingest(out chan<- []config.GenericMap) {
-	log.Debugf("entering  ingestKafka.Ingest")
+	log.Debugf("entering ingestKafka.Ingest")
 
 	// initialize background listener
 	ingestK.kafkaListener()
@@ -63,7 +63,7 @@ func (ingestK *ingestKafka) Ingest(out chan<- []config.GenericMap) {
 
 // background thread to read kafka messages; place received items into ingestKafka input channel
 func (ingestK *ingestKafka) kafkaListener() {
-	log.Debugf("entering  kafkaListener")
+	log.Debugf("entering kafkaListener")
 
 	go func() {
 		for {

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -30,6 +30,7 @@ import (
 const (
 	StageIngest    = "ingest"
 	StageTransform = "transform"
+	StageConnTrack = "conntrack"
 	StageExtract   = "extract"
 	StageEncode    = "encode"
 	StageWrite     = "write"

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -30,7 +30,7 @@ import (
 const (
 	StageIngest    = "ingest"
 	StageTransform = "transform"
-	StageConnTrack = "conntrack"
+	StageTrack     = "track"
 	StageExtract   = "extract"
 	StageEncode    = "encode"
 	StageWrite     = "write"

--- a/pkg/pipeline/pipeline_builder.go
+++ b/pkg/pipeline/pipeline_builder.go
@@ -297,6 +297,8 @@ func getWriter(params config.StageParam) (write.Writer, error) {
 		writer, err = write.NewWriteNone()
 	case api.LokiType:
 		writer, err = write.NewWriteLoki(params)
+	case api.FakeType:
+		writer, err = write.NewWriteFake(params)
 	default:
 		panic(fmt.Sprintf("`write` type %s not defined; if no writer needed, specify `none`", params.Write.Type))
 	}

--- a/pkg/pipeline/pipeline_builder.go
+++ b/pkg/pipeline/pipeline_builder.go
@@ -339,9 +339,9 @@ func getExtractor(params config.StageParam) (extract.Extractor, error) {
 	var extractor extract.Extractor
 	var err error
 	switch params.Extract.Type {
-	case "none":
+	case api.NoneType:
 		extractor, _ = extract.NewExtractNone()
-	case "aggregates":
+	case api.AggregateType:
 		extractor, err = extract.NewExtractAggregate(params)
 	default:
 		panic(fmt.Sprintf("`extract` type %s not defined; if no extractor needed, specify `none`", params.Extract.Type))
@@ -353,11 +353,11 @@ func getEncoder(params config.StageParam) (encode.Encoder, error) {
 	var encoder encode.Encoder
 	var err error
 	switch params.Encode.Type {
-	case "prom":
+	case api.PromType:
 		encoder, err = encode.NewEncodeProm(params)
-	case "kafka":
+	case api.KafkaType:
 		encoder, err = encode.NewEncodeKafka(params)
-	case "none":
+	case api.NoneType:
 		encoder, _ = encode.NewEncodeNone()
 	default:
 		panic(fmt.Sprintf("`encode` type %s not defined; if no encoder needed, specify `none`", params.Encode.Type))

--- a/pkg/pipeline/pipeline_builder.go
+++ b/pkg/pipeline/pipeline_builder.go
@@ -322,23 +322,8 @@ func getTransformer(params config.StageParam) (transform.Transformer, error) {
 }
 
 func getConnTrack(params config.StageParam) (conntrack.ConnectionTracker, error) {
-	var conntrack_ conntrack.ConnectionTracker
-	var err error
-	conntrack_, err = conntrack.NewConnectionTrack(params, clock.New())
-	// TODO:
-	//switch params.ConnTrack.Type {
-	//case api.GenericType:
-	//	transformer, err = transform.NewTransformGeneric(params)
-	//case api.FilterType:
-	//	transformer, err = transform.NewTransformFilter(params)
-	//case api.NetworkType:
-	//	transformer, err = transform.NewTransformNetwork(params)
-	//case api.NoneType:
-	//	transformer, err = transform.NewTransformNone()
-	//default:
-	//	panic(fmt.Sprintf("`transform` type %s not defined; if no transformer needed, specify `none`", params.Transform.Type))
-	//}
-	return conntrack_, err
+	ct, err := conntrack.NewConnectionTrack(params, clock.New())
+	return ct, err
 }
 
 func getExtractor(params config.StageParam) (extract.Extractor, error) {

--- a/pkg/pipeline/pipeline_builder.go
+++ b/pkg/pipeline/pipeline_builder.go
@@ -380,7 +380,7 @@ func findStageType(param *config.StageParam) string {
 	if param.Transform != nil && param.Transform.Type != "" {
 		return StageTransform
 	}
-	if param.ConnTrack != nil && param.ConnTrack.Type != "" {
+	if param.ConnTrack != nil {
 		return StageConnTrack
 	}
 	if param.Extract != nil && param.Extract.Type != "" {

--- a/pkg/pipeline/transform/transform.go
+++ b/pkg/pipeline/transform/transform.go
@@ -37,7 +37,7 @@ func (t *transformNone) Transform(f []config.GenericMap) []config.GenericMap {
 
 // NewTransformNone create a new transform
 func NewTransformNone() (Transformer, error) {
-	log.Debugf("entering  NewTransformNone")
+	log.Debugf("entering NewTransformNone")
 	return &transformNone{}, nil
 }
 

--- a/pkg/pipeline/write/write.go
+++ b/pkg/pipeline/write/write.go
@@ -27,12 +27,14 @@ type Writer interface {
 }
 type WriteNone struct {
 	PrevRecords []config.GenericMap
+	AllRecords  []config.GenericMap
 }
 
 // Write writes entries
 func (t *WriteNone) Write(in []config.GenericMap) {
 	log.Debugf("entering Write none, in = %v", in)
 	t.PrevRecords = in
+	t.AllRecords = append(t.AllRecords, in...)
 }
 
 // NewWriteNone create a new write

--- a/pkg/pipeline/write/write.go
+++ b/pkg/pipeline/write/write.go
@@ -27,14 +27,12 @@ type Writer interface {
 }
 type WriteNone struct {
 	PrevRecords []config.GenericMap
-	AllRecords  []config.GenericMap
 }
 
 // Write writes entries
 func (t *WriteNone) Write(in []config.GenericMap) {
 	log.Debugf("entering Write none, in = %v", in)
 	t.PrevRecords = in
-	t.AllRecords = append(t.AllRecords, in...)
 }
 
 // NewWriteNone create a new write

--- a/pkg/pipeline/write/write_fake.go
+++ b/pkg/pipeline/write/write_fake.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package write
+
+import (
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	log "github.com/sirupsen/logrus"
+)
+
+type WriteFake struct {
+	AllRecords []config.GenericMap
+	wait       chan struct{}
+}
+
+// Write stores in memory all records.
+func (w *WriteFake) Write(in []config.GenericMap) {
+	log.Debugf("entering writeFake Write")
+	log.Debugf("writeFake: number of entries = %d", len(in))
+	for _, r := range in {
+		w.AllRecords = append(w.AllRecords, r.Copy())
+	}
+	close(w.wait)
+}
+
+// Wait waits until Write() is done processing all the records.
+func (w *WriteFake) Wait() {
+	<-w.wait
+}
+
+// ResetWait resets the wait channel to allow waiters to block on Wait() for the next Write().
+// It should be invoked after Write() is done and all waiters are released.
+func (w *WriteFake) ResetWait() {
+	w.wait = make(chan struct{})
+}
+
+// NewWriteFake creates a new write.
+func NewWriteFake(params config.StageParam) (Writer, error) {
+	log.Debugf("entering NewWriteFake")
+	w := &WriteFake{}
+	w.ResetWait()
+	return w, nil
+}


### PR DESCRIPTION
This PR adds the following operational metrics:

1. **conntrack_memory_connections**: (Gauge) The total number of tracked connections in memory.

2. **conntrack_input_records**: (CounterVec) The total number of input records per classification.
```
conntrack_input_records{classification="rejected"} # Number of input records that were rejected
conntrack_input_records{classification="newConnection"} # Number of input records that caused creating a new connection
conntrack_input_records{classification="update"}  # Number of input records that matched a live connection
```

3. **conntrack_output_records**: (CounterVec) The total number of output records.
```
conntrack_output_records{type="newConnection"} # Number of output records of type newConnection
conntrack_output_records{type="endConnection"} # Number of output records of type endConnection
conntrack_output_records{type="flowLog"} # Number of output records of type flowLog
```

- [ ] This PR is based on top of #247 and should be merged after it.

Below is a printscreen of the metrics after running `make ocp-deploy` with the attached config. I had to add a prometheus pipeline stage to add the prometheus endpoint and expose the operational metrics.
[flowlogs-pipeline.conf.yaml.txt](https://github.com/netobserv/flowlogs-pipeline/files/9103602/flowlogs-pipeline.conf.yaml.txt)
![Screenshot 2022-07-13 at 17-11-16 Prometheus Time Series Collection and Processing Server](https://user-images.githubusercontent.com/37826670/178769573-e0278dcc-f94f-492d-8913-b657b9fd0cb8.png)