### PR TITLE
NETOBSERV-578: decrease informers' memory consumption

### DIFF
--- a/pkg/pipeline/transform/kubernetes/kubernetes.go
+++ b/pkg/pipeline/transform/kubernetes/kubernetes.go
@@ -65,9 +65,8 @@ type Owner struct {
 }
 
 type Info struct {
+	metav1.ObjectMeta
 	Type            string
-	Name            string
-	Namespace       string
 	Labels          map[string]string
 	OwnerReferences []metav1.OwnerReference
 	Owner           Owner
@@ -91,18 +90,22 @@ func (k *KubeData) GetInfo(ip string) (*Info, error) {
 			case typeNode:
 				node := objs[0].(*v1.Node)
 				info = &Info{
-					Type:      typeNode,
-					Name:      node.Name,
-					Namespace: node.Namespace,
-					Labels:    node.Labels,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      node.Name,
+						Namespace: node.Namespace,
+					},
+					Type:   typeNode,
+					Labels: node.Labels,
 				}
 			case typeService:
 				service := objs[0].(*v1.Service)
 				info = &Info{
-					Type:      typeService,
-					Name:      service.Name,
-					Namespace: service.Namespace,
-					Labels:    service.Labels,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      service.Name,
+						Namespace: service.Namespace,
+					},
+					Type:   typeService,
+					Labels: service.Labels,
 				}
 			}
 
@@ -192,9 +195,11 @@ func (k *KubeData) NewPodInformer(informerFactory informers.SharedInformerFactor
 			}
 		}
 		return &Info{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      pod.Name,
+				Namespace: pod.Namespace,
+			},
 			Type:            typePod,
-			Name:            pod.Name,
-			Namespace:       pod.Namespace,
 			Labels:          pod.Labels,
 			OwnerReferences: pod.OwnerReferences,
 			HostIP:          pod.Status.HostIP,
@@ -211,6 +216,7 @@ func (k *KubeData) NewPodInformer(informerFactory informers.SharedInformerFactor
 	if err != nil {
 		return fmt.Errorf("can't add %s indexer to Pods informer: %w", IndexIP, err)
 	}
+
 	k.ipInformers[typePod] = pods
 	return err
 }

--- a/pkg/pipeline/transform/kubernetes/kubernetes_test.go
+++ b/pkg/pipeline/transform/kubernetes/kubernetes_test.go
@@ -78,8 +78,8 @@ func TestGetInfoPods(t *testing.T) {
 	him := InformerMock{}
 	him.On("GetIndexer").Return(&hidx)
 
-	kubeData.ipInformers.pods = &pim
-	kubeData.ipInformers.nodes = &him
+	kubeData.pods = &pim
+	kubeData.nodes = &him
 	info, err := kubeData.GetInfo("1.2.3.4")
 	require.NoError(t, err)
 

--- a/pkg/pipeline/transform/transform_network_test.go
+++ b/pkg/pipeline/transform/transform_network_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func getMockNetworkTransformRules() api.NetworkTransformRules {
-	rules := api.NetworkTransformRules{
+	return api.NetworkTransformRules{
 		api.NetworkTransformRule{
 			Input:      "srcIP",
 			Output:     "subnet16SrcIP",
@@ -85,14 +85,16 @@ func getMockNetworkTransformRules() api.NetworkTransformRules {
 			Output: "8888IP_location",
 			Type:   "add_location",
 		},
+	}
+}
+func getK8sTransformRules() api.NetworkTransformRules {
+	return api.NetworkTransformRules{
 		api.NetworkTransformRule{
 			Input:  "srcIP",
 			Output: "srcIP_k8s",
 			Type:   "add_kubernetes",
 		},
 	}
-
-	return rules
 }
 
 func getExpectedOutput() config.GenericMap {

--- a/pkg/pipeline/transform/transform_network_test.go
+++ b/pkg/pipeline/transform/transform_network_test.go
@@ -87,15 +87,6 @@ func getMockNetworkTransformRules() api.NetworkTransformRules {
 		},
 	}
 }
-func getK8sTransformRules() api.NetworkTransformRules {
-	return api.NetworkTransformRules{
-		api.NetworkTransformRule{
-			Input:  "srcIP",
-			Output: "srcIP_k8s",
-			Type:   "add_kubernetes",
-		},
-	}
-}
 
 func getExpectedOutput() config.GenericMap {
 	return config.GenericMap{


### PR DESCRIPTION
This PR adds a Transformer for each Kubernetes informer that converts the watched Pods, Services, and Nodes to `Info` instances, that are stored by the informers cache and contain only the data that is required for the decoration.

This also alleviates the load on the Garbage Collector: before this patch, a new `Info` instance was created for each flow decoration. Now the same objects are reused on `GetInfo` invocations for the same IP.

In Flowlogs-Pipelines with mid-to-low loads, no improvements have been observed in terms of CPU and slight improvements in terms of memory. In the image below, the middle part corresponds to the new version of FLP.

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/939550/192978058-aa46f1c5-3cb9-4295-a8a0-214ee4b1bd1b.png">

