### PR TITLE
Add breaking-change triage in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,8 @@
+changelog:
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
With this config, PRs labelled "breaking-change" will automatically be categorized as such in release notes