### PR TITLE
change field names for extract_aggregate

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,13 +499,13 @@ parameters:
             - "dstIP"
             - "srcIP"
           operation: "avg"
-          recordKey: "value"
+          operationKey: "value"
 ```
 
 The output fields of the aggregates stage are:
 - `name`
 - `operation`
-- `record_key`
+- `operation_key`
 - `by`
 - `aggregate`
 - `total_value`: the total aggregate value

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Usage:
 Flags:  
       --config string        config file (default is $HOME/.flowlogs-pipeline)  
       --health.port string   Health server port (default "8080")  
-      --profile.port int     Go Pprof listen port (default disabled)
   -h, --help                 help for flowlogs-pipeline  
       --log-level string     Log level: debug, info, warning, error (default "error")  
       --parameters string    json of config file parameters field  
-      --pipeline string      json of config file pipeline field
+      --pipeline string      json of config file pipeline field  
+      --profile.port int     Go pprof tool port (default: disabled)
 ```
 <!---END-AUTO-flowlogs-pipeline_help--->
 

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -10,10 +10,8 @@ pipeline:
   follows: transform_network
 - name: extract_aggregate
   follows: extract_conntrack
-- name: extract_timebased
-  follows: extract_aggregate
 - name: encode_prom
-  follows: extract_timebased
+  follows: extract_aggregate
 - name: write_loki
   follows: extract_conntrack
 parameters:
@@ -118,24 +116,24 @@ parameters:
       - endConnection
       outputFields:
       - name: bytes_total
-        operationType: sum
+        operation: sum
         input: bytes
       - name: bytes
-        operationType: sum
+        operation: sum
         splitAB: true
       - name: packets_total
-        operationType: sum
+        operation: sum
         input: packets
       - name: packets
-        operationType: sum
+        operation: sum
         splitAB: true
       - name: numFlowLogs
-        operationType: count
+        operation: count
       - name: timeStart
-        operationType: min
+        operation: min
         input: timeReceived
       - name: timeEnd
-        operationType: max
+        operation: max
         input: timeReceived
       endConnectionTimeout: 30s
 - name: extract_aggregate
@@ -143,111 +141,100 @@ parameters:
     type: aggregates
     aggregates:
     - name: bandwidth_network_service
-      by:
+      groupByKeys:
       - service
       - _RecordType
       operationType: sum
       operationKey: bytes
     - name: bandwidth_source_destination_subnet
-      by:
+      groupByKeys:
       - dstSubnet24
       - srcSubnet24
       - _RecordType
       operationType: sum
       operationKey: bytes
     - name: bandwidth_source_subnet
-      by:
+      groupByKeys:
       - srcSubnet
       - _RecordType
       operationType: sum
       operationKey: bytes
     - name: connection_bytes_hist
-      by:
+      groupByKeys:
       - _RecordType
       operationType: raw_values
       operationKey: bytes_total
     - name: connection_bytes_hist_AB
-      by:
+      groupByKeys:
       - _RecordType
       operationType: raw_values
       operationKey: bytes_AB
     - name: connection_bytes_hist_BA
-      by:
+      groupByKeys:
       - _RecordType
       operationType: raw_values
       operationKey: bytes_BA
     - name: dest_connection_subnet_count
-      by:
+      groupByKeys:
       - dstSubnet
       - _RecordType
       operationType: count
       operationKey: isNewFlow
     - name: src_connection_count
-      by:
+      groupByKeys:
       - srcSubnet
       - _RecordType
       operationType: count
     - name: TCPFlags_count
-      by:
+      groupByKeys:
       - TCPFlags
       - _RecordType
       operationType: count
     - name: dst_as_connection_count
-      by:
+      groupByKeys:
       - dstAS
       - _RecordType
       operationType: count
     - name: src_as_connection_count
-      by:
+      groupByKeys:
       - srcAS
       - _RecordType
       operationType: count
     - name: count_source_destination_subnet
-      by:
+      groupByKeys:
       - dstSubnet24
       - srcSubnet24
       - _RecordType
       operationType: count
     - name: bandwidth_destination_subnet
-      by:
+      groupByKeys:
       - dstSubnet
       - _RecordType
       operationType: sum
       operationKey: bytes
     - name: bandwidth_namespace
-      by:
+      groupByKeys:
       - srcK8S_Namespace
       - srcK8S_Type
       - _RecordType
       operationType: sum
       operationKey: bytes
     - name: flows_bytes_hist
-      by:
+      groupByKeys:
       - all_Evaluate
       - _RecordType
       operationType: raw_values
       operationKey: bytes
     - name: dest_connection_location_count
-      by:
+      groupByKeys:
       - dstLocation_CountryName
       - _RecordType
       operationType: count
     - name: dest_service_count
-      by:
+      groupByKeys:
       - service
       - _RecordType
       operationType: count
-- name: extract_timebased
-  extract:
-    type: timebased
-    timebased:
-      rules:
-      - name: bandwidth_source_subnet
-        recordKey: srcSubnet
-        operation: sum
-        operationKey: total_value
-        topK: 5
-        timeInterval: 1m0s
 - name: encode_prom
   encode:
     type: prom
@@ -260,7 +247,7 @@ parameters:
           value: bandwidth_network_service
         valueKey: recent_op_value
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets: []
       - name: bandwidth_per_source_destination_subnet
@@ -270,17 +257,8 @@ parameters:
           value: bandwidth_source_destination_subnet
         valueKey: recent_op_value
         labels:
-        - by
+        - groupByKeys
         - aggregate
-        buckets: []
-      - name: bandwidth_per_source_subnet
-        type: gauge
-        filter:
-          key: name
-          value: bandwidth_source_subnet
-        valueKey: operation_result
-        labels:
-        - srcSubnet
         buckets: []
       - name: connection_size_histogram
         type: agg_histogram
@@ -289,7 +267,7 @@ parameters:
           value: connection_bytes_hist
         valueKey: recent_raw_values
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets:
         - 128
@@ -304,7 +282,7 @@ parameters:
           value: connection_bytes_hist_AB
         valueKey: recent_raw_values
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets:
         - 128
@@ -319,7 +297,7 @@ parameters:
           value: connection_bytes_hist_BA
         valueKey: recent_raw_values
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets:
         - 128
@@ -344,7 +322,7 @@ parameters:
           value: src_connection_count
         valueKey: recent_count
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets: []
       - name: connections_per_tcp_flags
@@ -354,7 +332,7 @@ parameters:
           value: TCPFlags_count
         valueKey: recent_count
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets: []
       - name: connections_per_destination_as
@@ -364,7 +342,7 @@ parameters:
           value: dst_as_connection_count
         valueKey: recent_count
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets: []
       - name: connections_per_source_as
@@ -374,7 +352,7 @@ parameters:
           value: src_as_connection_count
         valueKey: recent_count
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets: []
       - name: count_per_source_destination_subnet
@@ -384,7 +362,7 @@ parameters:
           value: count_source_destination_subnet
         valueKey: recent_count
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets: []
       - name: egress_per_destination_subnet
@@ -394,7 +372,7 @@ parameters:
           value: bandwidth_destination_subnet
         valueKey: recent_op_value
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets: []
       - name: egress_per_namespace
@@ -404,7 +382,7 @@ parameters:
           value: bandwidth_namespace
         valueKey: recent_op_value
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets: []
       - name: flows_length_histogram
@@ -414,7 +392,7 @@ parameters:
           value: flows_bytes_hist
         valueKey: recent_raw_values
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets:
         - 128
@@ -429,7 +407,7 @@ parameters:
           value: dest_connection_location_count
         valueKey: recent_count
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets: []
       - name: service_count
@@ -439,7 +417,7 @@ parameters:
           value: dest_service_count
         valueKey: recent_count
         labels:
-        - by
+        - groupByKeys
         - aggregate
         buckets: []
       port: 9102

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -118,24 +118,24 @@ parameters:
       - endConnection
       outputFields:
       - name: bytes_total
-        operation: sum
+        operationType: sum
         input: bytes
       - name: bytes
-        operation: sum
+        operationType: sum
         splitAB: true
       - name: packets_total
-        operation: sum
+        operationType: sum
         input: packets
       - name: packets
-        operation: sum
+        operationType: sum
         splitAB: true
       - name: numFlowLogs
-        operation: count
+        operationType: count
       - name: timeStart
-        operation: min
+        operationType: min
         input: timeReceived
       - name: timeEnd
-        operation: max
+        operationType: max
         input: timeReceived
       endConnectionTimeout: 30s
 - name: extract_aggregate
@@ -146,97 +146,97 @@ parameters:
       by:
       - service
       - _RecordType
-      operation: sum
+      operationType: sum
       operationKey: bytes
     - name: bandwidth_source_destination_subnet
       by:
       - dstSubnet24
       - srcSubnet24
       - _RecordType
-      operation: sum
+      operationType: sum
       operationKey: bytes
     - name: bandwidth_source_subnet
       by:
       - srcSubnet
       - _RecordType
-      operation: sum
+      operationType: sum
       operationKey: bytes
     - name: connection_bytes_hist
       by:
       - _RecordType
-      operation: raw_values
+      operationType: raw_values
       operationKey: bytes_total
     - name: connection_bytes_hist_AB
       by:
       - _RecordType
-      operation: raw_values
+      operationType: raw_values
       operationKey: bytes_AB
     - name: connection_bytes_hist_BA
       by:
       - _RecordType
-      operation: raw_values
+      operationType: raw_values
       operationKey: bytes_BA
     - name: dest_connection_subnet_count
       by:
       - dstSubnet
       - _RecordType
-      operation: count
+      operationType: count
       operationKey: isNewFlow
     - name: src_connection_count
       by:
       - srcSubnet
       - _RecordType
-      operation: count
+      operationType: count
     - name: TCPFlags_count
       by:
       - TCPFlags
       - _RecordType
-      operation: count
+      operationType: count
     - name: dst_as_connection_count
       by:
       - dstAS
       - _RecordType
-      operation: count
+      operationType: count
     - name: src_as_connection_count
       by:
       - srcAS
       - _RecordType
-      operation: count
+      operationType: count
     - name: count_source_destination_subnet
       by:
       - dstSubnet24
       - srcSubnet24
       - _RecordType
-      operation: count
+      operationType: count
     - name: bandwidth_destination_subnet
       by:
       - dstSubnet
       - _RecordType
-      operation: sum
+      operationType: sum
       operationKey: bytes
     - name: bandwidth_namespace
       by:
       - srcK8S_Namespace
       - srcK8S_Type
       - _RecordType
-      operation: sum
+      operationType: sum
       operationKey: bytes
     - name: flows_bytes_hist
       by:
       - all_Evaluate
       - _RecordType
-      operation: raw_values
+      operationType: raw_values
       operationKey: bytes
     - name: dest_connection_location_count
       by:
       - dstLocation_CountryName
       - _RecordType
-      operation: count
+      operationType: count
     - name: dest_service_count
       by:
       - service
       - _RecordType
-      operation: count
+      operationType: count
 - name: extract_timebased
   extract:
     type: timebased

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -147,40 +147,41 @@ parameters:
       - service
       - _RecordType
       operation: sum
-      recordKey: bytes
+      operationKey: bytes
     - name: bandwidth_source_destination_subnet
       by:
       - dstSubnet24
       - srcSubnet24
       - _RecordType
       operation: sum
-      recordKey: bytes
+      operationKey: bytes
     - name: bandwidth_source_subnet
       by:
       - srcSubnet
       - _RecordType
       operation: sum
-      recordKey: bytes
+      operationKey: bytes
     - name: connection_bytes_hist
       by:
       - _RecordType
       operation: raw_values
-      recordKey: bytes_total
+      operationKey: bytes_total
     - name: connection_bytes_hist_AB
       by:
       - _RecordType
       operation: raw_values
-      recordKey: bytes_AB
+      operationKey: bytes_AB
     - name: connection_bytes_hist_BA
       by:
       - _RecordType
       operation: raw_values
-      recordKey: bytes_BA
+      operationKey: bytes_BA
     - name: dest_connection_subnet_count
       by:
       - dstSubnet
       - _RecordType
       operation: count
+      operationKey: isNewFlow
     - name: src_connection_count
       by:
       - srcSubnet
@@ -212,20 +213,20 @@ parameters:
       - dstSubnet
       - _RecordType
       operation: sum
-      recordKey: bytes
+      operationKey: bytes
     - name: bandwidth_namespace
       by:
       - srcK8S_Namespace
       - srcK8S_Type
       - _RecordType
       operation: sum
-      recordKey: bytes
+      operationKey: bytes
     - name: flows_bytes_hist
       by:
       - all_Evaluate
       - _RecordType
       operation: raw_values
-      recordKey: bytes
+      operationKey: bytes
     - name: dest_connection_location_count
       by:
       - dstLocation_CountryName

--- a/docs/api.md
+++ b/docs/api.md
@@ -210,7 +210,7 @@ Following is the supported API format for specifying metrics time-based filters:
  timebased:
          rules: list of filter rules, each includes:
                  name: description of filter result
-                 recordKey: internal field to index TopK
+                 indexKey: internal field to index TopK
                  operationType: (enum) sum, min, max, avg, last or diff
                      sum: set output field to sum of parameters fields in the time window
                      avg: set output field to average of parameters fields in the time window

--- a/docs/api.md
+++ b/docs/api.md
@@ -211,7 +211,7 @@ Following is the supported API format for specifying metrics time-based filters:
          rules: list of filter rules, each includes:
                  name: description of filter result
                  recordKey: internal field to index TopK
-                 operation: (enum) sum, min, max, avg, last or diff
+                 operationType: (enum) sum, min, max, avg, last or diff
                      sum: set output field to sum of parameters fields in the time window
                      avg: set output field to average of parameters fields in the time window
                      min: set output field to minimum of parameters fields in the time window

--- a/docs/api.md
+++ b/docs/api.md
@@ -171,7 +171,7 @@ Following is the supported API format for specifying metrics aggregations:
          name: description of aggregation result
          by: list of fields on which to aggregate
          operation: sum, min, max, avg or raw_values
-         recordKey: internal field on which to perform the operation
+         operationKey: internal field on which to perform the operation
 </pre>
 ## Connection tracking API
 Following is the supported API format for specifying connection tracking:

--- a/docs/api.md
+++ b/docs/api.md
@@ -170,7 +170,7 @@ Following is the supported API format for specifying metrics aggregations:
  aggregates:
          name: description of aggregation result
          by: list of fields on which to aggregate
