### PR TITLE
Allow defining buffer length of internal nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/mariomac/guara v0.0.0-20220523124851-5fc279816f1f
 	github.com/mitchellh/mapstructure v1.4.3
-	github.com/netobserv/gopipes v0.1.1
+	github.com/netobserv/gopipes v0.2.0
 	github.com/netobserv/loki-client-go v0.0.0-20220927092034-f37122a54500
 	github.com/netobserv/netobserv-ebpf-agent v0.1.1-0.20220608092850-3fd4695b7cc2
 	github.com/netsampler/goflow2 v1.1.1-0.20220509155230-5300494e4785

--- a/go.sum
+++ b/go.sum
@@ -697,8 +697,8 @@ github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzE
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
-github.com/netobserv/gopipes v0.1.1 h1:f8zJsvnMgRFRa2B+1siwRtW0Y4dqeBROmkcI/HgT1gE=
-github.com/netobserv/gopipes v0.1.1/go.mod h1:eGoHZW1ON8Dx/zmDXUhsbVNqatPjtpdO0UZBmGZGmVI=
+github.com/netobserv/gopipes v0.2.0 h1:CnJQq32+xNuM85eVYy/HOf+StTJdh2K6RdaEg7NAJDg=
+github.com/netobserv/gopipes v0.2.0/go.mod h1:eGoHZW1ON8Dx/zmDXUhsbVNqatPjtpdO0UZBmGZGmVI=
 github.com/netobserv/loki-client-go v0.0.0-20220927092034-f37122a54500 h1:RmnoJe/ci5q+QdM7upFdxiU+D8F3L3qTd5wXCwwHefw=
 github.com/netobserv/loki-client-go v0.0.0-20220927092034-f37122a54500/go.mod h1:LHXpc5tjKvsfZn0pwLKrvlgEhZcCaw3Di9mUEZGAI4E=
 github.com/netobserv/netobserv-ebpf-agent v0.1.1-0.20220608092850-3fd4695b7cc2 h1:K7SjoqEfzpMfIjHV85Lg8UDMvZu8rPfrsgKRoo7W30o=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,6 +66,7 @@ type MetricsSettings struct {
 type PerfSettings struct {
 	BatcherMaxLen  int           `yaml:"batcherMaxLen,omitempty" json:"batcherMaxLen,omitempty"`
 	BatcherTimeout time.Duration `yaml:"batcherMaxTimeout,omitempty" json:"batcherMaxTimeout,omitempty"`
+	NodeBufferLen  int           `yaml:"nodeBufferLen,omitempty" json:"nodeBufferLen,omitempty"`
 }
 
 type Stage struct {

--- a/pkg/pipeline/conntrack_integ_test.go
+++ b/pkg/pipeline/conntrack_integ_test.go
@@ -113,8 +113,8 @@ func TestConnTrack(t *testing.T) {
 
 	// wait for all the lines to be ingested
 	test2.Eventually(t, 15*time.Second, func(t require.TestingT) {
-		require.EqualValues(t, atomic.LoadInt64(&ingest.Count), sentLines,
-			"sent: %d. got: %d", sentLines, ingest.Count)
+		count := atomic.LoadInt64(&ingest.Count)
+		require.EqualValues(t, count, sentLines, "sent: %d. got: %d", sentLines, count)
 	}, test2.Interval(10*time.Millisecond))
 
 	// Wait a moment to make the connections expired

--- a/vendor/github.com/netobserv/gopipes/pkg/node/options.go
+++ b/vendor/github.com/netobserv/gopipes/pkg/node/options.go
@@ -1,0 +1,22 @@
+package node
+
+type creationOptions struct {
+	// if 0, channel is unbuffered
+	channelBufferLen int
+}
+
+var defaultOptions = creationOptions{
+	channelBufferLen: 0,
+}
+
+// CreationOption allows overriding the default values of node instantiation
+type CreationOption func(options *creationOptions)
+
+// ChannelBufferLen is a node.CreationOption that allows specifying the length of the input
+// channels for a given node. The default value is 0, which means that the channels
+// are unbuffered.
+func ChannelBufferLen(length int) CreationOption {
+	return func(options *creationOptions) {
+		options.channelBufferLen = length
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/munnerz/goautoneg
 # github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 ## explicit
 github.com/mwitkow/go-conntrack
-# github.com/netobserv/gopipes v0.1.1
+# github.com/netobserv/gopipes v0.2.0
 ## explicit; go 1.17
 github.com/netobserv/gopipes/pkg/internal/connect
 github.com/netobserv/gopipes/pkg/internal/refl


### PR DESCRIPTION
Updated to version 0.2.0 of go-pipes and allow defining the length of the internal buffers between pipeline stages.