### PR TITLE
NETOBSERV-396: Expose TLS configuration for prometheus endpoint

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,6 +19,10 @@ Following is the supported API format for prometheus encode:
          port: port number to expose "/metrics" endpoint
          prefix: prefix added to each metric name
          expiryTime: seconds of no-flow to wait before deleting prometheus data item
+         tls: TLS configuration for the prometheus endpoint
+             enable: set to true to enable tls for the prometheus endpoint
+             certFile: path to the certificate file
+             keyFile: path to the key file
 </pre>
 ## Kafka encode API
 Following is the supported API format for kafka encode:

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -18,9 +18,8 @@
 package api
 
 type PromTLSConf struct {
-	Enable   bool   `yaml:"enable,omitempty" json:"enable,omitempty" doc:"set to true to enable tls for the prometheus endpoint"`
-	CertFile string `yaml:"certFile,omitempty" json:"certFile,omitempty" doc:"path to the certificate file"`
-	KeyFile  string `yaml:"keyFile,omitempty" json:"keyFile,omitempty" doc:"path to the key file"`
+	CertPath string `yaml:"certPath,omitempty" json:"certPath,omitempty" doc:"path to the certificate file"`
+	KeyPath  string `yaml:"keyPath,omitempty" json:"keyPath,omitempty" doc:"path to the key file"`
 }
 
 type PromEncode struct {
@@ -28,7 +27,7 @@ type PromEncode struct {
 	Port       int              `yaml:"port,omitempty" json:"port,omitempty" doc:"port number to expose \"/metrics\" endpoint"`
 	Prefix     string           `yaml:"prefix,omitempty" json:"prefix,omitempty" doc:"prefix added to each metric name"`
 	ExpiryTime int              `yaml:"expiryTime,omitempty" json:"expiryTime,omitempty" doc:"seconds of no-flow to wait before deleting prometheus data item"`
-	TLS        PromTLSConf      `yaml:"tls,omitempty" json:"tls,omitempty" doc:"TLS configuration for the prometheus endpoint"`
+	TLS        *PromTLSConf     `yaml:"tls,omitempty" json:"tls,omitempty" doc:"TLS configuration for the prometheus endpoint"`
 }
 
 type PromEncodeOperationEnum struct {

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -17,11 +17,18 @@
 
 package api
 
+type PromTLSConf struct {
+	Enable   bool   `yaml:"enable,omitempty" json:"enable,omitempty" doc:"set to true to enable tls for the prometheus endpoint"`
+	CertFile string `yaml:"certFile,omitempty" json:"certFile,omitempty" doc:"path to the certificate file"`
+	KeyFile  string `yaml:"keyFile,omitempty" json:"keyFile,omitempty" doc:"path to the key file"`
+}
+
 type PromEncode struct {
 	Metrics    PromMetricsItems `yaml:"metrics,omitempty" json:"metrics,omitempty" doc:"list of prometheus metric definitions, each includes:"`
 	Port       int              `yaml:"port,omitempty" json:"port,omitempty" doc:"port number to expose \"/metrics\" endpoint"`
 	Prefix     string           `yaml:"prefix,omitempty" json:"prefix,omitempty" doc:"prefix added to each metric name"`
 	ExpiryTime int              `yaml:"expiryTime,omitempty" json:"expiryTime,omitempty" doc:"seconds of no-flow to wait before deleting prometheus data item"`
+	TLS        PromTLSConf      `yaml:"tls,omitempty" json:"tls,omitempty" doc:"TLS configuration for the prometheus endpoint"`
 }
 
 type PromEncodeOperationEnum struct {

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -160,7 +160,7 @@ func TestKafkaPromPipeline(t *testing.T) {
 
 	b, err = json.Marshal(params[4])
 	require.NoError(t, err)
-	require.Equal(t, `{"name":"prom","encode":{"type":"prom","prom":{"metrics":[{"name":"connections_per_source_as","type":"counter","filter":{"key":"name","value":"src_as_connection_count"},"valueKey":"recent_count","labels":["by","aggregate"],"buckets":[]}],"port":9090,"prefix":"flp_"}}}`, string(b))
+	require.Equal(t, `{"name":"prom","encode":{"type":"prom","prom":{"metrics":[{"name":"connections_per_source_as","type":"counter","filter":{"key":"name","value":"src_as_connection_count"},"valueKey":"recent_count","labels":["by","aggregate"],"buckets":[]}],"port":9090,"prefix":"flp_","tls":{}}}}`, string(b))
 }
 
 func TestForkPipeline(t *testing.T) {

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -160,7 +160,7 @@ func TestKafkaPromPipeline(t *testing.T) {
 
 	b, err = json.Marshal(params[4])
 	require.NoError(t, err)
-	require.Equal(t, `{"name":"prom","encode":{"type":"prom","prom":{"metrics":[{"name":"connections_per_source_as","type":"counter","filter":{"key":"name","value":"src_as_connection_count"},"valueKey":"recent_count","labels":["by","aggregate"],"buckets":[]}],"port":9090,"prefix":"flp_","tls":{}}}}`, string(b))
+	require.Equal(t, `{"name":"prom","encode":{"type":"prom","prom":{"metrics":[{"name":"connections_per_source_as","type":"counter","filter":{"key":"name","value":"src_as_connection_count"},"valueKey":"recent_count","labels":["by","aggregate"],"buckets":[]}],"port":9090,"prefix":"flp_"}}}`, string(b))
 }
 
 func TestForkPipeline(t *testing.T) {

--- a/pkg/pipeline/encode/encode_prom.go
+++ b/pkg/pipeline/encode/encode_prom.go
@@ -68,7 +68,7 @@ type EncodeProm struct {
 	prefix      string
 	metrics     map[string]metricInfo
 	expiryTime  int64
-	tlsConfig   api.PromTLSConf
+	tlsConfig   *api.PromTLSConf
 	mCache      *utils.TimedCache
 	exitChan    <-chan struct{}
 	PrevRecords []config.GenericMap
@@ -207,8 +207,8 @@ func startPrometheusInterface(w *EncodeProm) {
 	http.Handle("/metrics", promhttp.Handler())
 
 	var err error
-	if w.tlsConfig.Enable {
-		err = http.ListenAndServeTLS(w.port, w.tlsConfig.CertFile, w.tlsConfig.KeyFile, nil)
+	if w.tlsConfig != nil {
+		err = http.ListenAndServeTLS(w.port, w.tlsConfig.CertPath, w.tlsConfig.KeyPath, nil)
 	} else {
 		err = http.ListenAndServe(w.port, nil)
 	}

--- a/pkg/pipeline/encode/encode_prom_test.go
+++ b/pkg/pipeline/encode/encode_prom_test.go
@@ -41,6 +41,10 @@ parameters:
         port: 9103
         prefix: test_
         expiryTime: 1
+        tls:
+          enable: false
+          certFile: /path/to/cert
+          keyFile: /path/to/key
         metrics:
           - name: Bytes
             type: gauge
@@ -73,33 +77,6 @@ func initNewEncodeProm(t *testing.T) Encoder {
 	return newEncode
 }
 
-const testConfigTLS = `---
-log-level: debug
-pipeline:
-  - name: encode1
-parameters:
-  - name: encode1
-    encode:
-      type: prom
-      prom:
-        port: 9103
-        prefix: test_
-        expiryTime: 1
-        tls:
-          enable: true
-          certFile: /path/to/cert
-          keyFile: /path/to/key
-`
-
-func initNewEncodePromTLS(t *testing.T) Encoder {
-	v := test.InitConfig(t, testConfigTLS)
-	require.NotNil(t, v)
-
-	newEncode, err := NewEncodeProm(config.Parameters[0])
-	require.Equal(t, err, nil)
-	return newEncode
-}
-
 func Test_NewEncodeProm(t *testing.T) {
 	newEncode := initNewEncodeProm(t)
 	encodeProm := newEncode.(*EncodeProm)
@@ -107,6 +84,9 @@ func Test_NewEncodeProm(t *testing.T) {
 	require.Equal(t, "test_", encodeProm.prefix)
 	require.Equal(t, 3, len(encodeProm.metrics))
 	require.Equal(t, int64(1), encodeProm.expiryTime)
+	require.Equal(t, false, encodeProm.tlsConfig.Enable)
+	require.Equal(t, "/path/to/cert", encodeProm.tlsConfig.CertFile)
+	require.Equal(t, "/path/to/key", encodeProm.tlsConfig.KeyFile)
 
 	metrics := encodeProm.metrics
 	assert.Contains(t, metrics, "Bytes")

--- a/pkg/pipeline/encode/encode_prom_test.go
+++ b/pkg/pipeline/encode/encode_prom_test.go
@@ -73,6 +73,33 @@ func initNewEncodeProm(t *testing.T) Encoder {
 	return newEncode
 }
 
+const testConfigTLS = `---
+log-level: debug
+pipeline:
+  - name: encode1
+parameters:
+  - name: encode1
+    encode:
+      type: prom
+      prom:
+        port: 9103
+        prefix: test_
+        expiryTime: 1
+        tls:
+          enable: true
+          certFile: /path/to/cert
+          keyFile: /path/to/key
+`
+
+func initNewEncodePromTLS(t *testing.T) Encoder {
+	v := test.InitConfig(t, testConfigTLS)
+	require.NotNil(t, v)
+
+	newEncode, err := NewEncodeProm(config.Parameters[0])
+	require.Equal(t, err, nil)
+	return newEncode
+}
+
 func Test_NewEncodeProm(t *testing.T) {
 	newEncode := initNewEncodeProm(t)
 	encodeProm := newEncode.(*EncodeProm)

--- a/pkg/pipeline/encode/encode_prom_test.go
+++ b/pkg/pipeline/encode/encode_prom_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
@@ -41,10 +42,6 @@ parameters:
         port: 9103
         prefix: test_
         expiryTime: 1
-        tls:
-          enable: false
-          certFile: /path/to/cert
-          keyFile: /path/to/key
         metrics:
           - name: Bytes
             type: gauge
@@ -84,9 +81,7 @@ func Test_NewEncodeProm(t *testing.T) {
 	require.Equal(t, "test_", encodeProm.prefix)
 	require.Equal(t, 3, len(encodeProm.metrics))
 	require.Equal(t, int64(1), encodeProm.expiryTime)
-	require.Equal(t, false, encodeProm.tlsConfig.Enable)
-	require.Equal(t, "/path/to/cert", encodeProm.tlsConfig.CertFile)
-	require.Equal(t, "/path/to/key", encodeProm.tlsConfig.KeyFile)
+	require.Equal(t, (*api.PromTLSConf)(nil), encodeProm.tlsConfig)
 
 	metrics := encodeProm.metrics
 	assert.Contains(t, metrics, "Bytes")


### PR DESCRIPTION
This enable TLS configuration for the prometheus endpoint