### PR TITLE
Change metrics to use connection tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ Usage:
   flowlogs-pipeline [flags]  
   
 Flags:  
-      --config string        config file (default is $HOME/.flowlogs-pipeline)  
-      --health.port string   Health server port (default "8080")  
-  -h, --help                 help for flowlogs-pipeline  
-      --log-level string     Log level: debug, info, warning, error (default "error")  
-      --parameters string    json of config file parameters field  
-      --pipeline string      json of config file pipeline field
+      --config string             config file (default is $HOME/.flowlogs-pipeline)  
+      --health.port string        Health server port (default "8080")  
+  -h, --help                      help for flowlogs-pipeline  
+      --log-level string          Log level: debug, info, warning, error (default "error")  
+      --metrics-settings string   json for global metrics settings  
+      --parameters string         json of config file parameters field  
+      --pipeline string           json of config file pipeline field  
+      --profile.port int          Go pprof tool port (default: disabled)
 ```
 <!---END-AUTO-flowlogs-pipeline_help--->
 

--- a/contrib/dashboards/dashboard_details.json
+++ b/contrib/dashboards/dashboard_details.json
@@ -976,7 +976,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "loki",
+         "datasource": "prometheus",
          "fill": 1,
          "fillGradient": 0,
          "gridPos": {
@@ -986,6 +986,91 @@
             "y": 0
          },
          "id": 14,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "topk(10,rate(flp_connections_per_destination_location{_RecordType=\"newConnection\"}[1m]))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Connections rate per destinationIP geo-location",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "loki",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+         },
+         "id": 15,
          "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -1070,7 +1155,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 15,
+         "id": 16,
          "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -1155,7 +1240,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 16,
+         "id": 17,
          "legend": {
             "alignAsTable": false,
             "avg": false,

--- a/contrib/dashboards/dashboard_details.json
+++ b/contrib/dashboards/dashboard_details.json
@@ -182,91 +182,6 @@
          ]
       },
       {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "prometheus",
-         "fill": 1,
-         "fillGradient": 0,
-         "gridPos": {
-            "h": 20,
-            "w": 25,
-            "x": 0,
-            "y": 0
-         },
-         "id": 4,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
-         },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
-         "targets": [
-            {
-               "expr": "topk(10,rate(flp_bandwidth_per_source_subnet[1m]))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "A"
-            }
-         ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Bandwidth per source subnet",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
-      },
-      {
          "cards": {
             "cardPadding": null,
             "cardRound": null
@@ -289,7 +204,7 @@
          "heatmap": { },
          "hideZeroBuckets": false,
          "highlightCards": true,
-         "id": 5,
+         "id": 4,
          "legend": {
             "show": false
          },
@@ -335,7 +250,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 6,
+         "id": 5,
          "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -420,7 +335,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 7,
+         "id": 6,
          "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -448,7 +363,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "topk(10,rate(flp_connections_per_source_subnet[1m]))",
+               "expr": "topk(10,rate(flp_connections_per_source_subnet{_RecordType=\"newConnection\"}[1m]))",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "",
@@ -505,7 +420,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 8,
+         "id": 7,
          "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -590,6 +505,91 @@
             "x": 0,
             "y": 0
          },
+         "id": 8,
+         "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "total": false,
+            "values": false
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "topk(10,rate(flp_connections_per_destination_as{_RecordType=\"newConnection\"}[1m]))",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Connections rate per destination AS",
+         "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "prometheus",
+         "fill": 1,
+         "fillGradient": 0,
+         "gridPos": {
+            "h": 20,
+            "w": 25,
+            "x": 0,
+            "y": 0
+         },
          "id": 9,
          "legend": {
             "alignAsTable": false,
@@ -618,7 +618,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "topk(10,rate(flp_connections_per_destination_as[1m]))",
+               "expr": "topk(10,rate(flp_connections_per_source_as{_RecordType=\"newConnection\"}[1m]))",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "",
@@ -628,7 +628,7 @@
          "thresholds": [ ],
          "timeFrom": null,
          "timeShift": null,
-         "title": "Connections rate per destination AS",
+         "title": "Connections rate per source AS",
          "tooltip": {
             "shared": true,
             "sort": 0,
@@ -703,92 +703,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "topk(10,rate(flp_connections_per_source_as[1m]))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "A"
-            }
-         ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Connections rate per source AS",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
-      },
-      {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
-         "datasource": "prometheus",
-         "fill": 1,
-         "fillGradient": 0,
-         "gridPos": {
-            "h": 20,
-            "w": 25,
-            "x": 0,
-            "y": 0
-         },
-         "id": 11,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
-         },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
-         "targets": [
-            {
-               "expr": "topk(10,rate(flp_count_per_source_destination_subnet[1m]))",
+               "expr": "topk(10,rate(flp_count_per_source_destination_subnet{_RecordType=\"newConnection\"}[1m]))",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "",
@@ -845,7 +760,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 12,
+         "id": 11,
          "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -930,7 +845,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 13,
+         "id": 12,
          "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -1024,7 +939,7 @@
          "heatmap": { },
          "hideZeroBuckets": false,
          "highlightCards": true,
-         "id": 14,
+         "id": 13,
          "legend": {
             "show": false
          },
@@ -1061,91 +976,6 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "prometheus",
-         "fill": 1,
-         "fillGradient": 0,
-         "gridPos": {
-            "h": 20,
-            "w": 25,
-            "x": 0,
-            "y": 0
-         },
-         "id": 15,
-         "legend": {
-            "alignAsTable": false,
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "rightSide": false,
-            "show": true,
-            "sideWidth": null,
-            "total": false,
-            "values": false
-         },
-         "lines": true,
-         "linewidth": 1,
-         "links": [ ],
-         "nullPointMode": "null",
-         "percentage": false,
-         "pointradius": 5,
-         "points": false,
-         "renderer": "flot",
-         "repeat": null,
-         "seriesOverrides": [ ],
-         "spaceLength": 10,
-         "stack": false,
-         "steppedLine": false,
-         "targets": [
-            {
-               "expr": "topk(10,rate(flp_connections_per_destination_location[1m]))",
-               "format": "time_series",
-               "intervalFactor": 2,
-               "legendFormat": "",
-               "refId": "A"
-            }
-         ],
-         "thresholds": [ ],
-         "timeFrom": null,
-         "timeShift": null,
-         "title": "Connections rate per destinationIP geo-location",
-         "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-         },
-         "type": "graph",
-         "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": [ ]
-         },
-         "yaxes": [
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            },
-            {
-               "format": "short",
-               "label": null,
-               "logBase": 1,
-               "max": null,
-               "min": null,
-               "show": true
-            }
-         ]
-      },
-      {
-         "aliasColors": { },
-         "bars": false,
-         "dashLength": 10,
-         "dashes": false,
          "datasource": "loki",
          "fill": 1,
          "fillGradient": 0,
@@ -1155,7 +985,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 16,
+         "id": 14,
          "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -1240,7 +1070,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 17,
+         "id": 15,
          "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -1325,7 +1155,7 @@
             "x": 0,
             "y": 0
          },
-         "id": 18,
+         "id": 16,
          "legend": {
             "alignAsTable": false,
             "avg": false,
@@ -1353,7 +1183,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "topk(10,rate(flp_service_count[1m]))",
+               "expr": "topk(10,rate(flp_service_count{_RecordType=\"newConnection\"}[1m]))",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "",

--- a/contrib/dashboards/dashboard_details.json
+++ b/contrib/dashboards/dashboard_details.json
@@ -1098,7 +1098,7 @@
          "steppedLine": false,
          "targets": [
             {
-               "expr": "sum by (srcK8S_Namespace) (sum_over_time({job=\"flowlogs-pipeline\"} | json | unwrap bytes [1m]))",
+               "expr": "sum by (srcK8S_Namespace) (sum_over_time({job=\"flowlogs-pipeline\"} | json | unwrap bytes |  __error__=\"\" [1m]))",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "",

--- a/contrib/dashboards/dashboard_manual_locations_on_map.json
+++ b/contrib/dashboards/dashboard_manual_locations_on_map.json
@@ -80,7 +80,7 @@
               "showLegend": true,
               "style": {
                 "color": {
-                  "field": "aggregate",
+                  "field": "dstLocation_CountryName",
                   "fixed": "dark-green"
                 },
                 "opacity": 0.4,
@@ -101,7 +101,7 @@
                   "mode": "fixed"
                 },
                 "text": {
-                  "field": "aggregate",
+                  "field": "dstLocation_CountryName",
                   "fixed": "",
                   "mode": "field"
                 },
@@ -116,8 +116,8 @@
             },
             "location": {
               "gazetteer": "public/gazetteer/countries.json",
-              "geohash": "aggregate",
-              "lookup": "aggregate",
+              "geohash": "dstLocation_CountryName",
+              "lookup": "dstLocation_CountryName",
               "mode": "lookup"
             },
             "name": "Layer 1",

--- a/contrib/dashboards/dashboard_totals.json
+++ b/contrib/dashboards/dashboard_totals.json
@@ -223,7 +223,7 @@
          "tableColumn": "",
          "targets": [
             {
-               "expr": "count(flp_service_count)",
+               "expr": "count(flp_service_count{_RecordType=\"newConnection\"})",
                "format": "time_series",
                "intervalFactor": 2,
                "legendFormat": "",

--- a/contrib/dashboards/jsonnet/dashboard_details.jsonnet
+++ b/contrib/dashboards/jsonnet/dashboard_details.jsonnet
@@ -49,22 +49,6 @@ dashboard.new(
   }
 )
 .addPanel(
-  graphPanel.new(
-    datasource='prometheus',
-    title="Bandwidth per source subnet",
-  )
-  .addTarget(
-    prometheus.target(
-      expr='topk(10,rate(flp_bandwidth_per_source_subnet[1m]))',
-    )
-  ), gridPos={
-    x: 0,
-    y: 0,
-    w: 25,
-    h: 20,
-  }
-)
-.addPanel(
   heatmapPanel.new(
     datasource='prometheus',
     title="Connection size in bytes heatmap",
@@ -106,7 +90,7 @@ dashboard.new(
   )
   .addTarget(
     prometheus.target(
-      expr='topk(10,rate(flp_connections_per_source_subnet[1m]))',
+      expr='topk(10,rate(flp_connections_per_source_subnet{_RecordType="newConnection"}[1m]))',
     )
   ), gridPos={
     x: 0,
@@ -138,7 +122,7 @@ dashboard.new(
   )
   .addTarget(
     prometheus.target(
-      expr='topk(10,rate(flp_connections_per_destination_as[1m]))',
+      expr='topk(10,rate(flp_connections_per_destination_as{_RecordType="newConnection"}[1m]))',
     )
   ), gridPos={
     x: 0,
@@ -154,7 +138,7 @@ dashboard.new(
   )
   .addTarget(
     prometheus.target(
-      expr='topk(10,rate(flp_connections_per_source_as[1m]))',
+      expr='topk(10,rate(flp_connections_per_source_as{_RecordType="newConnection"}[1m]))',
     )
   ), gridPos={
     x: 0,
@@ -170,7 +154,7 @@ dashboard.new(
   )
   .addTarget(
     prometheus.target(
-      expr='topk(10,rate(flp_count_per_source_destination_subnet[1m]))',
+      expr='topk(10,rate(flp_count_per_source_destination_subnet{_RecordType="newConnection"}[1m]))',
     )
   ), gridPos={
     x: 0,
@@ -232,22 +216,6 @@ dashboard.new(
 )
 .addPanel(
   graphPanel.new(
-    datasource='prometheus',
-    title="Connections rate per destinationIP geo-location",
-  )
-  .addTarget(
-    prometheus.target(
-      expr='topk(10,rate(flp_connections_per_destination_location[1m]))',
-    )
-  ), gridPos={
-    x: 0,
-    y: 0,
-    w: 25,
-    h: 20,
-  }
-)
-.addPanel(
-  graphPanel.new(
     datasource='loki',
     title="Bandwidth per source namespace",
   )
@@ -285,7 +253,7 @@ dashboard.new(
   )
   .addTarget(
     prometheus.target(
-      expr='topk(10,rate(flp_service_count[1m]))',
+      expr='topk(10,rate(flp_service_count{_RecordType="newConnection"}[1m]))',
     )
   ), gridPos={
     x: 0,

--- a/contrib/dashboards/jsonnet/dashboard_details.jsonnet
+++ b/contrib/dashboards/jsonnet/dashboard_details.jsonnet
@@ -216,6 +216,22 @@ dashboard.new(
 )
 .addPanel(
   graphPanel.new(
+    datasource='prometheus',
+    title="Connections rate per destinationIP geo-location",
+  )
+  .addTarget(
+    prometheus.target(
+      expr='topk(10,rate(flp_connections_per_destination_location{_RecordType="newConnection"}[1m]))',
+    )
+  ), gridPos={
+    x: 0,
+    y: 0,
+    w: 25,
+    h: 20,
+  }
+)
+.addPanel(
+  graphPanel.new(
     datasource='loki',
     title="Bandwidth per source namespace",
   )

--- a/contrib/dashboards/jsonnet/dashboard_details.jsonnet
+++ b/contrib/dashboards/jsonnet/dashboard_details.jsonnet
@@ -237,7 +237,7 @@ dashboard.new(
   )
   .addTarget(
     prometheus.target(
-      expr='sum by (srcK8S_Namespace) (sum_over_time({job="flowlogs-pipeline"} | json | unwrap bytes [1m]))',
+      expr='sum by (srcK8S_Namespace) (sum_over_time({job="flowlogs-pipeline"} | json | unwrap bytes |  __error__="" [1m]))',
     )
   ), gridPos={
     x: 0,

--- a/contrib/dashboards/jsonnet/dashboard_totals.jsonnet
+++ b/contrib/dashboards/jsonnet/dashboard_totals.jsonnet
@@ -87,7 +87,7 @@ dashboard.new(
   )
   .addTarget(
     prometheus.target(
-      expr='count(flp_service_count)',
+      expr='count(flp_service_count{_RecordType="newConnection"})',
     )
   ), gridPos={
     x: 0,

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -83,9 +83,6 @@ parameters:
         output: all
         type: add_if
         parameters: '>=0'
-      - input: dstIP
-        output: dstLocation
-        type: add_location
 - name: extract_conntrack
   extract:
     type: conntrack
@@ -225,11 +222,6 @@ parameters:
       - _RecordType
       operationType: raw_values
       operationKey: bytes
-    - name: dest_connection_location_count
-      groupByKeys:
-      - dstLocation_CountryName
-      - _RecordType
-      operationType: count
     - name: dest_service_count
       groupByKeys:
       - service
@@ -322,8 +314,8 @@ parameters:
           value: src_connection_count
         valueKey: recent_count
         labels:
-        - groupByKeys
-        - aggregate
+        - srcSubnet
+        - _RecordType
         buckets: []
       - name: connections_per_tcp_flags
         type: counter
@@ -342,8 +334,8 @@ parameters:
           value: dst_as_connection_count
         valueKey: recent_count
         labels:
-        - groupByKeys
-        - aggregate
+        - dstAS
+        - _RecordType
         buckets: []
       - name: connections_per_source_as
         type: counter
@@ -352,8 +344,8 @@ parameters:
           value: src_as_connection_count
         valueKey: recent_count
         labels:
-        - groupByKeys
-        - aggregate
+        - srcAS
+        - _RecordType
         buckets: []
       - name: count_per_source_destination_subnet
         type: counter
@@ -362,8 +354,9 @@ parameters:
           value: count_source_destination_subnet
         valueKey: recent_count
         labels:
-        - groupByKeys
-        - aggregate
+        - dstSubnet24
+        - srcSubnet24
+        - _RecordType
         buckets: []
       - name: egress_per_destination_subnet
         type: counter
@@ -400,16 +393,6 @@ parameters:
         - 10240
         - 102400
         - 1.048576e+06
-      - name: connections_per_destination_location
-        type: counter
-        filter:
-          key: name
-          value: dest_connection_location_count
-        valueKey: recent_count
-        labels:
-        - groupByKeys
-        - aggregate
-        buckets: []
       - name: service_count
         type: counter
         filter:
@@ -417,8 +400,8 @@ parameters:
           value: dest_service_count
         valueKey: recent_count
         labels:
-        - groupByKeys
-        - aggregate
+        - service
+        - _RecordType
         buckets: []
       port: 9102
       prefix: flp_

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -60,10 +60,12 @@ parameters:
           fields:
           - srcIP
           - srcPort
+          - srcAS
         - name: dst
           fields:
           - dstIP
           - dstPort
+          - dstAS
         - name: protocol
           fields:
           - proto
@@ -131,6 +133,9 @@ parameters:
         output: all
         type: add_if
         parameters: '>=0'
+      - input: dstIP
+        output: dstLocation
+        type: add_location
 - name: extract_aggregate
   extract:
     type: aggregates
@@ -220,6 +225,11 @@ parameters:
       - _RecordType
       operationType: raw_values
       operationKey: bytes
+    - name: dest_connection_location_count
+      groupByKeys:
+      - dstLocation_CountryName
+      - _RecordType
+      operationType: count
     - name: dest_service_count
       groupByKeys:
       - service
@@ -391,6 +401,16 @@ parameters:
         - 10240
         - 102400
         - 1.048576e+06
+      - name: connections_per_destination_location
+        type: counter
+        filter:
+          key: name
+          value: dest_connection_location_count
+        valueKey: recent_count
+        labels:
+        - dstLocation_CountryName
+        - _RecordType
+        buckets: []
       - name: service_count
         type: counter
         filter:

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -4,16 +4,16 @@ pipeline:
 - name: ingest_collector
 - name: transform_generic
   follows: ingest_collector
-- name: transform_network
-  follows: transform_generic
 - name: extract_conntrack
-  follows: transform_network
-- name: extract_aggregate
+  follows: transform_generic
+- name: transform_network
   follows: extract_conntrack
+- name: extract_aggregate
+  follows: transform_network
 - name: encode_prom
   follows: extract_aggregate
 - name: write_loki
-  follows: extract_conntrack
+  follows: transform_network
 parameters:
 - name: ingest_collector
   ingest:
@@ -50,39 +50,6 @@ parameters:
         output: packets
       - input: TimeReceived
         output: timeReceived
-- name: transform_network
-  transform:
-    type: network
-    network:
-      rules:
-      - input: dstPort
-        output: service
-        type: add_service
-        parameters: proto
-      - input: dstIP
-        output: dstSubnet24
-        type: add_subnet
-        parameters: /24
-      - input: srcIP
-        output: srcSubnet24
-        type: add_subnet
-        parameters: /24
-      - input: srcIP
-        output: srcSubnet
-        type: add_subnet
-        parameters: /16
-      - input: dstIP
-        output: dstSubnet
-        type: add_subnet
-        parameters: /16
-      - input: srcIP
-        output: srcK8S
-        type: add_kubernetes
-        parameters: srcK8S_labels
-      - input: bytes
-        output: all
-        type: add_if
-        parameters: '>=0'
 - name: extract_conntrack
   extract:
     type: conntrack
@@ -93,12 +60,10 @@ parameters:
           fields:
           - srcIP
           - srcPort
-          - srcSubnet
         - name: dst
           fields:
           - dstIP
           - dstPort
-          - dstSubnet
         - name: protocol
           fields:
           - proto
@@ -133,6 +98,39 @@ parameters:
         operation: max
         input: timeReceived
       endConnectionTimeout: 30s
+- name: transform_network
+  transform:
+    type: network
+    network:
+      rules:
+      - input: dstPort
+        output: service
+        type: add_service
+        parameters: proto
+      - input: dstIP
+        output: dstSubnet24
+        type: add_subnet
+        parameters: /24
+      - input: srcIP
+        output: srcSubnet24
+        type: add_subnet
+        parameters: /24
+      - input: srcIP
+        output: srcSubnet
+        type: add_subnet
+        parameters: /16
+      - input: dstIP
+        output: dstSubnet
+        type: add_subnet
+        parameters: /16
+      - input: srcIP
+        output: srcK8S
+        type: add_kubernetes
+        parameters: srcK8S_labels
+      - input: bytes
+        output: all
+        type: add_if
+        parameters: '>=0'
 - name: extract_aggregate
   extract:
     type: aggregates

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -18,7 +18,7 @@ and the transformation to generate the exported metric.
 | **Details** | Sum bytes for all traffic per network service | 
 | **Usage** | Evaluate network usage breakdown per network service | 
 | **Tags** | bandwidth, graph, rate, network-service |
-| **Operation** | aggregate by `service, _RecordType` and `sum` field `bytes` |
+| **OperationType** | aggregate by `service, _RecordType` and `sum` field `bytes` |
 | **Exposed as** | `flp_bandwidth_per_network_service` of type `counter` |
 | **Visualized as** | "Bandwidth per network service" on dashboard `details` |
 |||  
@@ -30,21 +30,9 @@ and the transformation to generate the exported metric.
 | **Details** | Sum bandwidth bytes for all traffic per source / destination subnet pair | 
 | **Usage** | Evaluate network usage breakdown per source / destination subnet pair | 
 | **Tags** | bandwidth, graph, rate, subnet |
-| **Operation** | aggregate by `dstSubnet24, srcSubnet24, _RecordType` and `sum` field `bytes` |
+| **OperationType** | aggregate by `dstSubnet24, srcSubnet24, _RecordType` and `sum` field `bytes` |
 | **Exposed as** | `flp_bandwidth_per_source_destination_subnet` of type `counter` |
 | **Visualized as** | "Bandwidth per src and destination subnet" on dashboard `details` |
-|||  
-
-
-### bandwidth per src subnet
-| **Description** | This metric observes the network bandwidth per source subnet | 
-|:---|:---|
-| **Details** | Sum bytes for all traffic per source subnet | 
-| **Usage** | Evaluate network usage breakdown per source subnet | 
-| **Tags** | bandwidth, graph, rate, subnet |
-| **Operation** | aggregate by `srcSubnet, _RecordType` and `sum` field `bytes` |
-| **Exposed as** | `flp_bandwidth_per_source_subnet` of type `counter` |
-| **Visualized as** | "Bandwidth per source subnet" on dashboard `details` |
 |||  
 
 
@@ -54,12 +42,12 @@ and the transformation to generate the exported metric.
 | **Details** | Connection size in bytes distribution over time | 
 | **Usage** | Evaluate connection size behavior including mice/elephant use-case | 
 | **Tags** | bandwidth, mice, elephant, rate |
-| **Operation** | aggregate by `_RecordType` and `raw_values` field `bytes_total` |
-| **Operation** | aggregate by `_RecordType` and `raw_values` field `bytes_AB` |
-| **Operation** | aggregate by `_RecordType` and `raw_values` field `bytes_BA` |
-| **Exposed as** | `flp_connection_size_histogram` of type `histogram` |
-| **Exposed as** | `flp_connection_size_histogram_ab` of type `histogram` |
-| **Exposed as** | `flp_connection_size_histogram_ba` of type `histogram` |
+| **OperationType** | aggregate by `_RecordType` and `raw_values` field `bytes_total` |
+| **OperationType** | aggregate by `_RecordType` and `raw_values` field `bytes_AB` |
+| **OperationType** | aggregate by `_RecordType` and `raw_values` field `bytes_BA` |
+| **Exposed as** | `flp_connection_size_histogram` of type `agg_histogram` |
+| **Exposed as** | `flp_connection_size_histogram_ab` of type `agg_histogram` |
+| **Exposed as** | `flp_connection_size_histogram_ba` of type `agg_histogram` |
 | **Visualized as** | "Connection size in bytes heatmap" on dashboard `details` |
 | **Visualized as** | "Connection size in bytes histogram" on dashboard `totals` |
 |||  
@@ -71,7 +59,7 @@ and the transformation to generate the exported metric.
 | **Details** | Counts the number of connections per subnet with network prefix length /16 | 
 | **Usage** | Evaluate network connections per subnet | 
 | **Tags** | rate, subnet |
-| **Operation** | aggregate by `dstSubnet, _RecordType` and `count`  |
+| **OperationType** | aggregate by `dstSubnet, _RecordType` and `count` field `isNewFlow` |
 | **Exposed as** | `flp_connections_per_destination_subnet` of type `counter` |
 | **Visualized as** | "Connections rate per destinationIP /16 subnets" on dashboard `details` |
 |||  
@@ -83,7 +71,7 @@ and the transformation to generate the exported metric.
 | **Details** | Counts the number of connections per subnet with network prefix length /16 | 
 | **Usage** | Evaluate network connections per subnet | 
 | **Tags** | rate, subnet |
-| **Operation** | aggregate by `srcSubnet, _RecordType` and `count`  |
+| **OperationType** | aggregate by `srcSubnet, _RecordType` and `count`  |
 | **Exposed as** | `flp_connections_per_source_subnet` of type `counter` |
 | **Visualized as** | "Connections rate per sourceIP /16 subnets" on dashboard `details` |
 |||  
@@ -95,7 +83,7 @@ and the transformation to generate the exported metric.
 | **Details** | Counts the number of connections per tcp flags | 
 | **Usage** | Evaluate difference in connections rate of different TCP Flags. Can be used, for example, to identify syn-attacks. | 
 | **Tags** | rate, TCPFlags |
-| **Operation** | aggregate by `TCPFlags, _RecordType` and `count`  |
+| **OperationType** | aggregate by `TCPFlags, _RecordType` and `count`  |
 | **Exposed as** | `flp_connections_per_tcp_flags` of type `counter` |
 | **Visualized as** | "Connections rate per TCPFlags" on dashboard `details` |
 |||  
@@ -107,7 +95,7 @@ and the transformation to generate the exported metric.
 | **Details** | Aggregates flow records by values of "DstAS" field and counts the number of entries in each aggregate with non zero value | 
 | **Usage** | Evaluate amount of connections targeted at different Autonomous Systems | 
 | **Tags** | rate, count, AS |
-| **Operation** | aggregate by `dstAS, _RecordType` and `count`  |
+| **OperationType** | aggregate by `dstAS, _RecordType` and `count`  |
 | **Exposed as** | `flp_connections_per_destination_as` of type `counter` |
 | **Visualized as** | "Connections rate per destination AS" on dashboard `details` |
 |||  
@@ -119,7 +107,7 @@ and the transformation to generate the exported metric.
 | **Details** | Aggregates flow records by values of "SrcAS" field and counts the number of entries in each aggregate with non zero value | 
 | **Usage** | Evaluate amount of connections initiated by different Autonomous Systems | 
 | **Tags** | rate, count, AS |
-| **Operation** | aggregate by `srcAS, _RecordType` and `count`  |
+| **OperationType** | aggregate by `srcAS, _RecordType` and `count`  |
 | **Exposed as** | `flp_connections_per_source_as` of type `counter` |
 | **Visualized as** | "Connections rate per source AS" on dashboard `details` |
 |||  
@@ -131,7 +119,7 @@ and the transformation to generate the exported metric.
 | **Details** | Count the number of distinct source / destination subnet pairs | 
 | **Usage** | Evaluate network usage breakdown per source / destination subnet pair | 
 | **Tags** | count, graph, rate, subnet |
-| **Operation** | aggregate by `dstSubnet24, srcSubnet24, _RecordType` and `count`  |
+| **OperationType** | aggregate by `dstSubnet24, srcSubnet24, _RecordType` and `count`  |
 | **Exposed as** | `flp_count_per_source_destination_subnet` of type `counter` |
 | **Visualized as** | "Connections rate of src / destination subnet occurences" on dashboard `details` |
 |||  
@@ -143,7 +131,7 @@ and the transformation to generate the exported metric.
 | **Details** | Sum egress bytes for all traffic per destination subnet | 
 | **Usage** | Evaluate network usage breakdown per destination subnet | 
 | **Tags** | bandwidth, graph, rate, subnet |
-| **Operation** | aggregate by `dstSubnet, _RecordType` and `sum` field `bytes` |
+| **OperationType** | aggregate by `dstSubnet, _RecordType` and `sum` field `bytes` |
 | **Exposed as** | `flp_egress_per_destination_subnet` of type `counter` |
 | **Visualized as** | "Bandwidth per destination subnet" on dashboard `details` |
 | **Visualized as** | "Total bandwidth" on dashboard `totals` |
@@ -156,7 +144,7 @@ and the transformation to generate the exported metric.
 | **Details** | Sum egress bytes for all traffic per namespace | 
 | **Usage** | Evaluate network usage breakdown per namespace | 
 | **Tags** | kubernetes, bandwidth, graph |
-| **Operation** | aggregate by `srcK8S_Namespace, srcK8S_Type, _RecordType` and `sum` field `bytes` |
+| **OperationType** | aggregate by `srcK8S_Namespace, srcK8S_Type, _RecordType` and `sum` field `bytes` |
 | **Exposed as** | `flp_egress_per_namespace` of type `counter` |
 | **Visualized as** | "Bandwidth per namespace" on dashboard `details` |
 |||  
@@ -168,22 +156,10 @@ and the transformation to generate the exported metric.
 | **Details** | Flows length distribution over time | 
 | **Usage** | Evaluate flows length behavior including mice/elephant use-case | 
 | **Tags** | bandwidth, mice, elephant, rate |
-| **Operation** | aggregate by `all_Evaluate, _RecordType` and `raw_values` field `bytes` |
-| **Exposed as** | `flp_flows_length_histogram` of type `histogram` |
+| **OperationType** | aggregate by `all_Evaluate, _RecordType` and `raw_values` field `bytes` |
+| **Exposed as** | `flp_flows_length_histogram` of type `agg_histogram` |
 | **Visualized as** | "Flows length heatmap" on dashboard `details` |
 | **Visualized as** | "Flows length histogram" on dashboard `totals` |
-|||  
-
-
-### geo location rate per dest
-| **Description** | This metric observes connections geo-location rate per destination IP | 
-|:---|:---|
-| **Details** | Counts the number of connections per geo-location based on destination IP | 
-| **Usage** | Evaluate network connections geo-location | 
-| **Tags** | rate, connections-count, geo-location, destinationIP |
-| **Operation** | aggregate by `dstLocation_CountryName, _RecordType` and `count`  |
-| **Exposed as** | `flp_connections_per_destination_location` of type `counter` |
-| **Visualized as** | "Connections rate per destinationIP geo-location" on dashboard `details` |
 |||  
 
 
@@ -213,7 +189,7 @@ and the transformation to generate the exported metric.
 | **Details** | Counts the number of connections per network service based on destination port number and protocol | 
 | **Usage** | Evaluate network services | 
 | **Tags** | rate, network-services, destination-port, destination-protocol |
-| **Operation** | aggregate by `service, _RecordType` and `count`  |
+| **OperationType** | aggregate by `service, _RecordType` and `count`  |
 | **Exposed as** | `flp_service_count` of type `counter` |
 | **Visualized as** | "Network services connections rate" on dashboard `details` |
 | **Visualized as** | "Number of network services" on dashboard `totals` |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -163,6 +163,18 @@ and the transformation to generate the exported metric.
 |||  
 
 
+### geo location rate per dest
+| **Description** | This metric observes connections geo-location rate per destination IP | 
+|:---|:---|
+| **Details** | Counts the number of connections per geo-location based on destination IP | 
+| **Usage** | Evaluate network connections geo-location | 
+| **Tags** | rate, connections-count, geo-location, destinationIP |
+| **OperationType** | aggregate by `dstLocation_CountryName, _RecordType` and `count`  |
+| **Exposed as** | `flp_connections_per_destination_location` of type `counter` |
+| **Visualized as** | "Connections rate per destinationIP geo-location" on dashboard `details` |
+|||  
+
+
 ### loki bandwidth per namespace
 | **Description** | This metric observes the bandwidth per namespace (from Loki) | 
 |:---|:---|

--- a/docs/operational-metrics.md
+++ b/docs/operational-metrics.md
@@ -111,3 +111,10 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 | **Labels** | stage | 
 
 
+### stage_duration_ms
+| **Name** | stage_duration_ms | 
+|:---|:---|
+| **Description** | Pipeline stage duration in milliseconds | 
+| **Type** | histogram | 
+
+

--- a/docs/operational-metrics.md
+++ b/docs/operational-metrics.md
@@ -111,10 +111,3 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 | **Labels** | stage | 
 
 
-### stage_duration_ms
-| **Name** | stage_duration_ms | 
-|:---|:---|
-| **Description** | Pipeline stage duration in milliseconds | 
-| **Type** | histogram | 
-
-

--- a/network_definitions/config.yaml
+++ b/network_definitions/config.yaml
@@ -46,12 +46,12 @@ extract:
           fields:
             - srcIP
             - srcPort
-            - srcSubnet
+            - srcAS
         - name: dst
           fields:
             - dstIP
             - dstPort
-            - dstSubnet
+            - dstAS
         - name: protocol
           fields:
             - proto

--- a/network_definitions/connection_rate_per_src_subnet.yaml
+++ b/network_definitions/connection_rate_per_src_subnet.yaml
@@ -31,12 +31,12 @@ encode:
         filter: {key: name, value: src_connection_count}
         valueKey: recent_count
         labels:
-          - groupByKeys
-          - aggregate
+          - srcSubnet
+          - _RecordType
 visualization:
   type: grafana
   grafana:
-    - expr: 'topk(10,rate(flp_connections_per_source_subnet[1m]))'
+    - expr: 'topk(10,rate(flp_connections_per_source_subnet{_RecordType="newConnection"}[1m]))'
       type: graphPanel
       dashboard: details
       title:

--- a/network_definitions/connections_per_dst_as.yaml
+++ b/network_definitions/connections_per_dst_as.yaml
@@ -26,12 +26,12 @@ encode:
         filter: { key: name, value: dst_as_connection_count }
         valueKey: recent_count
         labels:
-          - groupByKeys
-          - aggregate
+          - dstAS
+          - _RecordType
 visualization:
   type: grafana
   grafana:
-    - expr: 'topk(10,rate(flp_connections_per_destination_as[1m]))'
+    - expr: 'topk(10,rate(flp_connections_per_destination_as{_RecordType="newConnection"}[1m]))'
       type: graphPanel
       dashboard: details
       title:

--- a/network_definitions/connections_per_src_as.yaml
+++ b/network_definitions/connections_per_src_as.yaml
@@ -26,12 +26,12 @@ encode:
         filter: { key: name, value: src_as_connection_count }
         valueKey: recent_count
         labels:
-          - groupByKeys
-          - aggregate
+          - srcAS
+          - _RecordType
 visualization:
   type: grafana
   grafana:
-    - expr: 'topk(10,rate(flp_connections_per_source_as[1m]))'
+    - expr: 'topk(10,rate(flp_connections_per_source_as{_RecordType="newConnection"}[1m]))'
       type: graphPanel
       dashboard: details
       title:

--- a/network_definitions/count_per_src_dest_subnet.yaml
+++ b/network_definitions/count_per_src_dest_subnet.yaml
@@ -37,12 +37,13 @@ encode:
         filter: { key: name, value: count_source_destination_subnet }
         valueKey: recent_count
         labels:
-          - groupByKeys
-          - aggregate
+          - dstSubnet24
+          - srcSubnet24
+          - _RecordType
 visualization:
   type: grafana
   grafana:
-    - expr: 'topk(10,rate(flp_count_per_source_destination_subnet[1m]))'
+    - expr: 'topk(10,rate(flp_count_per_source_destination_subnet{_RecordType="newConnection"}[1m]))'
       type: graphPanel
       dashboard: details
       title:

--- a/network_definitions/geo-location_rate_per_dest.yaml
+++ b/network_definitions/geo-location_rate_per_dest.yaml
@@ -32,13 +32,8 @@ encode:
         filter: { key: name, value: dest_connection_location_count }
         valueKey: recent_count
         labels:
-<<<<<<< HEAD
-          - groupByKeys
-          - aggregate
-=======
           - dstLocation_CountryName
           - _RecordType
->>>>>>> Fix metrics to use connection tracking
 visualization:
   type: grafana
   grafana:

--- a/network_definitions/geo-location_rate_per_dest.yaml
+++ b/network_definitions/geo-location_rate_per_dest.yaml
@@ -32,12 +32,17 @@ encode:
         filter: { key: name, value: dest_connection_location_count }
         valueKey: recent_count
         labels:
+<<<<<<< HEAD
           - groupByKeys
           - aggregate
+=======
+          - dstLocation_CountryName
+          - _RecordType
+>>>>>>> Fix metrics to use connection tracking
 visualization:
   type: grafana
   grafana:
-    - expr: 'topk(10,rate(flp_connections_per_destination_location[1m]))'
+    - expr: 'topk(10,rate(flp_connections_per_destination_location{_RecordType="newConnection"}[1m]))'
       type: graphPanel
       dashboard: details
       title:

--- a/network_definitions/loki_bandwidth_per_namespace.yaml
+++ b/network_definitions/loki_bandwidth_per_namespace.yaml
@@ -13,7 +13,7 @@ tags:
 visualization:
   type: grafana
   grafana:
-    - expr: 'sum by (srcK8S_Namespace) (sum_over_time({job="flowlogs-pipeline"} | json | unwrap bytes [1m]))'
+    - expr: 'sum by (srcK8S_Namespace) (sum_over_time({job="flowlogs-pipeline"} | json | unwrap bytes |  __error__="" [1m]))'
       type: lokiGraphPanel
       dashboard: details
       title:

--- a/network_definitions/network_services_count.yaml
+++ b/network_definitions/network_services_count.yaml
@@ -33,17 +33,17 @@ encode:
         filter: { key: name, value: dest_service_count }
         valueKey: recent_count
         labels:
-          - groupByKeys
-          - aggregate
+          - service
+          - _RecordType
 visualization:
   type: grafana
   grafana:
-    - expr: 'topk(10,rate(flp_service_count[1m]))'
+    - expr: 'topk(10,rate(flp_service_count{_RecordType="newConnection"}[1m]))'
       type: graphPanel
       dashboard: details
       title:
         Network services connections rate
-    - expr: 'count(flp_service_count)'
+    - expr: 'count(flp_service_count{_RecordType="newConnection"})'
       type: singleStat
       dashboard: totals
       title:

--- a/pkg/confgen/flowlogs2metrics_config.go
+++ b/pkg/confgen/flowlogs2metrics_config.go
@@ -37,13 +37,13 @@ func (cg *ConfGen) GenerateFlowlogs2PipelineConfig() *config.ConfigFileStruct {
 		}
 		forkedNode = forkedNode.TransformGeneric("transform_generic", gen)
 	}
+	if cg.config.Extract.ConnTrack != nil {
+		forkedNode = forkedNode.ConnTrack("extract_conntrack", *cg.config.Extract.ConnTrack)
+	}
 	if len(cg.transformRules) > 0 {
 		forkedNode = forkedNode.TransformNetwork("transform_network", api.TransformNetwork{
 			Rules: cg.transformRules,
 		})
-	}
-	if cg.config.Extract.ConnTrack != nil {
-		forkedNode = forkedNode.ConnTrack("extract_conntrack", *cg.config.Extract.ConnTrack)
 	}
 	metricsNode := forkedNode
 	if len(cg.aggregateDefinitions) > 0 {


### PR DESCRIPTION
This PR changes the metrics that rely on connections to use the connection tracking

~~I have an issue with fixing [geo-location_rate_per_dest.yaml](https://github.com/netobserv/flowlogs-pipeline/blob/c4e2f41fc0f7d720b97e5d1d2033fc17e8aaf48c/network_definitions/geo-location_rate_per_dest.yaml)
The problem is that I need to add `dstLocation_CountryName` to the connection tracking key fields of `dst`:~~
https://github.com/netobserv/flowlogs-pipeline/blob/c4e2f41fc0f7d720b97e5d1d2033fc17e8aaf48c/network_definitions/config.yaml#L49-L52
~~But, there is no symmetric `srcLocation_CountryName` to add to the `src` section.~~

~~Adding a field to the `dst` section with no symmetric field in the `src` section will cause the grouping of flow-logs into connections to stop working in the bi-directional case. The hash of the flow-logs from `dst` to `src` will be different from the hash from `src` to `dst`.~~ The issue has been solved by moving the connection tracking one step back in the pipeline between `transform_generic` and `transform_network`.