### PR TITLE
Unify ingest metrics too

### DIFF
--- a/docs/operational-metrics.md
+++ b/docs/operational-metrics.md
@@ -39,11 +39,35 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 | **Labels** | error, metric, key | 
 
 
+### ingest_errors
+| **Name** | ingest_errors | 
+|:---|:---|
+| **Description** | Counter of errors during ingestion | 
+| **Type** | counter | 
+| **Labels** | stage, type, code | 
+
+
 ### ingest_flows_processed
 | **Name** | ingest_flows_processed | 
 |:---|:---|
-| **Description** | Number of flow logs processed by the ingester | 
-| **Type** | counter | 
+| **Description** | Provides number of flows processed, batches processed, and batch size stats | 
+| **Type** | summary | 
+| **Labels** | stage | 
+
+
+### ingest_latency_ms
+| **Name** | ingest_latency_ms | 
+|:---|:---|
+| **Description** | Latency between flow end time and ingest time, in milliseconds | 
+| **Type** | histogram | 
+| **Labels** | stage | 
+
+
+### ingest_packets_size_bytes
+| **Name** | ingest_packets_size_bytes | 
+|:---|:---|
+| **Description** | Ingested packets size distribution, in bytes | 
+| **Type** | summary | 
 | **Labels** | stage | 
 
 

--- a/pkg/operational/timer.go
+++ b/pkg/operational/timer.go
@@ -1,0 +1,51 @@
+package operational
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type Timer struct {
+	startTime *time.Time
+	observer  prometheus.Observer
+}
+
+func NewTimer(o prometheus.Observer) *Timer {
+	return &Timer{
+		observer: o,
+	}
+}
+
+// Start starts or restarts the timer, regardless if a previous call occurred without being observed first
+func (t *Timer) Start() time.Time {
+	now := time.Now()
+	t.startTime = &now
+	return now
+}
+
+// StartOnce starts the timer just the first time. Subsequent calls will be ignored,
+// until the timer is observed
+func (t *Timer) StartOnce() time.Time {
+	if t.startTime == nil {
+		now := time.Now()
+		t.startTime = &now
+	}
+	return *t.startTime
+}
+
+func (t *Timer) ObserveMilliseconds() {
+	t.observe(func(d time.Duration) float64 { return float64(d.Milliseconds()) })
+}
+
+func (t *Timer) ObserveSeconds() {
+	t.observe(time.Duration.Seconds)
+}
+
+func (t *Timer) observe(f func(d time.Duration) float64) {
+	if t.startTime != nil {
+		duration := time.Since(*t.startTime)
+		t.observer.Observe(f(duration))
+		t.startTime = nil
+	}
+}

--- a/pkg/pipeline/ingest/ingest_grpc.go
+++ b/pkg/pipeline/ingest/ingest_grpc.go
@@ -3,9 +3,6 @@ package ingest
 import (
 	"context"
 	"fmt"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
@@ -14,28 +11,14 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/grpc"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/pbflow"
-	flow "github.com/netsampler/goflow2/utils"
-	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
 	grpc2 "google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 )
 
 const (
 	defaultBufferLen = 100
-	decoderName      = "protobuf"
-	decoderVersion   = "protobuf1.0"
-)
-
-// Prometheus metrics describing the performance of the eBPF ingest
-// This metrics are internal to the goflow2 library, we update them here manually to align with the IPFIX ingester
-var (
-	flowDecoderCount    = flow.DecoderStats
-	processDelaySummary = flow.NetFlowTimeStatsSum.With(
-		prometheus.Labels{"version": decoderVersion, "router": ""})
-	flowTrafficBytesSum = flow.MetricPacketSizeSum
-	flowErrors          = flow.NetFlowErrors
 )
 
 // GRPCProtobuf ingests data from the NetObserv eBPF Agent, using Protocol Buffers over gRPC
@@ -58,10 +41,9 @@ func NewGRPCProtobuf(opMetrics *operational.Metrics, params config.StageParam) (
 		bufLen = defaultBufferLen
 	}
 	flowPackets := make(chan *pbflow.Records, bufLen)
-	metrics := newMetrics(opMetrics, params.Name, func() int { return len(flowPackets) })
-	counter := func(inc int) { metrics.flowsProcessed.Add(float64(inc)) }
+	metrics := newMetrics(opMetrics, params.Name, params.Ingest.Type, func() int { return len(flowPackets) })
 	collector, err := grpc.StartCollector(netObserv.Port, flowPackets,
-		grpc.WithGRPCServerOptions(grpc2.UnaryInterceptor(instrumentGRPC(netObserv.Port, counter))))
+		grpc.WithGRPCServerOptions(grpc2.UnaryInterceptor(instrumentGRPC(netObserv.Port, metrics))))
 	if err != nil {
 		return nil, err
 	}
