### PR TITLE
Improving performance of generic map copy

### DIFF
--- a/pkg/config/generic_map.go
+++ b/pkg/config/generic_map.go
@@ -21,7 +21,7 @@ type GenericMap map[string]interface{}
 
 // Copy will create a flat copy of GenericMap
 func (m GenericMap) Copy() GenericMap {
-	result := GenericMap{}
+	result := make(GenericMap, len(m))
 
 	for k, v := range m {
 		result[k] = v

--- a/pkg/config/generic_map_test.go
+++ b/pkg/config/generic_map_test.go
@@ -1,0 +1,17 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkGenericMap_Copy(b *testing.B) {
+	m := GenericMap{}
+	for i := 0; i < 20; i++ {
+		m[fmt.Sprintf("key-%d", i)] = fmt.Sprintf("value-%d", i)
+	}
+
+	for i := 0; i < b.N; i++ {
+		_ = m.Copy()
+	}
+}


### PR DESCRIPTION
The GenericMap's Copy method is run in diverse stages of the pipeline, for each processed flow.

Preallocating the map size to the expected resulting size can improve Copy CPU performance and memory allocations by 40%-50%.

Benchmark results with 20-entries maps (before vs after):

```
BenchmarkGenericMap_Copy-12       658083              1671 ns/op            1852 B/op          2 allocs/op
BenchmarkGenericMap_Copy-12       978686              1082 ns/op            1199 B/op          1 allocs/op
```

Benchmark results with 30-entries maps (before vs after):

```
BenchmarkGenericMap_Copy-12       354102              3280 ns/op            4337 B/op          4 allocs/op
BenchmarkGenericMap_Copy-12       633978              1758 ns/op            2324 B/op          1 allocs/op
```
