### PR TITLE
Speedup Loki JSON serialization

### DIFF
--- a/pkg/pipeline/write/write_loki.go
+++ b/pkg/pipeline/write/write_loki.go
@@ -37,6 +37,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var jsonEncodingConfig = jsonIter.Config{}.Froze()
+
 var (
 	keyReplacer = strings.NewReplacer("/", "_", ".", "_", "-", "_")
 )
@@ -121,7 +123,7 @@ func (l *Loki) ProcessRecord(in config.GenericMap) error {
 		delete(out, label)
 	}
 
-	js, err := jsonIter.ConfigCompatibleWithStandardLibrary.Marshal(out)
+	js, err := jsonEncodingConfig.Marshal(out)
 	if err != nil {
 		return err
 	}

--- a/pkg/pipeline/write/write_loki_test.go
+++ b/pkg/pipeline/write/write_loki_test.go
@@ -45,7 +45,16 @@ type fakeEmitter struct {
 }
 
 func (f *fakeEmitter) Handle(labels model.LabelSet, timestamp time.Time, record string) error {
-	a := f.Mock.Called(labels, timestamp, record)
+	// sort alphabetically records just for simplifying testing verification with JSON strings
+	recordMap := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(record), &recordMap); err != nil {
+		panic("expected JSON: " + err.Error())
+	}
+	recordBytes, err := json.Marshal(recordMap)
+	if err != nil {
+		panic("error unmarshaling: " + err.Error())
+	}
+	a := f.Mock.Called(labels, timestamp, string(recordBytes))
 	return a.Error(0)
 }
 


### PR DESCRIPTION
Changing the JSON encoder of Loki:

* Do not sort fields alphabetically
* Do not escape HTML (it still escapes JSON strings)

The improvements in terms of CPU are sensible:

<img width="974" alt="image" src="https://user-images.githubusercontent.com/939550/194848087-554e7aa4-57d5-469c-b9e8-00ba70b6b980.png">

