### PR TITLE
Remove namespace for nodes

### DIFF
--- a/pkg/pipeline/transform/kubernetes/kubernetes.go
+++ b/pkg/pipeline/transform/kubernetes/kubernetes.go
@@ -194,7 +194,7 @@ func (k *KubeData) initNodeInformer(informerFactory informers.SharedInformerFact
 		return &Info{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      node.Name,
-				Namespace: node.Namespace,
+				Namespace: "",
 				Labels:    node.Labels,
 			},
 			ips:  ips,


### PR DESCRIPTION
This is a minor change that maybe will have 0 impact.. But I've found a weird case where node's flows are sometimes assigned an empty string namespace, and other times namespace is undefined. This is very weird and I don't know why there is this discrepancy, maybe something wrong on the loki side? (since this field is used for indexing).

It ends up duplicating metrics in the console, and make it harder to work with in the console.