### PR TITLE
added TopK to bandwidth_per_src_subnet

### DIFF
--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -10,8 +10,10 @@ pipeline:
   follows: transform_network
 - name: extract_aggregate
   follows: extract_conntrack
-- name: encode_prom
+- name: extract_timebased
   follows: extract_aggregate
+- name: encode_prom
+  follows: extract_timebased
 - name: write_loki
   follows: extract_conntrack
 parameters:
@@ -237,6 +239,17 @@ parameters:
       - service
       - _RecordType
       operation: count
+- name: extract_timebased
+  extract:
+    type: timebased
+    timebased:
+      rules:
+      - name: bandwidth_source_subnet
+        recordKey: srcSubnet
+        operation: sum
+        operationKey: total_value
+        topK: 5
+        timeInterval: 1m0s
 - name: encode_prom
   encode:
     type: prom
@@ -263,17 +276,16 @@ parameters:
         - aggregate
         buckets: []
       - name: bandwidth_per_source_subnet
-        type: counter
+        type: gauge
         filter:
           key: name
           value: bandwidth_source_subnet
-        valueKey: recent_op_value
+        valueKey: operation_result
         labels:
-        - by
-        - aggregate
+        - srcSubnet
         buckets: []
       - name: connection_size_histogram
-        type: histogram
+        type: agg_histogram
         filter:
           key: name
           value: connection_bytes_hist
@@ -288,7 +300,7 @@ parameters:
         - 102400
         - 1.048576e+06
       - name: connection_size_histogram_ab
-        type: histogram
+        type: agg_histogram
         filter:
           key: name
           value: connection_bytes_hist_AB
@@ -303,7 +315,7 @@ parameters:
         - 102400
         - 1.048576e+06
       - name: connection_size_histogram_ba
-        type: histogram
+        type: agg_histogram
         filter:
           key: name
           value: connection_bytes_hist_BA
@@ -398,7 +410,7 @@ parameters:
         - aggregate
         buckets: []
       - name: flows_length_histogram
-        type: histogram
+        type: agg_histogram
         filter:
           key: name
           value: flows_bytes_hist

--- a/network_definitions/bandwidth_per_src_subnet.yaml
+++ b/network_definitions/bandwidth_per_src_subnet.yaml
@@ -24,17 +24,24 @@ extract:
         - _RecordType
       operation: sum
       recordKey: bytes
+  timebased:
+    rules:
+      - name: bandwidth_source_subnet
+        operation: sum
+        operationKey: total_value
+        recordKey: srcSubnet
+        topK: 5
+        timeInterval: 1m
 encode:
   type: prom
   prom:
     metrics:
       - name: bandwidth_per_source_subnet
-        type: counter
+        type: gauge
         filter: {key: name, value: bandwidth_source_subnet}
-        valueKey: recent_op_value
+        valueKey: operation_result
         labels:
-          - by
-          - aggregate
+          - srcSubnet
 visualization:
   type: grafana
   grafana:


### PR DESCRIPTION
This PR uses the timebased TopK feature in the standard metrics produced by flp. The relevant metric is flp_bandwidth_per_source_subnet, with Topk=5, showing the 5 subnets with the most traffic in the most recent minute.