### PR TITLE
Make yaml.Unmarshal strict

### DIFF
--- a/pkg/api/utils_test.go
+++ b/pkg/api/utils_test.go
@@ -37,6 +37,6 @@ func TestDuration_MarshalYAML(t *testing.T) {
 func TestDuration_UnmarshalYAML(t *testing.T) {
 	expectedMsg := testMessage{Elapsed: Duration{2 * time.Hour}}
 	var actualMsg testMessage
-	require.NoError(t, yaml.Unmarshal([]byte("elapsed: 2h\n"), &actualMsg))
+	require.NoError(t, yaml.UnmarshalStrict([]byte("elapsed: 2h\n"), &actualMsg))
 	require.Equal(t, expectedMsg, actualMsg)
 }

--- a/pkg/confgen/confgen_test.go
+++ b/pkg/confgen/confgen_test.go
@@ -55,7 +55,6 @@ encode:
     prefix: flp_
     port: 9102
 visualization:
-  type: grafana
   grafana:
     dashboards:
       - name: "details"
@@ -90,7 +89,6 @@ write:
     staticLabels:
       job: flowlogs-pipeline
 visualization:
-  type: grafana
   grafana:
     dashboards:
       - name: "details"

--- a/pkg/confgen/confgen_test.go
+++ b/pkg/confgen/confgen_test.go
@@ -107,7 +107,7 @@ details:
   test details
 usage:
   test usage
-labels:
+tags:
   - test
   - label
 transform:

--- a/pkg/confgen/config.go
+++ b/pkg/confgen/config.go
@@ -65,7 +65,7 @@ func (cg *ConfGen) ParseConfigFile(fileName string) (*Config, error) {
 		log.Debugf("ioutil.ReadFile err: %v ", err)
 		return nil, err
 	}
-	err = yaml.Unmarshal(yamlFile, &config)
+	err = yaml.UnmarshalStrict(yamlFile, &config)
 	if err != nil {
 		log.Debugf("Unmarshal err: %v ", err)
 		return nil, err


### PR DESCRIPTION
Using `yaml.UnmarshalStrict()` will prevent us from making typos in our yamls without being noticed.