### PR TITLE
Add to Transform Filter to support remove_entry_if_equal and remove_entry_if_not_equal

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ pipeline:
 Using `remove_entry_if_doesnt_exist` in the rule reverses the logic and will not remove the above example entry
 Using `remove_field` in the rule `type` instead, results in outputting the entry after
 removal of only the `SrcPort` key and value 
+Using `remove_entry_if_equal` will remove the entry if the specified field exists and is equal to the specified value.
+Using `remove_entry_if_not_equal` will remove the entry if the specified field exists and is not equal to the specified value.
 
 ### Transform Network
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -99,6 +99,14 @@ Following is the supported API format for filter transformations:
                      remove_field: removes the field from the entry
                      remove_entry_if_exists: removes the entry if the field exists
                      remove_entry_if_doesnt_exist: removes the entry if the field doesnt exist
+                     remove_entry_if_equal: removes the entry if the field value equals specified value
+                     remove_entry_if_not_equal: removes the entry if the field value does not equal specified value
+                 value: (enum) specified value of input field:
+                     remove_field: removes the field from the entry
+                     remove_entry_if_exists: removes the entry if the field exists
+                     remove_entry_if_doesnt_exist: removes the entry if the field doesnt exist
+                     remove_entry_if_equal: removes the entry if the field value equals specified value
+                     remove_entry_if_not_equal: removes the entry if the field value does not equal specified value
 </pre>
 ## Transform Network API
 Following is the supported API format for network transformations:

--- a/pkg/api/transform_filter.go
+++ b/pkg/api/transform_filter.go
@@ -25,6 +25,8 @@ type TransformFilterOperationEnum struct {
 	RemoveField              string `yaml:"remove_field" json:"remove_field" doc:"removes the field from the entry"`
 	RemoveEntryIfExists      string `yaml:"remove_entry_if_exists" json:"remove_entry_if_exists" doc:"removes the entry if the field exists"`
 	RemoveEntryIfDoesntExist string `yaml:"remove_entry_if_doesnt_exist" json:"remove_entry_if_doesnt_exist" doc:"removes the entry if the field doesnt exist"`
+	RemoveEntryIfEqual       string `yaml:"remove_entry_if_equal" json:"remove_entry_if_equal" doc:"removes the entry if the field value equals specified value"`
+	RemoveEntryIfNotEqual    string `yaml:"remove_entry_if_not_equal" json:"remove_entry_if_not_equal" doc:"removes the entry if the field value does not equal specified value"`
 }
 
 func TransformFilterOperationName(operation string) string {
@@ -32,6 +34,7 @@ func TransformFilterOperationName(operation string) string {
 }
 
 type TransformFilterRule struct {
-	Input string `yaml:"input,omitempty" json:"input,omitempty" doc:"entry input field"`
-	Type  string `yaml:"type,omitempty" json:"type,omitempty" enum:"TransformFilterOperationEnum" doc:"one of the following:"`
+	Input string      `yaml:"input,omitempty" json:"input,omitempty" doc:"entry input field"`
+	Type  string      `yaml:"type,omitempty" json:"type,omitempty" enum:"TransformFilterOperationEnum" doc:"one of the following:"`
+	Value interface{} `yaml:"value,omitempty" json:"value,omitempty" enum:"TransformFilterOperationEnum" doc:"specified value of input field:"`
 }

--- a/pkg/pipeline/transform/transform_filter.go
+++ b/pkg/pipeline/transform/transform_filter.go
@@ -48,6 +48,18 @@ func (f *Filter) Transform(input []config.GenericMap) []config.GenericMap {
 				if _, ok := entry[rule.Input]; !ok {
 					addToOutput = false
 				}
+			case api.TransformFilterOperationName("RemoveEntryIfEqual"):
+				if val, ok := entry[rule.Input]; ok {
+					if val == rule.Value {
+						addToOutput = false
+					}
+				}
+			case api.TransformFilterOperationName("RemoveEntryIfNotEqual"):
+				if val, ok := entry[rule.Input]; ok {
+					if val != rule.Value {
+						addToOutput = false
+					}
+				}
 			default:
 				log.Panicf("unknown type %s for transform.Filter rule: %v", rule.Type, rule)
 			}


### PR DESCRIPTION
Add to Transform Filter the ability to filter out flow logs based on whether a certain field is equal or not equal to some value.
This functionality is needed by Palmetto to filter out flow logs that do or do not satisfy some condition (such as direction of the flow).