### PR TITLE
disable CGO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ export GO111MODULE=on
 export CGO_ENABLED=0
 export GOOS=linux
 export GOARCH=amd64
-export CGO_ENABLED=1
 
 SHELL := /bin/bash
 DOCKER_TAG ?= latest

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,8 @@ clean: ## Clean
 TEST_OPTS := -race -coverpkg=./... -covermode=atomic -coverprofile=/tmp/coverage.out
 .PHONY: tests-unit
 tests-unit: validate_go ## Unit tests
-	go test -p 1 $(TEST_OPTS) $$(go list ./... | grep -v /e2e)
+	# enabling CGO is required for -race flag
+	CGO_ENABLED=1 go test -p 1 $(TEST_OPTS) $$(go list ./... | grep -v /e2e)
 
 .PHONY: tests-fast
 tests-fast: TEST_OPTS=
@@ -107,7 +108,7 @@ tests-fast: tests-unit ## Fast unit tests (no race tests / coverage)
 
 .PHONY: tests-e2e
 tests-e2e: validate_go $(KIND)  ## End-to-end tests
-	go test -p 1 -v -timeout 20m -race $$(go list ./... | grep  /e2e)
+	go test -p 1 -v -timeout 20m $$(go list ./... | grep  /e2e)
 
 .PHONY: tests-all
 tests-all: validate_go tests-unit tests-e2e ## All tests


### PR DESCRIPTION
CGO it's not required and usually makes executables more resource-consuming. It also adds some extra requirements to the build/test pipeline (e.g. having to have GCC + libraries, etc...)

Reference read: https://dave.cheney.net/2016/01/18/cgo-is-not-go