@@ -92,15 +74,15 @@ func (no *GRPCProtobuf) Close() error {
 	return err
 }
 
-func instrumentGRPC(port int, counter func(int)) grpc2.UnaryServerInterceptor {
-	localPort := strconv.Itoa(port)
+func instrumentGRPC(port int, m *metrics) grpc2.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
 		req interface{},
 		info *grpc2.UnaryServerInfo,
 		handler grpc2.UnaryHandler,
 	) (resp interface{}, err error) {
-		timeReceived := time.Now()
+		timer := m.stageDurationTimer()
+		timeReceived := timer.Start()
 		if info.FullMethod != "/pbflow.Collector/Send" {
 			return handler(ctx, req)
 		}
@@ -109,41 +91,23 @@ func instrumentGRPC(port int, counter func(int)) grpc2.UnaryServerInterceptor {
 		// instrument difference between flow time and ingest time
 		for _, entry := range flowRecords.Entries {
 			delay := timeReceived.Sub(entry.TimeFlowEnd.AsTime()).Seconds()
-			processDelaySummary.Observe(delay)
+			m.latency.Observe(delay)
 		}
 
-		// instruments number of decoded flow messages
-		flowDecoderCount.With(
-			prometheus.Labels{"worker": "", "name": decoderName}).Inc()
-
-		// instruments number of processed individual flows
-		counter(len(flowRecords.Entries))
-
-		// extract sender IP address
-		remoteIP := "unknown"
-		if md, ok := metadata.FromIncomingContext(ctx); ok {
-			if auth := md.Get(":authority"); len(auth) > 0 {
-				if portIdx := strings.IndexByte(auth[0], ':'); portIdx > 0 {
-					remoteIP = auth[0][:portIdx]
-				} else {
-					remoteIP = auth[0]
-				}
-			}
-		}
-		trafficLabels := prometheus.Labels{
-			"type":       "protobuf",
-			"remote_ip":  remoteIP,
-			"local_ip":   "0.0.0.0",
-			"local_port": localPort,
-		}
+		// instrument batch size distribution (which also instruments total flows counter under the hood)
+		m.batchSize.Observe(float64(len(flowRecords.Entries)))
 
 		// instrument message bytes
-		flowTrafficBytesSum.With(trafficLabels).Observe(float64(proto.Size(flowRecords)))
+		m.packetsSize.Observe(float64(proto.Size(flowRecords)))
 
 		resp, err = handler(ctx, req)
 		if err != nil {
-			flowErrors.With(prometheus.Labels{"router": "", "error": err.Error()}).Inc()
+			m.error(fmt.Sprint(status.Code(err)))
 		}
+
+		// Stage duration
+		timer.ObserveMilliseconds()
+
 		return resp, err
 	}
 }