-         operation: sum, min, max, avg or raw_values
+         operationType: sum, min, max, avg or raw_values
          operationKey: internal field on which to perform the operation
 </pre>
 ## Connection tracking API

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,6 +73,8 @@ Following is the supported API format for the kafka ingest:
                  json: JSON decoder
                  protobuf: Protobuf decoder
          batchMaxLen: the number of accumulated flows before being forwarded for processing
+         pullBatchLen: the capacity of the queue use to store pulled flows
+         pullMaxBytes: the maximum number of bytes being pulled from kafka
          commitInterval: the interval (in milliseconds) at which offsets are committed to the broker.  If 0, commits will be handled synchronously.
          tls: TLS client configuration (optional)
              insecureSkipVerify: skip client verifying the server's certificate chain and host name

--- a/docs/api.md
+++ b/docs/api.md
@@ -169,7 +169,7 @@ Following is the supported API format for specifying metrics aggregations:
 <pre>
  aggregates:
          name: description of aggregation result
-         by: list of fields on which to aggregate
+         groupByKeys: list of fields on which to aggregate
          operationType: sum, min, max, avg or raw_values
          operationKey: internal field on which to perform the operation
 </pre>

--- a/docs/confGenerator.md
+++ b/docs/confGenerator.md
@@ -95,10 +95,10 @@ extract: (8)
   type: aggregates (8.1)
   aggregates:
     - name: aggregate_name (8.2)
-      by: (8.3)
+      groupByKeys: (8.3)
         - aggregateField1
         - aggregateField2
-      operation: operation (8.4)
+      operationType: operation (8.4)
 encode: (9)
   type: prom (9.1)
   prom:
@@ -133,7 +133,7 @@ As needed, (7.4) adds additional parameters to the operation.
 > on the fields refer to [api.md](api.md#transform-network-api). 
 
 (8) Next, the transformed log lines are aggregated using **mathematical 
-operation** (8.4) based on the `by` fields (8.3) - 
+operation** (8.4) based on the `groupByKeys` fields (8.3) - 
 this actually moves the data from being log lines into being a metric named (8.2)  
 > For additional details on `extract aggregates`
 > refer to [README.md](../README.md#aggregates).  

--- a/network_definitions/bandwidth_per_network_service.yaml
+++ b/network_definitions/bandwidth_per_network_service.yaml
@@ -19,7 +19,7 @@ transform:
 extract:
   aggregates:
     - name: bandwidth_network_service
-      by:
+      groupByKeys:
         - service
         - _RecordType
       operationType: sum
@@ -33,7 +33,7 @@ encode:
         filter: {key: name, value: bandwidth_network_service}
         valueKey: recent_op_value
         labels:
-          - by
+          - groupByKeys
           - aggregate
 visualization:
   type: grafana

--- a/network_definitions/bandwidth_per_network_service.yaml
+++ b/network_definitions/bandwidth_per_network_service.yaml
@@ -23,7 +23,7 @@ extract:
         - service
         - _RecordType
       operation: sum
-      recordKey: bytes
+      operationKey: bytes
 encode:
   type: prom
   prom:

--- a/network_definitions/bandwidth_per_network_service.yaml
+++ b/network_definitions/bandwidth_per_network_service.yaml
@@ -22,7 +22,7 @@ extract:
       by:
         - service
         - _RecordType
-      operation: sum
+      operationType: sum
       operationKey: bytes
 encode:
   type: prom

--- a/network_definitions/bandwidth_per_src_dest_subnet.yaml
+++ b/network_definitions/bandwidth_per_src_dest_subnet.yaml
@@ -27,7 +27,7 @@ extract:
         - dstSubnet24
         - srcSubnet24
         - _RecordType
-      operation: sum
+      operationType: sum
       operationKey: bytes
 encode:
   type: prom

--- a/network_definitions/bandwidth_per_src_dest_subnet.yaml
+++ b/network_definitions/bandwidth_per_src_dest_subnet.yaml
@@ -28,7 +28,7 @@ extract:
         - srcSubnet24
         - _RecordType
       operation: sum
-      recordKey: bytes
+      operationKey: bytes
 encode:
   type: prom
   prom:

--- a/network_definitions/bandwidth_per_src_dest_subnet.yaml
+++ b/network_definitions/bandwidth_per_src_dest_subnet.yaml
@@ -23,7 +23,7 @@ transform:
 extract:
   aggregates:
     - name: bandwidth_source_destination_subnet
-      by:
+      groupByKeys:
         - dstSubnet24
         - srcSubnet24
         - _RecordType
@@ -38,7 +38,7 @@ encode:
         filter: {key: name, value: bandwidth_source_destination_subnet}
         valueKey: recent_op_value
         labels:
-          - by
+          - groupByKeys
           - aggregate
 visualization:
   type: grafana

--- a/network_definitions/bandwidth_per_src_subnet.yaml
+++ b/network_definitions/bandwidth_per_src_subnet.yaml
@@ -23,7 +23,7 @@ extract:
         - srcSubnet
         - _RecordType
       operation: sum
-      recordKey: bytes
+      operationKey: bytes
   timebased:
     rules:
       - name: bandwidth_source_subnet

--- a/network_definitions/bandwidth_per_src_subnet.yaml
+++ b/network_definitions/bandwidth_per_src_subnet.yaml
@@ -19,7 +19,7 @@ transform:
 extract:
   aggregates:
     - name: bandwidth_source_subnet
-      by:
+      groupByKeys:
         - srcSubnet
         - _RecordType
       operationType: sum

--- a/network_definitions/bandwidth_per_src_subnet.yaml
+++ b/network_definitions/bandwidth_per_src_subnet.yaml
@@ -22,7 +22,7 @@ extract:
       by:
         - srcSubnet
         - _RecordType
-      operation: sum
+      operationType: sum
       operationKey: bytes
   timebased:
     rules:

--- a/network_definitions/config.yaml
+++ b/network_definitions/config.yaml
@@ -61,24 +61,24 @@ extract:
         fieldGroupBRef: dst
     outputFields:
       - name: bytes_total
-        operationType: sum
+        operation: sum
         input: bytes
       - name: bytes
-        operationType: sum
+        operation: sum
         splitAB: true
       - name: packets_total
-        operationType: sum
+        operation: sum
         input: packets
       - name: packets
-        operationType: sum
+        operation: sum
         splitAB: true
       - name: numFlowLogs
-        operationType: count
+        operation: count
       - name: timeStart
-        operationType: min
+        operation: min
         input: timeReceived
       - name: timeEnd
-        operationType: max
+        operation: max
         input: timeReceived
 encode:
   prom:

--- a/network_definitions/config.yaml
+++ b/network_definitions/config.yaml
@@ -61,24 +61,24 @@ extract:
         fieldGroupBRef: dst
     outputFields:
       - name: bytes_total
-        operation: sum
+        operationType: sum
         input: bytes
       - name: bytes
-        operation: sum
+        operationType: sum
         splitAB: true
       - name: packets_total
-        operation: sum
+        operationType: sum
         input: packets
       - name: packets
-        operation: sum
+        operationType: sum
         splitAB: true
       - name: numFlowLogs
-        operation: count
+        operationType: count
       - name: timeStart
-        operation: min
+        operationType: min
         input: timeReceived
       - name: timeEnd
-        operation: max
+        operationType: max
         input: timeReceived
 encode:
   prom:

--- a/network_definitions/connection_length_histogram.yaml
+++ b/network_definitions/connection_length_histogram.yaml
@@ -16,17 +16,17 @@ extract:
       by:
         - _RecordType
       operation: raw_values
-      recordKey: bytes_total
+      operationKey: bytes_total
     - name: connection_bytes_hist_AB
       by:
         - _RecordType
       operation: raw_values
-      recordKey: bytes_AB
+      operationKey: bytes_AB
     - name: connection_bytes_hist_BA
       by:
         - _RecordType
       operation: raw_values
-      recordKey: bytes_BA
+      operationKey: bytes_BA
 encode:
   type: prom
   prom:

--- a/network_definitions/connection_length_histogram.yaml
+++ b/network_definitions/connection_length_histogram.yaml
@@ -13,17 +13,17 @@ tags:
 extract:
   aggregates:
     - name: connection_bytes_hist
-      by:
+      groupByKeys:
         - _RecordType
       operationType: raw_values
       operationKey: bytes_total
     - name: connection_bytes_hist_AB
-      by:
+      groupByKeys:
         - _RecordType
       operationType: raw_values
       operationKey: bytes_AB
     - name: connection_bytes_hist_BA
-      by:
+      groupByKeys:
         - _RecordType
       operationType: raw_values
       operationKey: bytes_BA
@@ -36,7 +36,7 @@ encode:
         filter: { key: name, value: connection_bytes_hist }
         valueKey: recent_raw_values
         labels:
-          - by
+          - groupByKeys
           - aggregate
         buckets:
           - 128
@@ -49,7 +49,7 @@ encode:
         filter: { key: name, value: connection_bytes_hist_AB }
         valueKey: recent_raw_values
         labels:
-          - by
+          - groupByKeys
           - aggregate
         buckets:
           - 128
@@ -62,7 +62,7 @@ encode:
         filter: { key: name, value: connection_bytes_hist_BA }
         valueKey: recent_raw_values
         labels:
-          - by
+          - groupByKeys
           - aggregate
         buckets:
           - 128

--- a/network_definitions/connection_length_histogram.yaml
+++ b/network_definitions/connection_length_histogram.yaml
@@ -15,17 +15,17 @@ extract:
     - name: connection_bytes_hist
       by:
         - _RecordType
-      operation: raw_values
+      operationType: raw_values
       operationKey: bytes_total
     - name: connection_bytes_hist_AB
       by:
         - _RecordType
-      operation: raw_values
+      operationType: raw_values
       operationKey: bytes_AB
     - name: connection_bytes_hist_BA
       by:
         - _RecordType
-      operation: raw_values
+      operationType: raw_values
       operationKey: bytes_BA
 encode:
   type: prom

--- a/network_definitions/connection_rate_per_dest_subnet.yaml
+++ b/network_definitions/connection_rate_per_dest_subnet.yaml
@@ -21,7 +21,7 @@ extract:
       by:
         - dstSubnet
         - _RecordType
-      operation: count
+      operationType: count
       operationKey: isNewFlow
 encode:
   type: prom

--- a/network_definitions/connection_rate_per_dest_subnet.yaml
+++ b/network_definitions/connection_rate_per_dest_subnet.yaml
@@ -18,7 +18,7 @@ extract:
   type: aggregates
   aggregates:
     - name: dest_connection_subnet_count
-      by:
+      groupByKeys:
         - dstSubnet
         - _RecordType
       operationType: count

--- a/network_definitions/connection_rate_per_dest_subnet.yaml
+++ b/network_definitions/connection_rate_per_dest_subnet.yaml
@@ -22,6 +22,7 @@ extract:
         - dstSubnet
         - _RecordType
       operation: count
+      operationKey: isNewFlow
 encode:
   type: prom
   prom:

--- a/network_definitions/connection_rate_per_src_subnet.yaml
+++ b/network_definitions/connection_rate_per_src_subnet.yaml
@@ -18,7 +18,7 @@ extract:
   type: aggregates
   aggregates:
     - name: src_connection_count
-      by:
+      groupByKeys:
         - srcSubnet
         - _RecordType
       operationType: count
@@ -31,7 +31,7 @@ encode:
         filter: {key: name, value: src_connection_count}
         valueKey: recent_count
         labels:
-          - by
+          - groupByKeys
           - aggregate
 visualization:
   type: grafana

--- a/network_definitions/connection_rate_per_src_subnet.yaml
+++ b/network_definitions/connection_rate_per_src_subnet.yaml
@@ -21,7 +21,7 @@ extract:
       by:
         - srcSubnet
         - _RecordType
-      operation: count
+      operationType: count
 encode:
   type: prom
   prom:

--- a/network_definitions/connection_rate_per_tcp_flags.yaml
+++ b/network_definitions/connection_rate_per_tcp_flags.yaml
@@ -15,7 +15,7 @@ extract:
       by:
         - TCPFlags
         - _RecordType
-      operation: count
+      operationType: count
 encode:
   type: prom
   prom:

--- a/network_definitions/connection_rate_per_tcp_flags.yaml
+++ b/network_definitions/connection_rate_per_tcp_flags.yaml
@@ -12,7 +12,7 @@ extract:
   type: aggregates
   aggregates:
     - name: TCPFlags_count
-      by:
+      groupByKeys:
         - TCPFlags
         - _RecordType
       operationType: count
@@ -25,7 +25,7 @@ encode:
         filter: { key: name, value: TCPFlags_count }
         valueKey: recent_count
         labels:
-          - by
+          - groupByKeys
           - aggregate
 visualization:
   type: grafana

--- a/network_definitions/connections_per_dst_as.yaml
+++ b/network_definitions/connections_per_dst_as.yaml
@@ -13,7 +13,7 @@ extract:
   type: aggregates
   aggregates:
     - name: dst_as_connection_count
-      by:
+      groupByKeys:
         - dstAS
         - _RecordType
       operationType: count
@@ -26,7 +26,7 @@ encode:
         filter: { key: name, value: dst_as_connection_count }
         valueKey: recent_count
         labels:
-          - by
+          - groupByKeys
           - aggregate
 visualization:
   type: grafana

--- a/network_definitions/connections_per_dst_as.yaml
+++ b/network_definitions/connections_per_dst_as.yaml
@@ -16,7 +16,7 @@ extract:
       by:
         - dstAS
         - _RecordType
-      operation: count
+      operationType: count
 encode:
   type: prom
   prom:

--- a/network_definitions/connections_per_src_as.yaml
+++ b/network_definitions/connections_per_src_as.yaml
@@ -16,7 +16,7 @@ extract:
       by:
         - srcAS
         - _RecordType
-      operation: count
+      operationType: count
 encode:
   type: prom
   prom:

--- a/network_definitions/connections_per_src_as.yaml
+++ b/network_definitions/connections_per_src_as.yaml
@@ -13,7 +13,7 @@ extract:
   type: aggregates
   aggregates:
     - name: src_as_connection_count
-      by:
+      groupByKeys:
         - srcAS
         - _RecordType
       operationType: count
@@ -26,7 +26,7 @@ encode:
         filter: { key: name, value: src_as_connection_count }
         valueKey: recent_count
         labels:
-          - by
+          - groupByKeys
           - aggregate
 visualization:
   type: grafana

--- a/network_definitions/count_per_src_dest_subnet.yaml
+++ b/network_definitions/count_per_src_dest_subnet.yaml
@@ -27,7 +27,7 @@ extract:
         - dstSubnet24
         - srcSubnet24
         - _RecordType
-      operation: count
+      operationType: count
 encode:
   type: prom
   prom:

--- a/network_definitions/count_per_src_dest_subnet.yaml
+++ b/network_definitions/count_per_src_dest_subnet.yaml
@@ -23,7 +23,7 @@ transform:
 extract:
   aggregates:
     - name: count_source_destination_subnet
-      by:
+      groupByKeys:
         - dstSubnet24
         - srcSubnet24
         - _RecordType
@@ -37,7 +37,7 @@ encode:
         filter: { key: name, value: count_source_destination_subnet }
         valueKey: recent_count
         labels:
-          - by
+          - groupByKeys
           - aggregate
 visualization:
   type: grafana

--- a/network_definitions/egress_bandwidth_per_dest_subnet.yaml
+++ b/network_definitions/egress_bandwidth_per_dest_subnet.yaml
@@ -23,7 +23,7 @@ extract:
         - dstSubnet
         - _RecordType
       operation: sum
-      recordKey: bytes
+      operationKey: bytes
 encode:
   type: prom
   prom:

--- a/network_definitions/egress_bandwidth_per_dest_subnet.yaml
+++ b/network_definitions/egress_bandwidth_per_dest_subnet.yaml
@@ -19,7 +19,7 @@ transform:
 extract:
   aggregates:
     - name: bandwidth_destination_subnet
-      by:
+      groupByKeys:
         - dstSubnet
         - _RecordType
       operationType: sum
@@ -33,7 +33,7 @@ encode:
         filter: { key: name, value: bandwidth_destination_subnet }
         valueKey: recent_op_value
         labels:
-          - by
+          - groupByKeys
           - aggregate
 visualization:
   type: grafana

--- a/network_definitions/egress_bandwidth_per_dest_subnet.yaml
+++ b/network_definitions/egress_bandwidth_per_dest_subnet.yaml
@@ -22,7 +22,7 @@ extract:
       by:
         - dstSubnet
         - _RecordType
-      operation: sum
+      operationType: sum
       operationKey: bytes
 encode:
   type: prom

--- a/network_definitions/egress_bandwidth_per_namespace.yaml
+++ b/network_definitions/egress_bandwidth_per_namespace.yaml
@@ -18,7 +18,7 @@ transform:
 extract:
   aggregates:
     - name: bandwidth_namespace
-      by:
+      groupByKeys:
         - srcK8S_Namespace
         - srcK8S_Type
         - _RecordType
@@ -33,7 +33,7 @@ encode:
         filter: { key: name, value: bandwidth_namespace }
         valueKey: recent_op_value
         labels:
-          - by
+          - groupByKeys
           - aggregate
 visualization:
   type: grafana

--- a/network_definitions/egress_bandwidth_per_namespace.yaml
+++ b/network_definitions/egress_bandwidth_per_namespace.yaml
@@ -22,7 +22,7 @@ extract:
         - srcK8S_Namespace
         - srcK8S_Type
         - _RecordType
-      operation: sum
+      operationType: sum
       operationKey: bytes
 encode:
   type: prom

--- a/network_definitions/egress_bandwidth_per_namespace.yaml
+++ b/network_definitions/egress_bandwidth_per_namespace.yaml
@@ -23,7 +23,7 @@ extract:
         - srcK8S_Type
         - _RecordType
       operation: sum
-      recordKey: bytes
+      operationKey: bytes
 encode:
   type: prom
   prom:

--- a/network_definitions/flows_length_histogram.yaml
+++ b/network_definitions/flows_length_histogram.yaml
@@ -22,7 +22,7 @@ extract:
       by:
         - all_Evaluate
         - _RecordType
-      operation: raw_values
+      operationType: raw_values
       operationKey: bytes
 encode:
   type: prom

--- a/network_definitions/flows_length_histogram.yaml
+++ b/network_definitions/flows_length_histogram.yaml
@@ -23,7 +23,7 @@ extract:
         - all_Evaluate
         - _RecordType
       operation: raw_values
-      recordkey: bytes
+      operationKey: bytes
 encode:
   type: prom
   prom:

--- a/network_definitions/flows_length_histogram.yaml
+++ b/network_definitions/flows_length_histogram.yaml
@@ -19,7 +19,7 @@ transform:
 extract:
   aggregates:
     - name: flows_bytes_hist
-      by:
+      groupByKeys:
         - all_Evaluate
         - _RecordType
       operationType: raw_values
@@ -33,7 +33,7 @@ encode:
         filter: { key: name, value: flows_bytes_hist }
         valueKey: recent_raw_values
         labels:
-          - by
+          - groupByKeys
           - aggregate
         buckets:
           - 128

--- a/network_definitions/geo-location_rate_per_dest.yaml
+++ b/network_definitions/geo-location_rate_per_dest.yaml
@@ -19,7 +19,7 @@ extract:
   type: aggregates
   aggregates:
     - name: dest_connection_location_count
-      by:
+      groupByKeys:
         - dstLocation_CountryName
         - _RecordType
       operationType: count
@@ -32,7 +32,7 @@ encode:
         filter: { key: name, value: dest_connection_location_count }
         valueKey: recent_count
         labels:
-          - by
+          - groupByKeys
           - aggregate
 visualization:
   type: grafana

--- a/network_definitions/geo-location_rate_per_dest.yaml
+++ b/network_definitions/geo-location_rate_per_dest.yaml
@@ -22,7 +22,7 @@ extract:
       by:
         - dstLocation_CountryName
         - _RecordType
-      operation: count
+      operationType: count
 encode:
   type: prom
   prom:

--- a/network_definitions/network_services_count.yaml
+++ b/network_definitions/network_services_count.yaml
@@ -20,7 +20,7 @@ extract:
   type: aggregates
   aggregates:
     - name: dest_service_count
-      by:
+      groupByKeys:
         - service
         - _RecordType
       operationType: count
@@ -33,7 +33,7 @@ encode:
         filter: { key: name, value: dest_service_count }
         valueKey: recent_count
         labels:
-          - by
+          - groupByKeys
           - aggregate
 visualization:
   type: grafana

--- a/network_definitions/network_services_count.yaml
+++ b/network_definitions/network_services_count.yaml
@@ -23,7 +23,7 @@ extract:
       by:
         - service
         - _RecordType
-      operation: count
+      operationType: count
 encode:
   type: prom
   prom:

--- a/pkg/api/extract_aggregate.go
+++ b/pkg/api/extract_aggregate.go
@@ -21,8 +21,8 @@ type AggregateBy []string
 type AggregateOperation string
 
 type AggregateDefinition struct {
-	Name         string             `yaml:"name,omitempty" json:"name,omitempty" doc:"description of aggregation result"`
-	By           AggregateBy        `yaml:"by,omitempty" json:"by,omitempty" doc:"list of fields on which to aggregate"`
-	Operation    AggregateOperation `yaml:"operation,omitempty" json:"operation,omitempty" doc:"sum, min, max, avg or raw_values"`
-	OperationKey string             `yaml:"operationKey,omitempty" json:"operationKey,omitempty" doc:"internal field on which to perform the operation"`
+	Name          string             `yaml:"name,omitempty" json:"name,omitempty" doc:"description of aggregation result"`
+	By            AggregateBy        `yaml:"by,omitempty" json:"by,omitempty" doc:"list of fields on which to aggregate"`
+	OperationType AggregateOperation `yaml:"operationType,omitempty" json:"operationType,omitempty" doc:"sum, min, max, avg or raw_values"`
+	OperationKey  string             `yaml:"operationKey,omitempty" json:"operationKey,omitempty" doc:"internal field on which to perform the operation"`
 }

--- a/pkg/api/extract_aggregate.go
+++ b/pkg/api/extract_aggregate.go
@@ -21,8 +21,8 @@ type AggregateBy []string
 type AggregateOperation string
 
 type AggregateDefinition struct {
-	Name      string             `yaml:"name,omitempty" json:"name,omitempty" doc:"description of aggregation result"`
-	By        AggregateBy        `yaml:"by,omitempty" json:"by,omitempty" doc:"list of fields on which to aggregate"`
-	Operation AggregateOperation `yaml:"operation,omitempty" json:"operation,omitempty" doc:"sum, min, max, avg or raw_values"`
-	RecordKey string             `yaml:"recordKey,omitempty" json:"recordKey,omitempty" doc:"internal field on which to perform the operation"`
+	Name         string             `yaml:"name,omitempty" json:"name,omitempty" doc:"description of aggregation result"`
+	By           AggregateBy        `yaml:"by,omitempty" json:"by,omitempty" doc:"list of fields on which to aggregate"`
+	Operation    AggregateOperation `yaml:"operation,omitempty" json:"operation,omitempty" doc:"sum, min, max, avg or raw_values"`
+	OperationKey string             `yaml:"operationKey,omitempty" json:"operationKey,omitempty" doc:"internal field on which to perform the operation"`
 }

--- a/pkg/api/extract_aggregate.go
+++ b/pkg/api/extract_aggregate.go
@@ -22,7 +22,7 @@ type AggregateOperation string
 
 type AggregateDefinition struct {
 	Name          string             `yaml:"name,omitempty" json:"name,omitempty" doc:"description of aggregation result"`
-	By            AggregateBy        `yaml:"by,omitempty" json:"by,omitempty" doc:"list of fields on which to aggregate"`
+	GroupByKeys   AggregateBy        `yaml:"groupByKeys,omitempty" json:"groupByKeys,omitempty" doc:"list of fields on which to aggregate"`
 	OperationType AggregateOperation `yaml:"operationType,omitempty" json:"operationType,omitempty" doc:"sum, min, max, avg or raw_values"`
 	OperationKey  string             `yaml:"operationKey,omitempty" json:"operationKey,omitempty" doc:"internal field on which to perform the operation"`
 }

--- a/pkg/api/extract_timebased.go
+++ b/pkg/api/extract_timebased.go
@@ -35,11 +35,11 @@ type ExtractTimebased struct {
 }
 
 type TimebasedFilterRule struct {
-	Name         string   `yaml:"name,omitempty" json:"name,omitempty" doc:"description of filter result"`
-	RecordKey    string   `yaml:"recordKey,omitempty" json:"recordKey,omitempty" doc:"internal field to index TopK"`
-	Operation    string   `yaml:"operation,omitempty" json:"operation,omitempty" enum:"FilterOperationEnum" doc:"sum, min, max, avg, last or diff"`
-	OperationKey string   `yaml:"operationKey,omitempty" json:"operationKey,omitempty" doc:"internal field on which to perform the operation"`
-	TopK         int      `yaml:"topK,omitempty" json:"topK,omitempty" doc:"number of highest incidence to report (default - report all)"`
-	Reversed     bool     `yaml:"reversed,omitempty" json:"reversed,omitempty" doc:"report lowest incidence instead of highest (default - false)"`
-	TimeInterval Duration `yaml:"timeInterval,omitempty" json:"timeInterval,omitempty" doc:"time duration of data to use to compute the metric"`
+	Name          string   `yaml:"name,omitempty" json:"name,omitempty" doc:"description of filter result"`
+	RecordKey     string   `yaml:"recordKey,omitempty" json:"recordKey,omitempty" doc:"internal field to index TopK"`
+	OperationType string   `yaml:"operationType,omitempty" json:"operationType,omitempty" enum:"FilterOperationEnum" doc:"sum, min, max, avg, last or diff"`
+	OperationKey  string   `yaml:"operationKey,omitempty" json:"operationKey,omitempty" doc:"internal field on which to perform the operation"`
+	TopK          int      `yaml:"topK,omitempty" json:"topK,omitempty" doc:"number of highest incidence to report (default - report all)"`
+	Reversed      bool     `yaml:"reversed,omitempty" json:"reversed,omitempty" doc:"report lowest incidence instead of highest (default - false)"`
+	TimeInterval  Duration `yaml:"timeInterval,omitempty" json:"timeInterval,omitempty" doc:"time duration of data to use to compute the metric"`
 }

--- a/pkg/api/extract_timebased.go
+++ b/pkg/api/extract_timebased.go
@@ -36,7 +36,7 @@ type ExtractTimebased struct {
 
 type TimebasedFilterRule struct {
 	Name          string   `yaml:"name,omitempty" json:"name,omitempty" doc:"description of filter result"`
-	RecordKey     string   `yaml:"recordKey,omitempty" json:"recordKey,omitempty" doc:"internal field to index TopK"`
+	IndexKey      string   `yaml:"indexKey,omitempty" json:"indexKey,omitempty" doc:"internal field to index TopK"`
 	OperationType string   `yaml:"operationType,omitempty" json:"operationType,omitempty" enum:"FilterOperationEnum" doc:"sum, min, max, avg, last or diff"`
 	OperationKey  string   `yaml:"operationKey,omitempty" json:"operationKey,omitempty" doc:"internal field on which to perform the operation"`
 	TopK          int      `yaml:"topK,omitempty" json:"topK,omitempty" doc:"number of highest incidence to report (default - report all)"`

--- a/pkg/confgen/confgen_test.go
+++ b/pkg/confgen/confgen_test.go
@@ -131,10 +131,10 @@ func Test_RunShortConfGen(t *testing.T) {
 	// Expects aggregates
 	require.Len(t, out.Parameters[2].Extract.Aggregates, 1)
 	require.Equal(t, api.AggregateDefinition{
-		Name:         "test_aggregates",
-		By:           api.AggregateBy{"service"},
-		Operation:    "sum",
-		OperationKey: "test_operation_key",
+		Name:          "test_aggregates",
+		By:            api.AggregateBy{"service"},
+		OperationType: "sum",
+		OperationKey:  "test_operation_key",
 	}, out.Parameters[2].Extract.Aggregates[0])
 
 	// Expects prom encode
@@ -304,16 +304,16 @@ func Test_RunLongConfGen(t *testing.T) {
 	// Expects aggregates
 	require.Len(t, out.Parameters[3].Extract.Aggregates, 2)
 	require.Equal(t, api.AggregateDefinition{
-		Name:         "test_aggregates",
-		By:           api.AggregateBy{"service"},
-		Operation:    "sum",
-		OperationKey: "test_operation_key",
+		Name:          "test_aggregates",
+		By:            api.AggregateBy{"service"},
+		OperationType: "sum",
+		OperationKey:  "test_operation_key",
 	}, out.Parameters[3].Extract.Aggregates[0])
 	require.Equal(t, api.AggregateDefinition{
-		Name:         "test_agg_histo",
-		By:           api.AggregateBy{"service"},
-		Operation:    "sum",
-		OperationKey: "test_operation_key",
+		Name:          "test_agg_histo",
+		By:            api.AggregateBy{"service"},
+		OperationType: "sum",
+		OperationKey:  "test_operation_key",
 	}, out.Parameters[3].Extract.Aggregates[1])
 
 	// Expects prom encode; make sure type "histogram" is changed to "agg_histogram"
@@ -360,10 +360,10 @@ func Test_GenerateTruncatedConfig(t *testing.T) {
 	// Expects aggregates
 	require.Len(t, params[0].Extract.Aggregates, 1)
 	require.Equal(t, api.AggregateDefinition{
-		Name:         "test_aggregates",
-		By:           api.AggregateBy{"service"},
-		Operation:    "sum",
-		OperationKey: "test_operation_key",
+		Name:          "test_aggregates",
+		By:            api.AggregateBy{"service"},
+		OperationType: "sum",
+		OperationKey:  "test_operation_key",
 	}, params[0].Extract.Aggregates[0])
 
 	// Expects prom encode

--- a/pkg/confgen/confgen_test.go
+++ b/pkg/confgen/confgen_test.go
@@ -132,7 +132,7 @@ func Test_RunShortConfGen(t *testing.T) {
 	require.Len(t, out.Parameters[2].Extract.Aggregates, 1)
 	require.Equal(t, api.AggregateDefinition{
 		Name:          "test_aggregates",
-		By:            api.AggregateBy{"service"},
+		GroupByKeys:   api.AggregateBy{"service"},
 		OperationType: "sum",
 		OperationKey:  "test_operation_key",
 	}, out.Parameters[2].Extract.Aggregates[0])
@@ -147,7 +147,7 @@ func Test_RunShortConfGen(t *testing.T) {
 			Type:     "gauge",
 			Filter:   api.PromMetricsFilter{Key: "", Value: ""},
 			ValueKey: "test_aggregates_value",
-			Labels:   []string{"by", "aggregate"},
+			Labels:   []string{"groupByKeys", "aggregate"},
 			Buckets:  []float64{},
 		}},
 	}, out.Parameters[3].Encode.Prom)
@@ -305,13 +305,13 @@ func Test_RunLongConfGen(t *testing.T) {
 	require.Len(t, out.Parameters[3].Extract.Aggregates, 2)
 	require.Equal(t, api.AggregateDefinition{
 		Name:          "test_aggregates",
-		By:            api.AggregateBy{"service"},
+		GroupByKeys:   api.AggregateBy{"service"},
 		OperationType: "sum",
 		OperationKey:  "test_operation_key",
 	}, out.Parameters[3].Extract.Aggregates[0])
 	require.Equal(t, api.AggregateDefinition{
 		Name:          "test_agg_histo",
-		By:            api.AggregateBy{"service"},
+		GroupByKeys:   api.AggregateBy{"service"},
 		OperationType: "sum",
 		OperationKey:  "test_operation_key",
 	}, out.Parameters[3].Extract.Aggregates[1])
@@ -326,14 +326,14 @@ func Test_RunLongConfGen(t *testing.T) {
 			Type:     "gauge",
 			Filter:   api.PromMetricsFilter{Key: "", Value: ""},
 			ValueKey: "test_aggregates_value",
-			Labels:   []string{"by", "aggregate"},
+			Labels:   []string{"groupByKeys", "aggregate"},
 			Buckets:  []float64{},
 		}, {
 			Name:     "test_histo",
 			Type:     "agg_histogram",
 			Filter:   api.PromMetricsFilter{Key: "", Value: ""},
 			ValueKey: "test_aggregates_value",
-			Labels:   []string{"by", "aggregate"},
+			Labels:   []string{"groupByKeys", "aggregate"},
 			Buckets:  []float64{},
 		}},
 	}, out.Parameters[4].Encode.Prom)
@@ -361,7 +361,7 @@ func Test_GenerateTruncatedConfig(t *testing.T) {
 	require.Len(t, params[0].Extract.Aggregates, 1)
 	require.Equal(t, api.AggregateDefinition{
 		Name:          "test_aggregates",
-		By:            api.AggregateBy{"service"},
+		GroupByKeys:   api.AggregateBy{"service"},
 		OperationType: "sum",
 		OperationKey:  "test_operation_key",
 	}, params[0].Extract.Aggregates[0])
@@ -374,7 +374,7 @@ func Test_GenerateTruncatedConfig(t *testing.T) {
 			Type:     "gauge",
 			Filter:   api.PromMetricsFilter{Key: "", Value: ""},
 			ValueKey: "test_aggregates_value",
-			Labels:   []string{"by", "aggregate"},
+			Labels:   []string{"groupByKeys", "aggregate"},
 		}},
 	}, params[1].Encode.Prom)
 }

