### PR TITLE
NETOBSERV-101 R&D: Kube enricher write path for downstream operator

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -126,6 +126,7 @@ Following is the supported API format for writing to loki:
  loki:
          url: the address of an existing Loki service to push the flows to
          tenantID: identifies the tenant for the request
+         authorizationTokenPath: authorization header path to parse and send to loki gateway
          batchWait: maximum amount of time to wait before sending a batch
          batchSize: maximum batch size (in bytes) of logs to accumulate before sending
          timeout: maximum time to wait for a server to respond to a request

--- a/pkg/api/write_loki.go
+++ b/pkg/api/write_loki.go
@@ -26,19 +26,20 @@ import (
 )
 
 type WriteLoki struct {
-	URL            string                       `yaml:"url,omitempty" json:"url,omitempty" doc:"the address of an existing Loki service to push the flows to"`
-	TenantID       string                       `yaml:"tenantID,omitempty" json:"tenantID,omitempty" doc:"identifies the tenant for the request"`
-	BatchWait      string                       `yaml:"batchWait,omitempty" json:"batchWait,omitempty" doc:"maximum amount of time to wait before sending a batch"`
-	BatchSize      int                          `yaml:"batchSize,omitempty" json:"batchSize,omitempty" doc:"maximum batch size (in bytes) of logs to accumulate before sending"`
-	Timeout        string                       `yaml:"timeout,omitempty" json:"timeout,omitempty" doc:"maximum time to wait for a server to respond to a request"`
-	MinBackoff     string                       `yaml:"minBackoff,omitempty" json:"minBackoff,omitempty" doc:"initial backoff time for client connection between retries"`
-	MaxBackoff     string                       `yaml:"maxBackoff,omitempty" json:"maxBackoff,omitempty" doc:"maximum backoff time for client connection between retries"`
-	MaxRetries     int                          `yaml:"maxRetries,omitempty" json:"maxRetries,omitempty" doc:"maximum number of retries for client connections"`
-	Labels         []string                     `yaml:"labels,omitempty" json:"labels,omitempty" doc:"map of record fields to be used as labels"`
-	StaticLabels   model.LabelSet               `yaml:"staticLabels,omitempty" json:"staticLabels,omitempty" doc:"map of common labels to set on each flow"`
-	IgnoreList     []string                     `yaml:"ignoreList,omitempty" json:"ignoreList,omitempty" doc:"map of record fields to be removed from the record"`
-	ClientConfig   *promConfig.HTTPClientConfig `yaml:"clientConfig,omitempty" json:"clientConfig,omitempty" doc:"clientConfig"`
-	TimestampLabel model.LabelName              `yaml:"timestampLabel,omitempty" json:"timestampLabel,omitempty" doc:"label to use for time indexing"`
+	URL                 string                       `yaml:"url,omitempty" json:"url,omitempty" doc:"the address of an existing Loki service to push the flows to"`
+	TenantID            string                       `yaml:"tenantID,omitempty" json:"tenantID,omitempty" doc:"identifies the tenant for the request"`
+	BearerAuthTokenPath string                       `yaml:"bearerAuthTokenPath,omitempty" json:"bearerAuthTokenPath,omitempty" doc:"bearer authorization header path to parse and send to loki gateway"`
+	BatchWait           string                       `yaml:"batchWait,omitempty" json:"batchWait,omitempty" doc:"maximum amount of time to wait before sending a batch"`
+	BatchSize           int                          `yaml:"batchSize,omitempty" json:"batchSize,omitempty" doc:"maximum batch size (in bytes) of logs to accumulate before sending"`
+	Timeout             string                       `yaml:"timeout,omitempty" json:"timeout,omitempty" doc:"maximum time to wait for a server to respond to a request"`
+	MinBackoff          string                       `yaml:"minBackoff,omitempty" json:"minBackoff,omitempty" doc:"initial backoff time for client connection between retries"`
+	MaxBackoff          string                       `yaml:"maxBackoff,omitempty" json:"maxBackoff,omitempty" doc:"maximum backoff time for client connection between retries"`
+	MaxRetries          int                          `yaml:"maxRetries,omitempty" json:"maxRetries,omitempty" doc:"maximum number of retries for client connections"`
+	Labels              []string                     `yaml:"labels,omitempty" json:"labels,omitempty" doc:"map of record fields to be used as labels"`
+	StaticLabels        model.LabelSet               `yaml:"staticLabels,omitempty" json:"staticLabels,omitempty" doc:"map of common labels to set on each flow"`
+	IgnoreList          []string                     `yaml:"ignoreList,omitempty" json:"ignoreList,omitempty" doc:"map of record fields to be removed from the record"`
+	ClientConfig        *promConfig.HTTPClientConfig `yaml:"clientConfig,omitempty" json:"clientConfig,omitempty" doc:"clientConfig"`
+	TimestampLabel      model.LabelName              `yaml:"timestampLabel,omitempty" json:"timestampLabel,omitempty" doc:"label to use for time indexing"`
 	// TimestampScale provides the scale in time of the units from the timestamp
 	// E.g. UNIX timescale is '1s' (one second) while other clock sources might have
 	// scales of '1ms' (one millisecond) or just '1' (one nanosecond)

--- a/pkg/pipeline/write/write_loki.go
+++ b/pkg/pipeline/write/write_loki.go
@@ -20,6 +20,7 @@ package write
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"math"
 	"strings"
 	"time"
@@ -85,11 +86,21 @@ func buildLokiConfig(c *api.WriteLoki) (loki.Config, error) {
 		return loki.Config{}, fmt.Errorf("failed in parsing MaxBackoff : %v", err)
 	}
 
+	authorization := ""
+	if c.BearerAuthTokenPath != "" {
+		bytes, err := ioutil.ReadFile(c.BearerAuthTokenPath)
+		if err != nil {
+			return loki.Config{}, fmt.Errorf("failed to parse authorization path: %s %w", c.BearerAuthTokenPath, err)
+		}
+		authorization = "Bearer " + string(bytes)
+	}
+
 	cfg := loki.Config{
-		TenantID:  c.TenantID,
-		BatchWait: batchWait,
-		BatchSize: c.BatchSize,
-		Timeout:   timeout,
+		TenantID:      c.TenantID,
+		Authorization: authorization,
+		BatchWait:     batchWait,
+		BatchSize:     c.BatchSize,
+		Timeout:       timeout,
 		BackoffConfig: backoff.BackoffConfig{
 			MinBackoff: minBackoff,
 			MaxBackoff: maxBackoff,


### PR DESCRIPTION
This PR adds Authorization header to loki write stage config loaded from specified `bearerAuthTokenPath` 

It will need [loki client go related PR](https://github.com/netobserv/loki-client-go/pull/1) and https://github.com/netobserv/flowlogs-pipeline/pull/263 to be merged first