### PR TITLE
Optimize Network Transformer switch

### DIFF
--- a/pkg/api/transform_network.go
+++ b/pkg/api/transform_network.go
@@ -36,6 +36,15 @@ func (tn *TransformNetwork) GetServiceFiles() (string, string) {
 	return p, s
 }
 
+const (
+	OpAddRegexIf    = "add_regex_if"
+	OpAddIf         = "add_if"
+	OpAddSubnet     = "add_subnet"
+	OpAddLocation   = "add_location"
+	OpAddService    = "add_service"
+	OpAddKubernetes = "add_kubernetes"
+)
+
 type TransformNetworkOperationEnum struct {
 	AddRegExIf    string `yaml:"add_regex_if" json:"add_regex_if" doc:"add output field if input field satisfies regex pattern from parameters field"`
 	AddIf         string `yaml:"add_if" json:"add_if" doc:"add output field if input field satisfies criteria from parameters field"`

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -54,7 +54,7 @@ func (n *Network) TransformEntry(inputEntry config.GenericMap) config.GenericMap
 	// TODO: for efficiency and maintainability, maybe each case in the switch below should be an individual implementation of Transformer
 	for _, rule := range n.Rules {
 		switch rule.Type {
-		case api.TransformNetworkOperationName("AddRegExIf"):
+		case api.OpAddRegexIf:
 			matched, err := regexp.MatchString(rule.Parameters, fmt.Sprintf("%s", outputEntry[rule.Input]))
 			if err != nil {
 				continue
@@ -63,7 +63,7 @@ func (n *Network) TransformEntry(inputEntry config.GenericMap) config.GenericMap
 				outputEntry[rule.Output] = outputEntry[rule.Input]
 				outputEntry[rule.Output+"_Matched"] = true
 			}
-		case api.TransformNetworkOperationName("AddIf"):
+		case api.OpAddIf:
 			expressionString := fmt.Sprintf("val %s", rule.Parameters)
 			expression, err := govaluate.NewEvaluableExpression(expressionString)
 			if err != nil {
@@ -79,14 +79,14 @@ func (n *Network) TransformEntry(inputEntry config.GenericMap) config.GenericMap
 				}
 				outputEntry[rule.Output+"_Evaluate"] = true
 			}
-		case api.TransformNetworkOperationName("AddSubnet"):
+		case api.OpAddSubnet:
 			_, ipv4Net, err := net.ParseCIDR(fmt.Sprintf("%v%s", outputEntry[rule.Input], rule.Parameters))
 			if err != nil {
 				log.Errorf("Can't find subnet for IP %v and prefix length %s - err %v", outputEntry[rule.Input], rule.Parameters, err)
 				continue
 			}
 			outputEntry[rule.Output] = ipv4Net.String()
-		case api.TransformNetworkOperationName("AddLocation"):
+		case api.OpAddLocation:
 			var locationInfo *location.Info
 			err, locationInfo := location.GetLocation(fmt.Sprintf("%s", outputEntry[rule.Input]))
 			if err != nil {
@@ -99,7 +99,7 @@ func (n *Network) TransformEntry(inputEntry config.GenericMap) config.GenericMap
 			outputEntry[rule.Output+"_CityName"] = locationInfo.CityName
 			outputEntry[rule.Output+"_Latitude"] = locationInfo.Latitude
 			outputEntry[rule.Output+"_Longitude"] = locationInfo.Longitude
-		case api.TransformNetworkOperationName("AddService"):
+		case api.OpAddService:
 			protocol := fmt.Sprintf("%v", outputEntry[rule.Parameters])
 			portNumber, err := strconv.Atoi(fmt.Sprintf("%v", outputEntry[rule.Input]))
 			if err != nil {
@@ -122,7 +122,7 @@ func (n *Network) TransformEntry(inputEntry config.GenericMap) config.GenericMap
 				}
 			}
 			outputEntry[rule.Output] = serviceName
-		case api.TransformNetworkOperationName("AddKubernetes"):
+		case api.OpAddKubernetes:
 			kubeInfo, err := kubernetes.Data.GetInfo(fmt.Sprintf("%s", outputEntry[rule.Input]))
 			if err != nil {
 				log.Debugf("Can't find kubernetes info for IP %v err %v", outputEntry[rule.Input], err)
@@ -164,11 +164,11 @@ func NewTransformNetwork(params config.StageParam) (Transformer, error) {
 	}
 	for _, rule := range jsonNetworkTransform.Rules {
 		switch rule.Type {
-		case api.TransformNetworkOperationName("AddLocation"):
+		case api.OpAddLocation:
 			needToInitLocationDB = true
-		case api.TransformNetworkOperationName("AddKubernetes"):
+		case api.OpAddKubernetes:
 			needToInitKubeData = true
-		case api.TransformNetworkOperationName("AddService"):
+		case api.OpAddService:
 			needToInitNetworkServices = true
 		}
 	}


### PR DESCRIPTION
The api.TransformNetworkOperationName function is not known at compile time while the `api.Op...` constants are.

This gives room to the Go compiler for implementing the `switch` more efficiently (e.g. lookup table vs if-elses...). This is specially important in the network_transformer, which lookups multiple rules for each flow.