### PR TITLE
Add fake TLS keys to scan ignore list

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+[allowlist]
+  description = "Repo Allowlist"
+  paths = [
+    '''pkg/test/tls.go''',
+
+    # Ignore the .gitleaks.toml
+    '''\.gitleaks\.toml$''',
+  ]
+  regexes = [
+    # '''custom-regexes-to-ignore-here''',
+  ]


### PR DESCRIPTION
cf https://github.com/leaktk/fake-leaks/blob/main/.gitleaks.toml

Context: I've got a security alert triggered because of the fake certificates used there in tests.
We need to add this `gitleak` config file to mark that as false positive