--- a/pkg/pipeline/ingest/ingest_kafka_test.go
+++ b/pkg/pipeline/ingest/ingest_kafka_test.go
@@ -83,13 +83,13 @@ func initNewIngestKafka(t *testing.T, configTemplate string) Ingester {
 func Test_NewIngestKafka1(t *testing.T) {
 	newIngest := initNewIngestKafka(t, testConfig1)
 	ingestKafka := newIngest.(*ingestKafka)
-	require.Equal(t, "topic1", ingestKafka.kafkaParams.Topic)
-	require.Equal(t, "group1", ingestKafka.kafkaParams.GroupId)
+	require.Equal(t, "topic1", ingestKafka.kafkaReader.Config().Topic)
+	require.Equal(t, "group1", ingestKafka.kafkaReader.Config().GroupID)
 	expectedBrokers := []string{"1.1.1.1:9092"}
-	require.Equal(t, expectedBrokers, ingestKafka.kafkaParams.Brokers)
-	require.Equal(t, "FirstOffset", ingestKafka.kafkaParams.StartOffset)
+	require.Equal(t, expectedBrokers, ingestKafka.kafkaReader.Config().Brokers)
+	require.Equal(t, int64(-2), ingestKafka.kafkaReader.Config().StartOffset)
 	require.Equal(t, 2, len(ingestKafka.kafkaReader.Config().GroupBalancers))
-	require.Equal(t, int64(300), ingestKafka.kafkaParams.BatchReadTimeout)
+	require.Equal(t, int64(300), ingestKafka.batchReadTimeout)
 	require.Equal(t, int(500), ingestKafka.batchMaxLength)
 	require.Equal(t, time.Duration(500)*time.Millisecond, ingestKafka.kafkaReader.Config().CommitInterval)
 }
@@ -97,13 +97,13 @@ func Test_NewIngestKafka1(t *testing.T) {
 func Test_NewIngestKafka2(t *testing.T) {
 	newIngest := initNewIngestKafka(t, testConfig2)
 	ingestKafka := newIngest.(*ingestKafka)
-	require.Equal(t, "topic2", ingestKafka.kafkaParams.Topic)
-	require.Equal(t, "group2", ingestKafka.kafkaParams.GroupId)
+	require.Equal(t, "topic2", ingestKafka.kafkaReader.Config().Topic)
+	require.Equal(t, "group2", ingestKafka.kafkaReader.Config().GroupID)
 	expectedBrokers := []string{"1.1.1.2:9092"}
-	require.Equal(t, expectedBrokers, ingestKafka.kafkaParams.Brokers)
-	require.Equal(t, "LastOffset", ingestKafka.kafkaParams.StartOffset)
+	require.Equal(t, expectedBrokers, ingestKafka.kafkaReader.Config().Brokers)
+	require.Equal(t, int64(-1), ingestKafka.kafkaReader.Config().StartOffset)
 	require.Equal(t, 1, len(ingestKafka.kafkaReader.Config().GroupBalancers))
-	require.Equal(t, defaultBatchReadTimeout, ingestKafka.kafkaParams.BatchReadTimeout)
+	require.Equal(t, defaultBatchReadTimeout, ingestKafka.batchReadTimeout)
 	require.Equal(t, int(1000), ingestKafka.batchMaxLength)
 	require.Equal(t, time.Duration(1000)*time.Millisecond, ingestKafka.kafkaReader.Config().CommitInterval)
 }
@@ -211,7 +211,7 @@ func Test_MaxBatchLength(t *testing.T) {
 	fr := fakeKafkaReader{readToDo: 15}
 	ingestKafka.kafkaReader = &fr
 	ingestKafka.batchMaxLength = 10
-	ingestKafka.kafkaParams.BatchReadTimeout = 10000
+	ingestKafka.batchReadTimeout = 10000
 
 	// run Ingest in a separate thread
 	go func() {
@@ -234,7 +234,7 @@ func Test_BatchTimeout(t *testing.T) {
 	fr := fakeKafkaReader{readToDo: 5}
 	ingestKafka.kafkaReader = &fr
 	ingestKafka.batchMaxLength = 1000
-	ingestKafka.kafkaParams.BatchReadTimeout = 100
+	ingestKafka.batchReadTimeout = 100
 
 	beforeIngest := time.Now()
 	// run Ingest in a separate thread

--- a/pkg/pipeline/ingest/metrics.go
+++ b/pkg/pipeline/ingest/metrics.go
@@ -6,21 +6,69 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+var (
+	latencyHistogram = operational.DefineMetric(
+		"ingest_latency_ms",
+		"Latency between flow end time and ingest time, in milliseconds",
+		operational.TypeHistogram,
+		"stage",
+	)
+	batchSizeSummary = operational.DefineMetric(
+		"ingest_flows_processed", // This is intentionally named to emphasize its utility for flows counting, despite being a batch size distribution
+		"Provides number of flows processed, batches processed, and batch size stats",
+		operational.TypeSummary,
+		"stage",
+	)
+	packetsSizeSummary = operational.DefineMetric(
+		"ingest_packets_size_bytes",
+		"Ingested packets size distribution, in bytes",
+		operational.TypeSummary,
+		"stage",
+	)
+	errorsCounter = operational.DefineMetric(
+		"ingest_errors",
+		"Counter of errors during ingestion",
+		operational.TypeCounter,
+		"stage", "type", "code",
+	)
+)
+
 type metrics struct {
 	*operational.Metrics
-	stage          string
-	flowsProcessed prometheus.Counter
+	stage         string
+	stageType     string
+	stageDuration prometheus.Observer
+	latency       prometheus.Histogram
+	batchSize     prometheus.Summary
+	packetsSize   prometheus.Summary
+	errors        *prometheus.CounterVec
 }
 
-func newMetrics(opMetrics *operational.Metrics, stage string, inGaugeFunc func() int) *metrics {
+func newMetrics(opMetrics *operational.Metrics, stage, stageType string, inGaugeFunc func() int) *metrics {
 	opMetrics.CreateInQueueSizeGauge(stage, inGaugeFunc)
 	return &metrics{
-		Metrics:        opMetrics,
-		stage:          stage,
-		flowsProcessed: opMetrics.CreateFlowsProcessedCounter(stage),
+		Metrics:       opMetrics,
+		stage:         stage,
+		stageType:     stageType,
+		latency:       opMetrics.NewHistogram(&latencyHistogram, []float64{.001, .01, .1, 1, 10, 100, 1000, 10000}, stage),
+		stageDuration: opMetrics.GetOrCreateStageDurationHisto().WithLabelValues(stage),
+		batchSize:     opMetrics.NewSummary(&batchSizeSummary, stage),
+		packetsSize:   opMetrics.NewSummary(&packetsSizeSummary, stage),
+		errors:        opMetrics.NewCounterVec(&errorsCounter),
 	}
 }
 
 func (m *metrics) createOutQueueLen(out chan<- []config.GenericMap) {
 	m.CreateOutQueueSizeGauge(m.stage, func() int { return len(out) })
+}
+
+// Increment error counter
+// `code` should reflect any error code relative to this type. It can be a short string message,
+// but make sure to not include any dynamic value with high cardinality
+func (m *metrics) error(code string) {
+	m.errors.WithLabelValues(m.stage, m.stageType, code).Inc()
+}
+
+func (m *metrics) stageDurationTimer() *operational.Timer {
+	return operational.NewTimer(m.stageDuration)
 }

--- a/pkg/pipeline/pipeline_builder.go
+++ b/pkg/pipeline/pipeline_builder.go
@@ -57,17 +57,8 @@ type pipelineEntry struct {
 	Writer      write.Writer
 }
 
-var (
-	stageDurationDef = operational.DefineMetric(
-		"stage_duration_ms",
-		"Pipeline stage duration in milliseconds",
-		operational.TypeHistogram,
-		"stage",
-	)
-)
-
 func newBuilder(params []config.StageParam, stages []config.Stage, opMetrics *operational.Metrics) *builder {
-	stageDuration := opMetrics.NewHistogramVec(&stageDurationDef, []float64{.001, .01, .1, 1, 10, 100, 1000, 10000})
+	stageDuration := opMetrics.GetOrCreateStageDurationHisto()
 
 	return &builder{
 		pipelineEntryMap: map[string]*pipelineEntry{},


### PR DESCRIPTION
Except for netflow/ipfix which continue to use goflow2 metrics, other ingester now adopt the same "framework" for metrics as the other stages, hence also have new names with a prefix

New metrics are:


### ingest_errors
| **Name** | ingest_errors | 
|:---|:---|
| **Description** | Counter of errors during ingestion | 
| **Type** | counter | 
| **Labels** | stage, type, code | 


### ingest_flows_processed
| **Name** | ingest_flows_processed | 
|:---|:---|
| **Description** | Provides number of flows processed, batches processed, and batch size stats | 
| **Type** | summary | 
| **Labels** | stage | 


### ingest_latency_ms
| **Name** | ingest_latency_ms | 
|:---|:---|
| **Description** | Latency between flow end time and ingest time, in milliseconds | 
| **Type** | histogram | 
| **Labels** | stage | 


### ingest_packets_size_bytes
| **Name** | ingest_packets_size_bytes | 
|:---|:---|
| **Description** | Ingested packets size distribution, in bytes | 
| **Type** | summary | 
| **Labels** | stage | 
