### PR TITLE
Remove unnecessary goroutine of loki writer

### DIFF
--- a/pkg/pipeline/write/write_loki.go
+++ b/pkg/pipeline/write/write_loki.go
@@ -47,8 +47,6 @@ type emitter interface {
 	Handle(labels model.LabelSet, timestamp time.Time, record string) error
 }
 
-const channelSize = 1000
-
 // Loki record writer
 type Loki struct {
 	lokiConfig     loki.Config

--- a/pkg/pipeline/write/write_loki.go
+++ b/pkg/pipeline/write/write_loki.go
@@ -253,10 +253,6 @@ func NewWriteLoki(opMetrics *operational.Metrics, params config.StageParam) (*Lo
 		}
 	}
 
-	// TODO / FIXME / FIGUREOUT: seems like we have 2 input channels for Loki? (this one, and see also pipeline_builder.go / getStageNode / StageWrite)
-	in := make(chan config.GenericMap, channelSize)
-	opMetrics.CreateInQueueSizeGauge(params.Name+"-2", func() int { return len(in) })
-
 	l := &Loki{
 		lokiConfig:     lokiConfig,
 		apiConfig:      lokiConfigIn,


### PR DESCRIPTION
Loki write use a goroutine to do async send to loki.

This is unnecessary because loki client is already doing async send.

I tested this change under some load and did not see any impact.