--- a/pkg/confgen/confgen_test.go
+++ b/pkg/confgen/confgen_test.go
@@ -131,10 +131,10 @@ func Test_RunShortConfGen(t *testing.T) {
 	// Expects aggregates
 	require.Len(t, out.Parameters[2].Extract.Aggregates, 1)
 	require.Equal(t, api.AggregateDefinition{
-		Name:      "test_aggregates",
-		By:        api.AggregateBy{"service"},
-		Operation: "sum",
-		RecordKey: "test_record_key",
+		Name:         "test_aggregates",
+		By:           api.AggregateBy{"service"},
+		Operation:    "sum",
+		OperationKey: "test_operation_key",
 	}, out.Parameters[2].Extract.Aggregates[0])
 
 	// Expects prom encode
@@ -304,16 +304,16 @@ func Test_RunLongConfGen(t *testing.T) {
 	// Expects aggregates
 	require.Len(t, out.Parameters[3].Extract.Aggregates, 2)
 	require.Equal(t, api.AggregateDefinition{
-		Name:      "test_aggregates",
-		By:        api.AggregateBy{"service"},
-		Operation: "sum",
-		RecordKey: "test_record_key",
+		Name:         "test_aggregates",
+		By:           api.AggregateBy{"service"},
+		Operation:    "sum",
+		OperationKey: "test_operation_key",
 	}, out.Parameters[3].Extract.Aggregates[0])
 	require.Equal(t, api.AggregateDefinition{
-		Name:      "test_agg_histo",
-		By:        api.AggregateBy{"service"},
-		Operation: "sum",
-		RecordKey: "test_record_key",
+		Name:         "test_agg_histo",
+		By:           api.AggregateBy{"service"},
+		Operation:    "sum",
+		OperationKey: "test_operation_key",
 	}, out.Parameters[3].Extract.Aggregates[1])
 
 	// Expects prom encode; make sure type "histogram" is changed to "agg_histogram"
@@ -360,10 +360,10 @@ func Test_GenerateTruncatedConfig(t *testing.T) {
 	// Expects aggregates
 	require.Len(t, params[0].Extract.Aggregates, 1)
 	require.Equal(t, api.AggregateDefinition{
-		Name:      "test_aggregates",
-		By:        api.AggregateBy{"service"},
-		Operation: "sum",
-		RecordKey: "test_record_key",
+		Name:         "test_aggregates",
+		By:           api.AggregateBy{"service"},
+		Operation:    "sum",
+		OperationKey: "test_operation_key",
 	}, params[0].Extract.Aggregates[0])
 
 	// Expects prom encode

--- a/pkg/confgen/dedup_test.go
+++ b/pkg/confgen/dedup_test.go
@@ -44,17 +44,17 @@ func Test_dedupeNetworkTransformRules(t *testing.T) {
 
 func Test_dedupeAggregateDefinitions(t *testing.T) {
 	slice := aggregate.Definitions{
-		api.AggregateDefinition{Name: "n1", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o1")},
-		api.AggregateDefinition{Name: "n1", By: api.AggregateBy{"a"}, OperationType: api.AggregateOperation("o1")},
-		api.AggregateDefinition{Name: "n2", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o2")},
-		api.AggregateDefinition{Name: "n3", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o3")},
-		api.AggregateDefinition{Name: "n2", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o2")},
+		api.AggregateDefinition{Name: "n1", GroupByKeys: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o1")},
+		api.AggregateDefinition{Name: "n1", GroupByKeys: api.AggregateBy{"a"}, OperationType: api.AggregateOperation("o1")},
+		api.AggregateDefinition{Name: "n2", GroupByKeys: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o2")},
+		api.AggregateDefinition{Name: "n3", GroupByKeys: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o3")},
+		api.AggregateDefinition{Name: "n2", GroupByKeys: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o2")},
 	}
 	expected := aggregate.Definitions{
-		api.AggregateDefinition{Name: "n1", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o1")},
-		api.AggregateDefinition{Name: "n1", By: api.AggregateBy{"a"}, OperationType: api.AggregateOperation("o1")},
-		api.AggregateDefinition{Name: "n2", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o2")},
-		api.AggregateDefinition{Name: "n3", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o3")},
+		api.AggregateDefinition{Name: "n1", GroupByKeys: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o1")},
+		api.AggregateDefinition{Name: "n1", GroupByKeys: api.AggregateBy{"a"}, OperationType: api.AggregateOperation("o1")},
+		api.AggregateDefinition{Name: "n2", GroupByKeys: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o2")},
+		api.AggregateDefinition{Name: "n3", GroupByKeys: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o3")},
 	}
 	actual := dedupeAggregateDefinitions(slice)
 

--- a/pkg/confgen/dedup_test.go
+++ b/pkg/confgen/dedup_test.go
@@ -44,17 +44,17 @@ func Test_dedupeNetworkTransformRules(t *testing.T) {
 
 func Test_dedupeAggregateDefinitions(t *testing.T) {
 	slice := aggregate.Definitions{
-		api.AggregateDefinition{Name: "n1", By: api.AggregateBy{"a", "b"}, Operation: api.AggregateOperation("o1")},
-		api.AggregateDefinition{Name: "n1", By: api.AggregateBy{"a"}, Operation: api.AggregateOperation("o1")},
-		api.AggregateDefinition{Name: "n2", By: api.AggregateBy{"a", "b"}, Operation: api.AggregateOperation("o2")},
-		api.AggregateDefinition{Name: "n3", By: api.AggregateBy{"a", "b"}, Operation: api.AggregateOperation("o3")},
-		api.AggregateDefinition{Name: "n2", By: api.AggregateBy{"a", "b"}, Operation: api.AggregateOperation("o2")},
+		api.AggregateDefinition{Name: "n1", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o1")},
+		api.AggregateDefinition{Name: "n1", By: api.AggregateBy{"a"}, OperationType: api.AggregateOperation("o1")},
+		api.AggregateDefinition{Name: "n2", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o2")},
+		api.AggregateDefinition{Name: "n3", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o3")},
+		api.AggregateDefinition{Name: "n2", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o2")},
 	}
 	expected := aggregate.Definitions{
-		api.AggregateDefinition{Name: "n1", By: api.AggregateBy{"a", "b"}, Operation: api.AggregateOperation("o1")},
-		api.AggregateDefinition{Name: "n1", By: api.AggregateBy{"a"}, Operation: api.AggregateOperation("o1")},
-		api.AggregateDefinition{Name: "n2", By: api.AggregateBy{"a", "b"}, Operation: api.AggregateOperation("o2")},
-		api.AggregateDefinition{Name: "n3", By: api.AggregateBy{"a", "b"}, Operation: api.AggregateOperation("o3")},
+		api.AggregateDefinition{Name: "n1", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o1")},
+		api.AggregateDefinition{Name: "n1", By: api.AggregateBy{"a"}, OperationType: api.AggregateOperation("o1")},
+		api.AggregateDefinition{Name: "n2", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o2")},
+		api.AggregateDefinition{Name: "n3", By: api.AggregateBy{"a", "b"}, OperationType: api.AggregateOperation("o3")},
 	}
 	actual := dedupeAggregateDefinitions(slice)
 

--- a/pkg/confgen/doc.go
+++ b/pkg/confgen/doc.go
@@ -52,7 +52,7 @@ func (cg *ConfGen) generatePromEncodeText(metrics api.PromMetricsItems) string {
 func (cg *ConfGen) generateOperationText(definitions aggregate.Definitions) string {
 	section := ""
 	for _, definition := range definitions {
-		by := strings.Join(definition.By[:], ", ")
+		by := strings.Join(definition.GroupByKeys[:], ", ")
 		operation := definition.OperationType
 		operationKey := definition.OperationKey
 		if operationKey != "" {

--- a/pkg/confgen/doc.go
+++ b/pkg/confgen/doc.go
@@ -53,12 +53,12 @@ func (cg *ConfGen) generateOperationText(definitions aggregate.Definitions) stri
 	section := ""
 	for _, definition := range definitions {
 		by := strings.Join(definition.By[:], ", ")
-		operation := definition.Operation
+		operation := definition.OperationType
 		operationKey := definition.OperationKey
 		if operationKey != "" {
 			operationKey = fmt.Sprintf("field `%s`", operationKey)
 		}
-		section = section + fmt.Sprintf("| **Operation** | aggregate by `%s` and `%s` %s |\n", by, operation, operationKey)
+		section = section + fmt.Sprintf("| **OperationType** | aggregate by `%s` and `%s` %s |\n", by, operation, operationKey)
 	}
 
 	return section

--- a/pkg/confgen/doc.go
+++ b/pkg/confgen/doc.go
@@ -54,11 +54,11 @@ func (cg *ConfGen) generateOperationText(definitions aggregate.Definitions) stri
 	for _, definition := range definitions {
 		by := strings.Join(definition.By[:], ", ")
 		operation := definition.Operation
-		recordKey := definition.RecordKey
-		if recordKey != "" {
-			recordKey = fmt.Sprintf("field `%s`", recordKey)
+		operationKey := definition.OperationKey
+		if operationKey != "" {
+			operationKey = fmt.Sprintf("field `%s`", operationKey)
 		}
-		section = section + fmt.Sprintf("| **Operation** | aggregate by `%s` and `%s` %s |\n", by, operation, recordKey)
+		section = section + fmt.Sprintf("| **Operation** | aggregate by `%s` and `%s` %s |\n", by, operation, operationKey)
 	}
 
 	return section

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -114,7 +114,7 @@ func TestKafkaPromPipeline(t *testing.T) {
 	})
 	pl = pl.Aggregate("aggregate", []api.AggregateDefinition{{
 		Name:          "src_as_connection_count",
-		By:            api.AggregateBy{"srcAS"},
+		GroupByKeys:   api.AggregateBy{"srcAS"},
 		OperationType: "count",
 	}})
 	pl = pl.EncodePrometheus("prom", api.PromEncode{
@@ -156,7 +156,7 @@ func TestKafkaPromPipeline(t *testing.T) {
 
 	b, err = json.Marshal(params[3])
 	require.NoError(t, err)
-	require.JSONEq(t, `{"name":"aggregate","extract":{"type":"aggregates","aggregates":[{"name":"src_as_connection_count","by":["srcAS"],"operationType":"count"}]}}`, string(b))
+	require.JSONEq(t, `{"name":"aggregate","extract":{"type":"aggregates","aggregates":[{"name":"src_as_connection_count","groupByKeys":["srcAS"],"operationType":"count"}]}}`, string(b))
 
 	b, err = json.Marshal(params[4])
 	require.NoError(t, err)

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -113,9 +113,9 @@ func TestKafkaPromPipeline(t *testing.T) {
 		KeyDefinition: api.KeyDefinition{},
 	})
 	pl = pl.Aggregate("aggregate", []api.AggregateDefinition{{
-		Name:      "src_as_connection_count",
-		By:        api.AggregateBy{"srcAS"},
-		Operation: "count",
+		Name:          "src_as_connection_count",
+		By:            api.AggregateBy{"srcAS"},
+		OperationType: "count",
 	}})
 	pl = pl.EncodePrometheus("prom", api.PromEncode{
 		Metrics: api.PromMetricsItems{{
@@ -156,7 +156,7 @@ func TestKafkaPromPipeline(t *testing.T) {
 
 	b, err = json.Marshal(params[3])
 	require.NoError(t, err)
-	require.JSONEq(t, `{"name":"aggregate","extract":{"type":"aggregates","aggregates":[{"name":"src_as_connection_count","by":["srcAS"],"operation":"count"}]}}`, string(b))
+	require.JSONEq(t, `{"name":"aggregate","extract":{"type":"aggregates","aggregates":[{"name":"src_as_connection_count","by":["srcAS"],"operationType":"count"}]}}`, string(b))
 
 	b, err = json.Marshal(params[4])
 	require.NoError(t, err)

--- a/pkg/pipeline/aggregate_prom_test.go
+++ b/pkg/pipeline/aggregate_prom_test.go
@@ -43,19 +43,19 @@ parameters:
      type: aggregates
      aggregates:
        - name: bandwidth_sum
-         by:
+         groupByKeys:
          - service
          operationType: sum
          operationKey: bytes
 
        - name: bandwidth_count
-         by:
+         groupByKeys:
          - service
          operationType: count
          operationKey:
 
        - name: bandwidth_raw_values
-         by:
+         groupByKeys:
          - service
          operationType: raw_values
          operationKey: bytes

--- a/pkg/pipeline/aggregate_prom_test.go
+++ b/pkg/pipeline/aggregate_prom_test.go
@@ -46,19 +46,19 @@ parameters:
          by:
          - service
          operation: sum
-         recordkey: bytes
+         operationKey: bytes
 
        - name: bandwidth_count
          by:
          - service
          operation: count
-         recordkey: 
+         operationKey:
 
        - name: bandwidth_raw_values
          by:
          - service
          operation: raw_values
-         recordkey: bytes
+         operationKey: bytes
  - name: encode
    encode:
      type: prom

--- a/pkg/pipeline/aggregate_prom_test.go
+++ b/pkg/pipeline/aggregate_prom_test.go
@@ -45,19 +45,19 @@ parameters:
        - name: bandwidth_sum
          by:
          - service
-         operation: sum
+         operationType: sum
          operationKey: bytes
 
        - name: bandwidth_count
          by:
          - service
-         operation: count
+         operationType: count
          operationKey:
 
        - name: bandwidth_raw_values
          by:
          - service
-         operation: raw_values
+         operationType: raw_values
          operationKey: bytes
  - name: encode
    encode:

--- a/pkg/pipeline/extract/aggregate/aggregate.go
+++ b/pkg/pipeline/extract/aggregate/aggregate.go
@@ -64,7 +64,7 @@ func (aggregate Aggregate) LabelsFromEntry(entry config.GenericMap) (Labels, boo
 	allLabelsFound := true
 	labels := Labels{}
 
-	for _, key := range aggregate.Definition.By {
+	for _, key := range aggregate.Definition.GroupByKeys {
 		value, ok := entry[key]
 		if !ok {
 			allLabelsFound = false
@@ -212,17 +212,17 @@ func (aggregate Aggregate) GetMetrics() []config.GenericMap {
 			"name":              aggregate.Definition.Name,
 			"operation":         aggregate.Definition.OperationType,
 			"operation_key":     aggregate.Definition.OperationKey,
-			"by":                strings.Join(aggregate.Definition.By, ","),
+			"by":                strings.Join(aggregate.Definition.GroupByKeys, ","),
 			"aggregate":         string(group.normalizedValues),
 			"total_value":       group.totalValue,
 			"total_count":       group.totalCount,
 			"recent_raw_values": group.recentRawValues,
 			"recent_op_value":   group.recentOpValue,
 			"recent_count":      group.recentCount,
-			strings.Join(aggregate.Definition.By, "_"): string(group.normalizedValues),
+			strings.Join(aggregate.Definition.GroupByKeys, "_"): string(group.normalizedValues),
 		}
-		// add the items in aggregate.Definition.By individually to the entry
-		for _, key := range aggregate.Definition.By {
+		// add the items in aggregate.Definition.GroupByKeys individually to the entry
+		for _, key := range aggregate.Definition.GroupByKeys {
 			newEntry[key] = group.labels[key]
 		}
 		metrics = append(metrics, newEntry)

--- a/pkg/pipeline/extract/aggregate/aggregate.go
+++ b/pkg/pipeline/extract/aggregate/aggregate.go
@@ -141,15 +141,15 @@ func (aggregate Aggregate) UpdateByEntry(entry config.GenericMap, normalizedValu
 	aggregate.cache.UpdateCacheEntry(string(normalizedValues), groupState)
 
 	// update value
-	recordKey := aggregate.Definition.RecordKey
+	operationKey := aggregate.Definition.OperationKey
 	operation := aggregate.Definition.Operation
 
 	if operation == OperationCount {
 		groupState.totalValue = float64(groupState.totalCount + 1)
 		groupState.recentOpValue = float64(groupState.recentCount + 1)
 	} else {
-		if recordKey != "" {
-			value, ok := entry[recordKey]
+		if operationKey != "" {
+			value, ok := entry[operationKey]
 			if ok {
 				valueString := fmt.Sprintf("%v", value)
 				valueFloat64, _ := strconv.ParseFloat(valueString, 64)
@@ -211,7 +211,7 @@ func (aggregate Aggregate) GetMetrics() []config.GenericMap {
 		newEntry := config.GenericMap{
 			"name":              aggregate.Definition.Name,
 			"operation":         aggregate.Definition.Operation,
-			"record_key":        aggregate.Definition.RecordKey,
+			"operation_key":     aggregate.Definition.OperationKey,
 			"by":                strings.Join(aggregate.Definition.By, ","),
 			"aggregate":         string(group.normalizedValues),
 			"total_value":       group.totalValue,

--- a/pkg/pipeline/extract/aggregate/aggregate.go
+++ b/pkg/pipeline/extract/aggregate/aggregate.go
@@ -210,7 +210,7 @@ func (aggregate Aggregate) GetMetrics() []config.GenericMap {
 		group := value.(*GroupState)
 		newEntry := config.GenericMap{
 			"name":              aggregate.Definition.Name,
-			"operation":         aggregate.Definition.OperationType,
+			"operation_type":    aggregate.Definition.OperationType,
 			"operation_key":     aggregate.Definition.OperationKey,
 			"by":                strings.Join(aggregate.Definition.GroupByKeys, ","),
 			"aggregate":         string(group.normalizedValues),

--- a/pkg/pipeline/extract/aggregate/aggregate.go
+++ b/pkg/pipeline/extract/aggregate/aggregate.go
@@ -129,10 +129,10 @@ func (aggregate Aggregate) UpdateByEntry(entry config.GenericMap, normalizedValu
 	oldEntry, ok := aggregate.cache.GetCacheEntry(string(normalizedValues))
 	if !ok {
 		groupState = &GroupState{normalizedValues: normalizedValues, labels: labels}
-		initVal := getInitValue(string(aggregate.Definition.Operation))
+		initVal := getInitValue(string(aggregate.Definition.OperationType))
 		groupState.totalValue = initVal
 		groupState.recentOpValue = initVal
-		if aggregate.Definition.Operation == OperationRawValues {
+		if aggregate.Definition.OperationType == OperationRawValues {
 			groupState.recentRawValues = make([]float64, 0)
 		}
 	} else {
@@ -142,7 +142,7 @@ func (aggregate Aggregate) UpdateByEntry(entry config.GenericMap, normalizedValu
 
 	// update value
 	operationKey := aggregate.Definition.OperationKey
-	operation := aggregate.Definition.Operation
+	operation := aggregate.Definition.OperationType
 
 	if operation == OperationCount {
 		groupState.totalValue = float64(groupState.totalCount + 1)
@@ -210,7 +210,7 @@ func (aggregate Aggregate) GetMetrics() []config.GenericMap {
 		group := value.(*GroupState)
 		newEntry := config.GenericMap{
 			"name":              aggregate.Definition.Name,
-			"operation":         aggregate.Definition.Operation,
+			"operation":         aggregate.Definition.OperationType,
 			"operation_key":     aggregate.Definition.OperationKey,
 			"by":                strings.Join(aggregate.Definition.By, ","),
 			"aggregate":         string(group.normalizedValues),
@@ -227,11 +227,11 @@ func (aggregate Aggregate) GetMetrics() []config.GenericMap {
 		}
 		metrics = append(metrics, newEntry)
 		// Once reported, we reset the recentXXX fields
-		if aggregate.Definition.Operation == OperationRawValues {
+		if aggregate.Definition.OperationType == OperationRawValues {
 			group.recentRawValues = make([]float64, 0)
 		}
 		group.recentCount = 0
-		group.recentOpValue = getInitValue(string(aggregate.Definition.Operation))
+		group.recentOpValue = getInitValue(string(aggregate.Definition.OperationType))
 	})
 
 	return metrics

--- a/pkg/pipeline/extract/aggregate/aggregate_test.go
+++ b/pkg/pipeline/extract/aggregate/aggregate_test.go
@@ -31,10 +31,10 @@ import (
 func GetMockAggregate() Aggregate {
 	aggregate := Aggregate{
 		Definition: api.AggregateDefinition{
-			Name:         "Avg by src and dst IP's",
-			By:           api.AggregateBy{"dstIP", "srcIP"},
-			Operation:    "avg",
-			OperationKey: "value",
+			Name:          "Avg by src and dst IP's",
+			By:            api.AggregateBy{"dstIP", "srcIP"},
+			OperationType: "avg",
+			OperationKey:  "value",
 		},
 		cache:      utils.NewTimedCache(),
 		mutex:      &sync.Mutex{},
@@ -78,9 +78,9 @@ func Test_getNormalizedValues(t *testing.T) {
 func Test_LabelsFromEntry(t *testing.T) {
 	aggregate := Aggregate{
 		Definition: api.AggregateDefinition{
-			By:           api.AggregateBy{"dstIP", "srcIP"},
-			Operation:    "count",
-			OperationKey: "",
+			By:            api.AggregateBy{"dstIP", "srcIP"},
+			OperationType: "count",
+			OperationKey:  "",
 		},
 	}
 	expectedLabels := getMockLabels(false)

--- a/pkg/pipeline/extract/aggregate/aggregate_test.go
+++ b/pkg/pipeline/extract/aggregate/aggregate_test.go
@@ -31,10 +31,10 @@ import (
 func GetMockAggregate() Aggregate {
 	aggregate := Aggregate{
 		Definition: api.AggregateDefinition{
-			Name:      "Avg by src and dst IP's",
-			By:        api.AggregateBy{"dstIP", "srcIP"},
-			Operation: "avg",
-			RecordKey: "value",
+			Name:         "Avg by src and dst IP's",
+			By:           api.AggregateBy{"dstIP", "srcIP"},
+			Operation:    "avg",
+			OperationKey: "value",
 		},
 		cache:      utils.NewTimedCache(),
 		mutex:      &sync.Mutex{},
@@ -78,9 +78,9 @@ func Test_getNormalizedValues(t *testing.T) {
 func Test_LabelsFromEntry(t *testing.T) {
 	aggregate := Aggregate{
 		Definition: api.AggregateDefinition{
-			By:        api.AggregateBy{"dstIP", "srcIP"},
-			Operation: "count",
-			RecordKey: "",
+			By:           api.AggregateBy{"dstIP", "srcIP"},
+			Operation:    "count",
+			OperationKey: "",
 		},
 	}
 	expectedLabels := getMockLabels(false)

--- a/pkg/pipeline/extract/aggregate/aggregate_test.go
+++ b/pkg/pipeline/extract/aggregate/aggregate_test.go
@@ -32,7 +32,7 @@ func GetMockAggregate() Aggregate {
 	aggregate := Aggregate{
 		Definition: api.AggregateDefinition{
 			Name:          "Avg by src and dst IP's",
-			By:            api.AggregateBy{"dstIP", "srcIP"},
+			GroupByKeys:   api.AggregateBy{"dstIP", "srcIP"},
 			OperationType: "avg",
 			OperationKey:  "value",
 		},
@@ -78,7 +78,7 @@ func Test_getNormalizedValues(t *testing.T) {
 func Test_LabelsFromEntry(t *testing.T) {
 	aggregate := Aggregate{
 		Definition: api.AggregateDefinition{
-			By:            api.AggregateBy{"dstIP", "srcIP"},
+			GroupByKeys:   api.AggregateBy{"dstIP", "srcIP"},
 			OperationType: "count",
 			OperationKey:  "",
 		},

--- a/pkg/pipeline/extract/aggregate/aggregates_test.go
+++ b/pkg/pipeline/extract/aggregate/aggregates_test.go
@@ -41,7 +41,7 @@ parameters:
             - "dstIP"
             - "srcIP"
           Operation: "avg"
-          RecordKey: "value"
+          OperationKey: "value"
 `
 	v, cfg := test.InitConfig(t, yamlConfig)
 	require.NotNil(t, v)

--- a/pkg/pipeline/extract/aggregate/aggregates_test.go
+++ b/pkg/pipeline/extract/aggregate/aggregates_test.go
@@ -40,7 +40,7 @@ parameters:
           By:
             - "dstIP"
             - "srcIP"
-          Operation: "avg"
+          OperationType: "avg"
           OperationKey: "value"
 `
 	v, cfg := test.InitConfig(t, yamlConfig)

--- a/pkg/pipeline/extract/aggregate/aggregates_test.go
+++ b/pkg/pipeline/extract/aggregate/aggregates_test.go
@@ -37,7 +37,7 @@ parameters:
       type: aggregates
       aggregates:
         - Name: "Avg by src and dst IP's"
-          By:
+          GroupByKeys:
             - "dstIP"
             - "srcIP"
           OperationType: "avg"

--- a/pkg/pipeline/extract/conntrack/aggregator_test.go
+++ b/pkg/pipeline/extract/conntrack/aggregator_test.go
@@ -37,7 +37,7 @@ func TestNewAggregator_Invalid(t *testing.T) {
 	})
 	require.NotNil(t, err)
 
-	// unknown Operation
+	// unknown OperationType
 	_, err = newAggregator(api.OutputField{
 		Name:      "MyAgg",
 		Operation: "unknown",
@@ -69,22 +69,22 @@ func TestNewAggregator_Valid(t *testing.T) {
 			expected:    &aSum{aggregateBase{"MyInput", "MyAgg", false, 0}},
 		},
 		{
-			name:        "Operation sum",
+			name:        "OperationType sum",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "sum"},
 			expected:    &aSum{aggregateBase{"MyAgg", "MyAgg", false, 0}},
 		},
 		{
-			name:        "Operation count",
+			name:        "OperationType count",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "count"},
 			expected:    &aCount{aggregateBase{"MyAgg", "MyAgg", false, 0}},
 		},
 		{
-			name:        "Operation max",
+			name:        "OperationType max",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "max"},
 			expected:    &aMax{aggregateBase{"MyAgg", "MyAgg", false, -math.MaxFloat64}},
 		},
 		{
-			name:        "Operation min",
+			name:        "OperationType min",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "min"},
 			expected:    &aMin{aggregateBase{"MyAgg", "MyAgg", false, math.MaxFloat64}},
 		},

--- a/pkg/pipeline/extract/extract_aggregate_test.go
+++ b/pkg/pipeline/extract/extract_aggregate_test.go
@@ -40,37 +40,37 @@ parameters:
       type: aggregates
       aggregates:
         - name: bandwidth_count
-          by:
+          groupByKeys:
           - service
           operationType: count
           operationKey: ""
 
         - name: bandwidth_sum
-          by:
+          groupByKeys:
           - service
           operationType: sum
           operationKey: bytes
 
         - name: bandwidth_max
-          by:
+          groupByKeys:
           - service
           operationType: max
           operationKey: bytes
 
         - name: bandwidth_min
-          by:
+          groupByKeys:
           - service
           operationType: min
           operationKey: bytes
 
         - name: bandwidth_avg
-          by:
+          groupByKeys:
           - service
           operationType: avg
           operationKey: bytes
 
         - name: bandwidth_raw_values
-          by:
+          groupByKeys:
           - service
           operationType: raw_values
           operationKey: bytes

--- a/pkg/pipeline/extract/extract_aggregate_test.go
+++ b/pkg/pipeline/extract/extract_aggregate_test.go
@@ -43,37 +43,37 @@ parameters:
           by:
           - service
           operation: count
-          recordkey: ""
+          operationKey: ""
 
         - name: bandwidth_sum
           by:
           - service
           operation: sum
-          recordkey: bytes
+          operationKey: bytes
 
         - name: bandwidth_max
           by:
           - service
           operation: max
-          recordkey: bytes
+          operationKey: bytes
 
         - name: bandwidth_min
           by:
           - service
           operation: min
-          recordkey: bytes
+          operationKey: bytes
 
         - name: bandwidth_avg
           by:
           - service
           operation: avg
-          recordkey: bytes
+          operationKey: bytes
 
         - name: bandwidth_raw_values
           by:
           - service
           operation: raw_values
-          recordkey: bytes
+          operationKey: bytes
 `
 	var err error
 

--- a/pkg/pipeline/extract/extract_aggregate_test.go
+++ b/pkg/pipeline/extract/extract_aggregate_test.go
@@ -42,37 +42,37 @@ parameters:
         - name: bandwidth_count
           by:
           - service
-          operation: count
+          operationType: count
           operationKey: ""
 
         - name: bandwidth_sum
           by:
           - service
-          operation: sum
+          operationType: sum
           operationKey: bytes
 
         - name: bandwidth_max
           by:
           - service
-          operation: max
+          operationType: max
           operationKey: bytes
 
         - name: bandwidth_min
           by:
           - service
-          operation: min
+          operationType: min
           operationKey: bytes
 
         - name: bandwidth_avg
           by:
           - service
-          operation: avg
+          operationType: avg
           operationKey: bytes
 
         - name: bandwidth_raw_values
           by:
           - service
-          operation: raw_values
+          operationType: raw_values
           operationKey: bytes
 `
 	var err error

--- a/pkg/pipeline/extract/extract_timebased.go
+++ b/pkg/pipeline/extract/extract_timebased.go
@@ -27,8 +27,8 @@ import (
 )
 
 type ExtractTimebased struct {
-	Filters          []timebased.FilterStruct
-	RecordKeyStructs map[string]*timebased.RecordKeyTable
+	Filters         []timebased.FilterStruct
+	IndexKeyStructs map[string]*timebased.IndexKeyTable
 }
 
 // Extract extracts a flow before being stored
@@ -38,7 +38,7 @@ func (et *ExtractTimebased) Extract(entries []config.GenericMap) []config.Generi
 	// Populate the Table with the current entries
 	for _, entry := range entries {
 		log.Debugf("ExtractTimebased Extract, entry = %v", entry)
-		timebased.AddEntryToTables(et.RecordKeyStructs, entry, nowInSecs)
+		timebased.AddEntryToTables(et.IndexKeyStructs, entry, nowInSecs)
 	}
 
 	output := make([]config.GenericMap, 0)
@@ -52,7 +52,7 @@ func (et *ExtractTimebased) Extract(entries []config.GenericMap) []config.Generi
 	log.Debugf("output of extract timebased: %v", output)
 
 	// delete entries from tables that are outside time windows
-	timebased.DeleteOldEntriesFromTables(et.RecordKeyStructs, nowInSecs)
+	timebased.DeleteOldEntriesFromTables(et.IndexKeyStructs, nowInSecs)
 
 	return output
 }
@@ -65,10 +65,10 @@ func NewExtractTimebased(params config.StageParam) (Extractor, error) {
 	}
 	log.Debugf("NewExtractTimebased; rules = %v", rules)
 
-	tmpRecordKeyStructs, tmpFilters := timebased.CreateRecordKeysAndFilters(rules)
+	tmpIndexKeyStructs, tmpFilters := timebased.CreateIndexKeysAndFilters(rules)
 
 	return &ExtractTimebased{
-		Filters:          tmpFilters,
-		RecordKeyStructs: tmpRecordKeyStructs,
+		Filters:         tmpFilters,
+		IndexKeyStructs: tmpIndexKeyStructs,
 	}, nil
 }

--- a/pkg/pipeline/extract/extract_timebased_test.go
+++ b/pkg/pipeline/extract/extract_timebased_test.go
@@ -33,7 +33,7 @@ func GetMockTimebased1() ExtractTimebased {
 		Filters: []timebased.FilterStruct{
 			{Rule: api.TimebasedFilterRule{
 				Name:          "TopK_Bytes1",
-				RecordKey:     "SrcAddr",
+				IndexKey:      "SrcAddr",
 				OperationType: "last",
 				OperationKey:  "Bytes",
 				TopK:          3,
@@ -41,7 +41,7 @@ func GetMockTimebased1() ExtractTimebased {
 			}},
 			{Rule: api.TimebasedFilterRule{
 				Name:          "BotK_Bytes1",
-				RecordKey:     "SrcAddr",
+				IndexKey:      "SrcAddr",
 				OperationType: "avg",
 				OperationKey:  "Bytes",
 				TopK:          2,
@@ -49,7 +49,7 @@ func GetMockTimebased1() ExtractTimebased {
 				TimeInterval:  api.Duration{Duration: 15 * time.Second},
 			}},
 		},
-		RecordKeyStructs: map[string]*timebased.RecordKeyTable{},
+		IndexKeyStructs: map[string]*timebased.IndexKeyTable{},
 	}
 	return tb
 }
@@ -66,13 +66,13 @@ parameters:
           - name: TopK_Bytes1
             operationType: last
             operationKey: Bytes
-            recordKey: SrcAddr
+            indexKey: SrcAddr
             topK: 3
             timeInterval: 10s
           - name: BotK_Bytes1
             operationType: avg
             operationKey: Bytes
-            recordKey: SrcAddr
+            indexKey: SrcAddr
             topK: 2
             reversed: true
             timeInterval: 15s
@@ -90,7 +90,7 @@ parameters:
           - name: TopK_Bytes2
             operationType: sum
             operationKey: Bytes
-            recordKey: SrcAddr
+            indexKey: SrcAddr
             topK: 1
             timeInterval: 10s
 `
@@ -107,7 +107,7 @@ parameters:
           - name: BotK_Bytes3
             operationType: diff
             operationKey: Bytes
-            recordKey: SrcAddr
+            indexKey: SrcAddr
             topK: 1
             reversed: true
             timeInterval: 10s
@@ -125,7 +125,7 @@ parameters:
           - name: TopK_Bytes4
             operationType: max
             operationKey: Bytes
-            recordKey: SrcAddr
+            indexKey: SrcAddr
             topK: 1
             timeInterval: 10s
 `
@@ -142,7 +142,7 @@ parameters:
           - name: BotK_Bytes5
             operationType: min
             operationKey: Bytes
-            recordKey: SrcAddr
+            indexKey: SrcAddr
             topK: 1
             reversed: true
             timeInterval: 10s
@@ -160,7 +160,7 @@ parameters:
           - name: All_Bytes6
             operationType: sum
             operationKey: Bytes
-            recordKey: SrcAddr
+            indexKey: SrcAddr
             timeInterval: 10s
 `
 
@@ -195,7 +195,7 @@ func Test_ExtractTimebasedExtract1(t *testing.T) {
 			"operation":        "last",
 			"operation_key":    "Bytes",
 			"operation_result": float64(1000),
-			"record_key":       "SrcAddr",
+			"index_key":        "SrcAddr",
 			"SrcAddr":          "10.0.0.4",
 		},
 		{
@@ -204,7 +204,7 @@ func Test_ExtractTimebasedExtract1(t *testing.T) {
 			"operation":        "last",
 			"operation_key":    "Bytes",
 			"operation_result": float64(900),
-			"record_key":       "SrcAddr",
+			"index_key":        "SrcAddr",
 			"SrcAddr":          "10.0.0.3",
 		},
 		{
@@ -213,7 +213,7 @@ func Test_ExtractTimebasedExtract1(t *testing.T) {
 			"operation":        "last",
 			"operation_key":    "Bytes",
 			"operation_result": float64(800),
-			"record_key":       "SrcAddr",
+			"index_key":        "SrcAddr",
 			"SrcAddr":          "10.0.0.2",
 		},
 		{
@@ -222,7 +222,7 @@ func Test_ExtractTimebasedExtract1(t *testing.T) {
 			"operation":        "avg",
 			"operation_key":    "Bytes",
 			"operation_result": float64(400),
-			"record_key":       "SrcAddr",
+			"index_key":        "SrcAddr",
 			"SrcAddr":          "10.0.0.1",
 		},
 		{
@@ -231,7 +231,7 @@ func Test_ExtractTimebasedExtract1(t *testing.T) {
 			"operation":        "avg",
 			"operation_key":    "Bytes",
 			"operation_result": float64(500),
-			"record_key":       "SrcAddr",
+			"index_key":        "SrcAddr",
 			"SrcAddr":          "10.0.0.2",
 		},
 	}
@@ -251,7 +251,7 @@ func Test_ExtractTimebasedExtract2(t *testing.T) {
 			"operation":        "sum",
 			"operation_key":    "Bytes",
 			"operation_result": float64(1800),
-			"record_key":       "SrcAddr",
+			"index_key":        "SrcAddr",
 			"SrcAddr":          "10.0.0.3",
 		},
 	}
@@ -271,7 +271,7 @@ func Test_ExtractTimebasedExtract3(t *testing.T) {
 			"operation":        "diff",
 			"operation_key":    "Bytes",
 			"operation_result": float64(0),
-			"record_key":       "SrcAddr",
+			"index_key":        "SrcAddr",
 			"SrcAddr":          "10.0.0.4",
 		},
 	}
@@ -291,7 +291,7 @@ func Test_ExtractTimebasedExtract4(t *testing.T) {
 			"operation":        "max",
 			"operation_key":    "Bytes",
 			"operation_result": float64(1000),
-			"record_key":       "SrcAddr",
+			"index_key":        "SrcAddr",
 			"SrcAddr":          "10.0.0.4",
 		},
 	}
@@ -311,7 +311,7 @@ func Test_ExtractTimebasedExtract5(t *testing.T) {
 			"operation":        "min",
 			"operation_key":    "Bytes",
 			"operation_result": float64(100),
-			"record_key":       "SrcAddr",
+			"index_key":        "SrcAddr",
 			"SrcAddr":          "10.0.0.1",
 		},
 	}
@@ -331,7 +331,7 @@ func Test_ExtractTimebasedExtract6(t *testing.T) {
 			"operation":        "sum",
 			"operation_key":    "Bytes",
 			"operation_result": float64(1200),
-			"record_key":       "SrcAddr",
+			"index_key":        "SrcAddr",
 			"SrcAddr":          "10.0.0.1",
 		},
 		{
@@ -340,7 +340,7 @@ func Test_ExtractTimebasedExtract6(t *testing.T) {
 			"operation":        "sum",
 			"operation_key":    "Bytes",
 			"operation_result": float64(1500),
-			"record_key":       "SrcAddr",
+			"index_key":        "SrcAddr",
 			"SrcAddr":          "10.0.0.2",
 		},
 		{
@@ -349,7 +349,7 @@ func Test_ExtractTimebasedExtract6(t *testing.T) {
 			"operation":        "sum",
 			"operation_key":    "Bytes",
 			"operation_result": float64(1800),
-			"record_key":       "SrcAddr",
+			"index_key":        "SrcAddr",
 			"SrcAddr":          "10.0.0.3",
 		},
 		{
@@ -358,7 +358,7 @@ func Test_ExtractTimebasedExtract6(t *testing.T) {
 			"operation":        "sum",
 			"operation_key":    "Bytes",
 			"operation_result": float64(1000),
-			"record_key":       "SrcAddr",
+			"index_key":        "SrcAddr",
 			"SrcAddr":          "10.0.0.4",
 		},
 	}

--- a/pkg/pipeline/extract/extract_timebased_test.go
+++ b/pkg/pipeline/extract/extract_timebased_test.go
@@ -32,21 +32,21 @@ func GetMockTimebased1() ExtractTimebased {
 	tb := ExtractTimebased{
 		Filters: []timebased.FilterStruct{
 			{Rule: api.TimebasedFilterRule{
-				Name:         "TopK_Bytes1",
-				RecordKey:    "SrcAddr",
-				Operation:    "last",
-				OperationKey: "Bytes",
-				TopK:         3,
-				TimeInterval: api.Duration{Duration: 10 * time.Second},
+				Name:          "TopK_Bytes1",
+				RecordKey:     "SrcAddr",
+				OperationType: "last",
+				OperationKey:  "Bytes",
+				TopK:          3,
+				TimeInterval:  api.Duration{Duration: 10 * time.Second},
 			}},
 			{Rule: api.TimebasedFilterRule{
-				Name:         "BotK_Bytes1",
-				RecordKey:    "SrcAddr",
-				Operation:    "avg",
-				OperationKey: "Bytes",
-				TopK:         2,
-				Reversed:     true,
-				TimeInterval: api.Duration{Duration: 15 * time.Second},
+				Name:          "BotK_Bytes1",
+				RecordKey:     "SrcAddr",
+				OperationType: "avg",
+				OperationKey:  "Bytes",
+				TopK:          2,
+				Reversed:      true,
+				TimeInterval:  api.Duration{Duration: 15 * time.Second},
 			}},
 		},
 		RecordKeyStructs: map[string]*timebased.RecordKeyTable{},
@@ -64,13 +64,13 @@ parameters:
       timebased:
         rules:
           - name: TopK_Bytes1
-            operation: last
+            operationType: last
             operationKey: Bytes
             recordKey: SrcAddr
             topK: 3
             timeInterval: 10s
           - name: BotK_Bytes1
-            operation: avg
+            operationType: avg
             operationKey: Bytes
             recordKey: SrcAddr
             topK: 2
@@ -88,7 +88,7 @@ parameters:
       timebased:
         rules:
           - name: TopK_Bytes2
-            operation: sum
+            operationType: sum
             operationKey: Bytes
             recordKey: SrcAddr
             topK: 1
@@ -105,7 +105,7 @@ parameters:
       timebased:
         rules:
           - name: BotK_Bytes3
-            operation: diff
+            operationType: diff
             operationKey: Bytes
             recordKey: SrcAddr
             topK: 1
@@ -123,7 +123,7 @@ parameters:
       timebased:
         rules:
           - name: TopK_Bytes4
-            operation: max
+            operationType: max
             operationKey: Bytes
             recordKey: SrcAddr
             topK: 1
@@ -140,7 +140,7 @@ parameters:
       timebased:
         rules:
           - name: BotK_Bytes5
-            operation: min
+            operationType: min
             operationKey: Bytes
             recordKey: SrcAddr
             topK: 1
@@ -158,7 +158,7 @@ parameters:
       timebased:
         rules:
           - name: All_Bytes6
-            operation: sum
+            operationType: sum
             operationKey: Bytes
             recordKey: SrcAddr
             timeInterval: 10s

--- a/pkg/pipeline/extract/timebased/filters.go
+++ b/pkg/pipeline/extract/timebased/filters.go
@@ -31,7 +31,7 @@ import (
 func (fs *FilterStruct) CalculateResults(nowInSecs time.Time) {
 	log.Debugf("CalculateResults nowInSecs = %v", nowInSecs)
 	oldestValidTime := nowInSecs.Add(-fs.Rule.TimeInterval.Duration)
-	for key, l := range fs.RecordKeyDataTable.dataTableMap {
+	for key, l := range fs.IndexKeyDataTable.dataTableMap {
 		var valueFloat64 = float64(0)
 		var err error
 		switch fs.Rule.OperationType {
@@ -142,13 +142,13 @@ func (fs *FilterStruct) CreateGenericMap() []config.GenericMap {
 	for _, result := range fs.Output {
 		t := config.GenericMap{
 			"name":             fs.Rule.Name,
-			"record_key":       fs.Rule.RecordKey,
+			"index_key":        fs.Rule.IndexKey,
 			"operation":        fs.Rule.OperationType,
 			"operation_key":    fs.Rule.OperationKey,
 			"key":              result.key,
 			"operation_result": result.operationResult,
 		}
-		t[fs.Rule.RecordKey] = result.key
+		t[fs.Rule.IndexKey] = result.key
 		log.Debugf("FilterStruct CreateGenericMap: %v", t)
 		output = append(output, t)
 	}

--- a/pkg/pipeline/extract/timebased/filters.go
+++ b/pkg/pipeline/extract/timebased/filters.go
@@ -34,7 +34,7 @@ func (fs *FilterStruct) CalculateResults(nowInSecs time.Time) {
 	for key, l := range fs.RecordKeyDataTable.dataTableMap {
 		var valueFloat64 = float64(0)
 		var err error
-		switch fs.Rule.Operation {
+		switch fs.Rule.OperationType {
 		case api.FilterOperationName("FilterOperationLast"):
 			// handle empty list
 			if l.Len() == 0 {
@@ -75,7 +75,7 @@ func (fs *FilterStruct) CalculateResults(nowInSecs time.Time) {
 
 func (fs *FilterStruct) CalculateValue(l *list.List, oldestValidTime time.Time) float64 {
 	log.Debugf("CalculateValue nowInSecs = %v", oldestValidTime)
-	currentValue := getInitValue(fs.Rule.Operation)
+	currentValue := getInitValue(fs.Rule.OperationType)
 	nItems := 0
 	for e := l.Front(); e != nil; e = e.Next() {
 		cEntry := e.Value.(*TableEntry)
@@ -85,7 +85,7 @@ func (fs *FilterStruct) CalculateValue(l *list.List, oldestValidTime time.Time) 
 		}
 		valueFloat64, _ := utils.ConvertToFloat64(cEntry.entry[fs.Rule.OperationKey])
 		nItems++
-		switch fs.Rule.Operation {
+		switch fs.Rule.OperationType {
 		case api.FilterOperationName("FilterOperationSum"), api.FilterOperationName("FilterOperationAvg"):
 			currentValue += valueFloat64
 		case api.FilterOperationName("FilterOperationMax"):
@@ -94,7 +94,7 @@ func (fs *FilterStruct) CalculateValue(l *list.List, oldestValidTime time.Time) 
 			currentValue = math.Min(currentValue, valueFloat64)
 		}
 	}
-	if fs.Rule.Operation == api.FilterOperationName("FilterOperationAvg") && nItems > 0 {
+	if fs.Rule.OperationType == api.FilterOperationName("FilterOperationAvg") && nItems > 0 {
 		currentValue = currentValue / float64(nItems)
 	}
 	return currentValue
@@ -143,7 +143,7 @@ func (fs *FilterStruct) CreateGenericMap() []config.GenericMap {
 		t := config.GenericMap{
 			"name":             fs.Rule.Name,
 			"record_key":       fs.Rule.RecordKey,
-			"operation":        fs.Rule.Operation,
+			"operation":        fs.Rule.OperationType,
 			"operation_key":    fs.Rule.OperationKey,
 			"key":              result.key,
 			"operation_result": result.operationResult,

--- a/pkg/pipeline/extract/timebased/tables.go
+++ b/pkg/pipeline/extract/timebased/tables.go
@@ -26,8 +26,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func AddEntryToTables(recordKeyStructs map[string]*RecordKeyTable, entry config.GenericMap, nowInSecs time.Time) {
-	for key, recordTable := range recordKeyStructs {
+func AddEntryToTables(indexKeyStructs map[string]*IndexKeyTable, entry config.GenericMap, nowInSecs time.Time) {
+	for key, recordTable := range indexKeyStructs {
 		log.Debugf("ExtractTimebased addEntryToTables: key = %s, recordTable = %v", key, recordTable)
 		if val, ok := entry[key]; ok {
 			cEntry := &TableEntry{
@@ -49,8 +49,8 @@ func AddEntryToTable(cEntry *TableEntry, tableList *list.List) {
 	tableList.PushBack(cEntry)
 }
 
-func DeleteOldEntriesFromTables(recordKeyStructs map[string]*RecordKeyTable, nowInSecs time.Time) {
-	for _, recordTable := range recordKeyStructs {
+func DeleteOldEntriesFromTables(indexKeyStructs map[string]*IndexKeyTable, nowInSecs time.Time) {
+	for _, recordTable := range indexKeyStructs {
 		oldestTime := nowInSecs.Add(-recordTable.maxTimeInterval)
 		for _, tableMap := range recordTable.dataTableMap {
 			for {

--- a/pkg/pipeline/extract/timebased/timebased.go
+++ b/pkg/pipeline/extract/timebased/timebased.go
@@ -79,7 +79,7 @@ func CreateRecordKeysAndFilters(rules []api.TimebasedFilterRule) (map[string]*Re
 				rStruct.maxTimeInterval = filterRule.TimeInterval.Duration
 			}
 		}
-		// verify the validity of the Operation field in the filterRule
+		// verify the validity of the OperationType field in the filterRule
 		switch filterRule.Operation {
 		case api.FilterOperationName("FilterOperationLast"),
 			api.FilterOperationName("FilterOperationDiff"),

--- a/pkg/pipeline/extract/timebased/timebased.go
+++ b/pkg/pipeline/extract/timebased/timebased.go
@@ -27,10 +27,10 @@ import (
 )
 
 type FilterStruct struct {
-	Rule               api.TimebasedFilterRule
-	RecordKeyDataTable *RecordKeyTable
-	Results            filterOperationResults
-	Output             []filterOperationResult
+	Rule              api.TimebasedFilterRule
+	IndexKeyDataTable *IndexKeyTable
+	Results           filterOperationResults
+	Output            []filterOperationResult
 }
 
 type filterOperationResults map[string]*filterOperationResult
@@ -42,7 +42,7 @@ type filterOperationResult struct {
 
 type DataTableMap map[string]*list.List
 
-type RecordKeyTable struct {
+type IndexKeyTable struct {
 	maxTimeInterval time.Duration
 	dataTableMap    DataTableMap
 }
@@ -52,28 +52,28 @@ type TableEntry struct {
 	entry     config.GenericMap
 }
 
-// CreateRecordKeysAndFilters creates structures for each RecordKey that appears in the rules.
-// Note that the same RecordKey might appear in more than one Rule.
-// Connect RecordKey structure to its filters.
-// For each RecordKey, we need a table of history to handle the largest TimeInterval.
-func CreateRecordKeysAndFilters(rules []api.TimebasedFilterRule) (map[string]*RecordKeyTable, []FilterStruct) {
-	tmpRecordKeyStructs := make(map[string]*RecordKeyTable)
+// CreateIndexKeysAndFilters creates structures for each IndexKey that appears in the rules.
+// Note that the same IndexKey might appear in more than one Rule.
+// Connect IndexKey structure to its filters.
+// For each IndexKey, we need a table of history to handle the largest TimeInterval.
+func CreateIndexKeysAndFilters(rules []api.TimebasedFilterRule) (map[string]*IndexKeyTable, []FilterStruct) {
+	tmpIndexKeyStructs := make(map[string]*IndexKeyTable)
 	tmpFilters := make([]FilterStruct, 0)
 	for _, filterRule := range rules {
-		log.Debugf("CreateRecordKeysAndFilters: filterRule = %v", filterRule)
-		// verify there is a valid RecordKey
-		if filterRule.RecordKey == "" {
-			log.Errorf("missing RecordKey for filter %s", filterRule.Name)
+		log.Debugf("CreateIndexKeysAndFilters: filterRule = %v", filterRule)
+		// verify there is a valid IndexKey
+		if filterRule.IndexKey == "" {
+			log.Errorf("missing IndexKey for filter %s", filterRule.Name)
 			continue
 		}
-		rStruct, ok := tmpRecordKeyStructs[filterRule.RecordKey]
+		rStruct, ok := tmpIndexKeyStructs[filterRule.IndexKey]
 		if !ok {
-			rStruct = &RecordKeyTable{
+			rStruct = &IndexKeyTable{
 				maxTimeInterval: filterRule.TimeInterval.Duration,
 				dataTableMap:    make(DataTableMap),
 			}
-			tmpRecordKeyStructs[filterRule.RecordKey] = rStruct
-			log.Debugf("new RecordKeyTable: name = %s = %v", filterRule.RecordKey, *rStruct)
+			tmpIndexKeyStructs[filterRule.IndexKey] = rStruct
+			log.Debugf("new IndexKeyTable: name = %s = %v", filterRule.IndexKey, *rStruct)
 		} else {
 			if filterRule.TimeInterval.Duration > rStruct.maxTimeInterval {
 				rStruct.maxTimeInterval = filterRule.TimeInterval.Duration
@@ -93,12 +93,12 @@ func CreateRecordKeysAndFilters(rules []api.TimebasedFilterRule) (map[string]*Re
 			continue
 		}
 		tmpFilter := FilterStruct{
-			Rule:               filterRule,
-			RecordKeyDataTable: rStruct,
-			Results:            make(filterOperationResults),
+			Rule:              filterRule,
+			IndexKeyDataTable: rStruct,
+			Results:           make(filterOperationResults),
 		}
 		log.Debugf("new Rule = %v", tmpFilter)
 		tmpFilters = append(tmpFilters, tmpFilter)
 	}
-	return tmpRecordKeyStructs, tmpFilters
+	return tmpIndexKeyStructs, tmpFilters
 }

--- a/pkg/pipeline/extract/timebased/timebased.go
+++ b/pkg/pipeline/extract/timebased/timebased.go
@@ -80,7 +80,7 @@ func CreateRecordKeysAndFilters(rules []api.TimebasedFilterRule) (map[string]*Re
 			}
 		}
 		// verify the validity of the OperationType field in the filterRule
-		switch filterRule.Operation {
+		switch filterRule.OperationType {
 		case api.FilterOperationName("FilterOperationLast"),
 			api.FilterOperationName("FilterOperationDiff"),
 			api.FilterOperationName("FilterOperationAvg"),
@@ -89,7 +89,7 @@ func CreateRecordKeysAndFilters(rules []api.TimebasedFilterRule) (map[string]*Re
 			api.FilterOperationName("FilterOperationSum"):
 			// OK; nothing to do
 		default:
-			log.Errorf("illegal operation type %s", filterRule.Operation)
+			log.Errorf("illegal operation type %s", filterRule.OperationType)
 			continue
 		}
 		tmpFilter := FilterStruct{

--- a/pkg/pipeline/extract/timebased/timebased_test.go
+++ b/pkg/pipeline/extract/timebased/timebased_test.go
@@ -30,29 +30,29 @@ import (
 func getTimebasedRules() []api.TimebasedFilterRule {
 	rules := []api.TimebasedFilterRule{
 		{
-			Name:         "Top2_sum",
-			RecordKey:    "SrcAddr",
-			Operation:    "sum",
-			OperationKey: "Bytes",
-			TopK:         2,
-			TimeInterval: api.Duration{Duration: 1 * time.Second},
+			Name:          "Top2_sum",
+			RecordKey:     "SrcAddr",
+			OperationType: "sum",
+			OperationKey:  "Bytes",
+			TopK:          2,
+			TimeInterval:  api.Duration{Duration: 1 * time.Second},
 		},
 		{
-			Name:         "Bot2_last",
-			RecordKey:    "SrcAddr",
-			Operation:    "last",
-			OperationKey: "Bytes",
-			Reversed:     true,
-			TimeInterval: api.Duration{Duration: 3 * time.Second},
+			Name:          "Bot2_last",
+			RecordKey:     "SrcAddr",
+			OperationType: "last",
+			OperationKey:  "Bytes",
+			Reversed:      true,
+			TimeInterval:  api.Duration{Duration: 3 * time.Second},
 		},
 		{
-			Name:         "Top4_max",
-			RecordKey:    "DstAddr",
-			Operation:    "max",
-			OperationKey: "Bytes",
-			TopK:         4,
-			Reversed:     false,
-			TimeInterval: api.Duration{Duration: 1 * time.Second},
+			Name:          "Top4_max",
+			RecordKey:     "DstAddr",
+			OperationType: "max",
+			OperationKey:  "Bytes",
+			TopK:          4,
+			Reversed:      false,
+			TimeInterval:  api.Duration{Duration: 1 * time.Second},
 		},
 	}
 	return rules
@@ -75,12 +75,12 @@ func Test_CreateRecordKeysAndFilters(t *testing.T) {
 func Test_CreateRecordKeysAndFiltersError(t *testing.T) {
 	rules := []api.TimebasedFilterRule{
 		{
-			Name:         "filter1",
-			RecordKey:    "",
-			Operation:    "sum",
-			OperationKey: "operationKey1",
-			TopK:         2,
-			TimeInterval: api.Duration{Duration: 10 * time.Second},
+			Name:          "filter1",
+			RecordKey:     "",
+			OperationType: "sum",
+			OperationKey:  "operationKey1",
+			TopK:          2,
+			TimeInterval:  api.Duration{Duration: 10 * time.Second},
 		},
 	}
 	recordKeyStructs, filters := CreateRecordKeysAndFilters(rules)

--- a/pkg/test/e2e/pipline/flp-config.yaml
+++ b/pkg/test/e2e/pipline/flp-config.yaml
@@ -82,80 +82,80 @@ data:
             - name: bandwidth_network_service
               by:
                 - service
-              operation: sum
+              operationType: sum
               operationKey: bytes
             - name: bandwidth_source_destination_subnet
               by:
                 - dstSubnet24
                 - srcSubnet24
-              operation: sum
+              operationType: sum
               operationKey: bytes
             - name: bandwidth_source_subnet
               by:
                 - srcSubnet
-              operation: sum
+              operationType: sum
               operationKey: bytes
             - name: dest_connection_subnet_count
               by:
                 - dstSubnet
-              operation: sum
+              operationType: sum
               operationKey: isNewFlow
             - name: src_connection_count
               by:
                 - srcSubnet
-              operation: count
+              operationType: count
               operationKey: ""
             - name: TCPFlags_count
               by:
                 - TCPFlags
-              operation: count
+              operationType: count
               operationKey: ""
             - name: dst_as_connection_count
               by:
                 - dstAS
-              operation: count
+              operationType: count
               operationKey: ""
             - name: src_as_connection_count
               by:
                 - srcAS
-              operation: count
+              operationType: count
               operationKey: ""
             - name: count_source_destination_subnet
               by:
                 - dstSubnet24
                 - srcSubnet24
-              operation: count
+              operationType: count
               operationKey: ""
             - name: bandwidth_destination_subnet
               by:
                 - dstSubnet
-              operation: sum
+              operationType: sum
               operationKey: bytes
             - name: bandwidth_namespace
               by:
                 - srcK8S_Namespace
                 - srcK8S_Type
-              operation: sum
+              operationType: sum
               operationKey: bytes
             - name: dest_connection_location_count
               by:
                 - dstLocation_CountryName
-              operation: count
+              operationType: count
               operationKey: ""
             - name: mice_count
               by:
                 - mice_Evaluate
-              operation: count
+              operationType: count
               operationKey: ""
             - name: elephant_count
               by:
                 - elephant_Evaluate
-              operation: count
+              operationType: count
               operationKey: ""
             - name: dest_service_count
               by:
                 - service
-              operation: count
+              operationType: count
               operationKey: ""
           type: aggregates
         name: extract_aggregate

--- a/pkg/test/e2e/pipline/flp-config.yaml
+++ b/pkg/test/e2e/pipline/flp-config.yaml
@@ -80,80 +80,80 @@ data:
       - extract:
           aggregates:
             - name: bandwidth_network_service
-              by:
+              groupByKeys:
                 - service
               operationType: sum
               operationKey: bytes
             - name: bandwidth_source_destination_subnet
-              by:
+              groupByKeys:
                 - dstSubnet24
                 - srcSubnet24
               operationType: sum
               operationKey: bytes
             - name: bandwidth_source_subnet
-              by:
+              groupByKeys:
                 - srcSubnet
               operationType: sum
               operationKey: bytes
             - name: dest_connection_subnet_count
-              by:
+              groupByKeys:
                 - dstSubnet
               operationType: sum
               operationKey: isNewFlow
             - name: src_connection_count
-              by:
+              groupByKeys:
                 - srcSubnet
               operationType: count
               operationKey: ""
             - name: TCPFlags_count
-              by:
+              groupByKeys:
                 - TCPFlags
               operationType: count
               operationKey: ""
             - name: dst_as_connection_count
-              by:
+              groupByKeys:
                 - dstAS
               operationType: count
               operationKey: ""
             - name: src_as_connection_count
-              by:
+              groupByKeys:
                 - srcAS
               operationType: count
               operationKey: ""
             - name: count_source_destination_subnet
-              by:
+              groupByKeys:
                 - dstSubnet24
                 - srcSubnet24
               operationType: count
               operationKey: ""
             - name: bandwidth_destination_subnet
-              by:
+              groupByKeys:
                 - dstSubnet
               operationType: sum
               operationKey: bytes
             - name: bandwidth_namespace
-              by:
+              groupByKeys:
                 - srcK8S_Namespace
                 - srcK8S_Type
               operationType: sum
               operationKey: bytes
             - name: dest_connection_location_count
-              by:
+              groupByKeys:
                 - dstLocation_CountryName
               operationType: count
               operationKey: ""
             - name: mice_count
-              by:
+              groupByKeys:
                 - mice_Evaluate
               operationType: count
               operationKey: ""
             - name: elephant_count
-              by:
+              groupByKeys:
                 - elephant_Evaluate
               operationType: count
               operationKey: ""
             - name: dest_service_count
-              by:
+              groupByKeys:
                 - service
               operationType: count
               operationKey: ""
@@ -166,105 +166,105 @@ data:
                 type: counter
                 valueKey: bandwidth_network_service_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: bandwidth_per_source_destination_subnet
                 type: counter
                 valueKey: bandwidth_source_destination_subnet_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: bandwidth_per_source_subnet
                 type: counter
                 valueKey: bandwidth_source_subnet_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: connections_per_destination_subnet
                 type: counter
                 valueKey: dest_connection_subnet_count_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: connections_per_source_subnet
                 type: counter
                 valueKey: src_connection_count_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: connections_per_tcp_flags
                 type: counter
                 valueKey: TCPFlags_count_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: connections_per_destination_as
                 type: counter
                 valueKey: dst_as_connection_count_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: connections_per_source_as
                 type: counter
                 valueKey: src_as_connection_count_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: count_per_source_destination_subnet
                 type: counter
                 valueKey: count_source_destination_subnet_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: egress_per_destination_subnet
                 type: counter
                 valueKey: bandwidth_destination_subnet_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: egress_per_namespace
                 type: counter
                 valueKey: bandwidth_namespace_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: connections_per_destination_location
                 type: counter
                 valueKey: dest_connection_location_count_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: mice_count
                 type: counter
                 valueKey: mice_count_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: elephant_count
                 type: counter
                 valueKey: elephant_count_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
               - name: service_count
                 type: counter
                 valueKey: dest_service_count_value
                 labels:
-                  - by
+                  - groupByKeys
                   - aggregate
                 buckets: []
             port: 9102

--- a/pkg/test/e2e/pipline/flp-config.yaml
+++ b/pkg/test/e2e/pipline/flp-config.yaml
@@ -83,80 +83,80 @@ data:
               by:
                 - service
               operation: sum
-              recordKey: bytes
+              operationKey: bytes
             - name: bandwidth_source_destination_subnet
               by:
                 - dstSubnet24
                 - srcSubnet24
               operation: sum
-              recordKey: bytes
+              operationKey: bytes
             - name: bandwidth_source_subnet
               by:
                 - srcSubnet
               operation: sum
-              recordKey: bytes
+              operationKey: bytes
             - name: dest_connection_subnet_count
               by:
                 - dstSubnet
               operation: sum
-              recordKey: isNewFlow
+              operationKey: isNewFlow
             - name: src_connection_count
               by:
                 - srcSubnet
               operation: count
-              recordKey: ""
+              operationKey: ""
             - name: TCPFlags_count
               by:
                 - TCPFlags
               operation: count
-              recordKey: ""
+              operationKey: ""
             - name: dst_as_connection_count
               by:
                 - dstAS
               operation: count
-              recordKey: ""
+              operationKey: ""
             - name: src_as_connection_count
               by:
                 - srcAS
               operation: count
-              recordKey: ""
+              operationKey: ""
             - name: count_source_destination_subnet
               by:
                 - dstSubnet24
                 - srcSubnet24
               operation: count
-              recordKey: ""
+              operationKey: ""
             - name: bandwidth_destination_subnet
               by:
                 - dstSubnet
               operation: sum
-              recordKey: bytes
+              operationKey: bytes
             - name: bandwidth_namespace
               by:
                 - srcK8S_Namespace
                 - srcK8S_Type
               operation: sum
-              recordKey: bytes
+              operationKey: bytes
             - name: dest_connection_location_count
               by:
                 - dstLocation_CountryName
               operation: count
-              recordKey: ""
+              operationKey: ""
             - name: mice_count
               by:
                 - mice_Evaluate
               operation: count
-              recordKey: ""
+              operationKey: ""
             - name: elephant_count
               by:
                 - elephant_Evaluate
               operation: count
-              recordKey: ""
+              operationKey: ""
             - name: dest_service_count
               by:
                 - service
               operation: count
-              recordKey: ""
+              operationKey: ""
           type: aggregates
         name: extract_aggregate
       - encode:

--- a/pkg/test/network_defs.go
+++ b/pkg/test/network_defs.go
@@ -79,7 +79,7 @@ extract:
       by:
         - service
       operation: sum
-      recordKey: test_record_key
+      operationKey: test_operation_key
 encode:
   type: prom
   prom:
@@ -116,7 +116,7 @@ extract:
       by:
         - service
       operation: sum
-      recordKey: test_record_key
+      operationKey: test_operation_key
 encode:
   type: prom
   prom:

--- a/pkg/test/network_defs.go
+++ b/pkg/test/network_defs.go
@@ -78,7 +78,7 @@ extract:
     - name: test_aggregates
       by:
         - service
-      operation: sum
+      operationType: sum
       operationKey: test_operation_key
 encode:
   type: prom
@@ -115,7 +115,7 @@ extract:
     - name: test_agg_histo
       by:
         - service
-      operation: sum
+      operationType: sum
       operationKey: test_operation_key
 encode:
   type: prom

--- a/pkg/test/network_defs.go
+++ b/pkg/test/network_defs.go
@@ -76,7 +76,7 @@ transform:
 extract:
   aggregates:
     - name: test_aggregates
-      by:
+      groupByKeys:
         - service
       operationType: sum
       operationKey: test_operation_key
@@ -88,7 +88,7 @@ encode:
         type: gauge
         valueKey: test_aggregates_value
         labels:
-          - by
+          - groupByKeys
           - aggregate
 visualization:
   type: grafana
@@ -113,7 +113,7 @@ tags:
 extract:
   aggregates:
     - name: test_agg_histo
-      by:
+      groupByKeys:
         - service
       operationType: sum
       operationKey: test_operation_key
@@ -125,7 +125,7 @@ encode:
         type: histogram
         valueKey: test_aggregates_value
         labels:
-          - by
+          - groupByKeys
           - aggregate
 `
 

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -103,10 +103,10 @@ func GetExtractMockEntry() config.GenericMap {
 	return entry
 }
 
-func CreateMockAgg(name, recordKey, by, agg, op string, totalValue float64, totalCount int, rrv []float64, recentOpValue float64, recentCount int) config.GenericMap {
+func CreateMockAgg(name, operationKey, by, agg, op string, totalValue float64, totalCount int, rrv []float64, recentOpValue float64, recentCount int) config.GenericMap {
 	return config.GenericMap{
 		"name":              name,
-		"record_key":        recordKey,
+		"operation_key":     operationKey,
 		"by":                by,
 		"aggregate":         agg,
 		by:                  agg,

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -103,14 +103,14 @@ func GetExtractMockEntry() config.GenericMap {
 	return entry
 }
 
-func CreateMockAgg(name, operationKey, by, agg, op string, totalValue float64, totalCount int, rrv []float64, recentOpValue float64, recentCount int) config.GenericMap {
+func CreateMockAgg(name, operationKey, groupByKeys, agg, op string, totalValue float64, totalCount int, rrv []float64, recentOpValue float64, recentCount int) config.GenericMap {
 	return config.GenericMap{
 		"name":              name,
 		"operation_key":     operationKey,
-		"by":                by,
+		"by":                groupByKeys,
 		"aggregate":         agg,
-		by:                  agg,
-		"operation":         api.AggregateOperation(op),
+		groupByKeys:         agg,
+		"operation_type":    api.AggregateOperation(op),
 		"total_value":       totalValue,
 		"recent_raw_values": rrv,
 		"total_count":       totalCount,


### PR DESCRIPTION
Both extract-aggregate and extract-timebased use an `Operation` and a `key` on which to perform the operation. This PR changes the usage in extract-aggregate to match the usage in extract-timebased so that the field on which the `Operation` is performed is called `operationKey`.