### PR TITLE
conntrack: Add `_IsFirst` field

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ A possible output would look like:
 {
     "_RecordType": "endConnection",
     "_HashId": "3e8ba98164baecaf",
+    "_IsFirst": true,
     "SrcAddr": "10.0.0.1",
     "SrcPort": 1234,
     "DstAddr": "10.0.0.2",
@@ -645,6 +646,11 @@ Notice that all output records contain `_RecordType` and `_HashId` fields.
 Output fields that set `splitAB: true` (like in `Bytes`) are split into 2 fields `Bytes_AB` and `Bytes_BA` which 
 aggregate values separately based on direction A->B and B->A respectively.
 When `splitAB` is absent, its default value is `false`.
+
+The boolean field `_IsFirst` exists only in records of type `newConnection`, `updateConnection` and `endConnection`.
+It is set to true only on the first record of the connection.
+The `_IsFirst` fields is useful in cases where `newConnection` records are not outputted (to reduce the number output records)
+and there is a need to count the total number of connections: simply counting `_IsFirst=true` 
 
 ### Timebased TopK
 

--- a/pkg/api/conntrack.go
+++ b/pkg/api/conntrack.go
@@ -24,6 +24,7 @@ import (
 const (
 	HashIdFieldName     = "_HashId"
 	RecordTypeFieldName = "_RecordType"
+	IsFirstFieldName    = "_IsFirst"
 )
 
 type ConnTrack struct {

--- a/pkg/pipeline/conntrack_integ_test.go
+++ b/pkg/pipeline/conntrack_integ_test.go
@@ -138,6 +138,7 @@ func TestConnTrack(t *testing.T) {
 		"TimeFlowStart": 1_637_501_079.0,
 		"_HashId":       "d28db42bcd8aea8f",
 		"_RecordType":   "endConnection",
+		"_IsFirst":      false,
 		"numFlowLogs":   5.0,
 	}
 	// Wait for the record to be eventually forwarded to the writer

--- a/pkg/pipeline/extract/conntrack/conntrack_test.go
+++ b/pkg/pipeline/extract/conntrack/conntrack_test.go
@@ -235,14 +235,14 @@ func TestEndConn_Bidirectional(t *testing.T) {
 		},
 	}
 
-	for _, test := range table {
+	for _, tt := range table {
 		var prevTime time.Time
-		t.Run(test.name, func(t *testing.T) {
-			require.Less(t, prevTime, test.time)
-			prevTime = test.time
-			clk.Set(test.time)
-			actual := ct.Extract(test.inputFlowLogs)
-			require.Equal(t, test.expected, actual)
+		t.Run(tt.name, func(t *testing.T) {
+			require.Less(t, prevTime, tt.time)
+			prevTime = tt.time
+			clk.Set(tt.time)
+			actual := ct.Extract(tt.inputFlowLogs)
+			require.Equal(t, tt.expected, actual)
 		})
 	}
 }
@@ -334,14 +334,14 @@ func TestEndConn_Unidirectional(t *testing.T) {
 		},
 	}
 
-	for _, test := range table {
+	for _, tt := range table {
 		var prevTime time.Time
-		t.Run(test.name, func(t *testing.T) {
-			require.Less(t, prevTime, test.time)
-			prevTime = test.time
-			clk.Set(test.time)
-			actual := ct.Extract(test.inputFlowLogs)
-			require.Equal(t, test.expected, actual)
+		t.Run(tt.name, func(t *testing.T) {
+			require.Less(t, prevTime, tt.time)
+			prevTime = tt.time
+			clk.Set(tt.time)
+			actual := ct.Extract(tt.inputFlowLogs)
+			require.Equal(t, tt.expected, actual)
 		})
 	}
 }
@@ -482,14 +482,14 @@ func TestUpdateConn_Unidirectional(t *testing.T) {
 		},
 	}
 
-	for _, test := range table {
+	for _, tt := range table {
 		var prevTime time.Time
-		t.Run(test.name, func(t *testing.T) {
-			require.Less(t, prevTime, test.time)
-			prevTime = test.time
-			clk.Set(test.time)
-			actual := ct.Extract(test.inputFlowLogs)
-			require.Equal(t, test.expected, actual)
+		t.Run(tt.name, func(t *testing.T) {
+			require.Less(t, prevTime, tt.time)
+			prevTime = tt.time
+			clk.Set(tt.time)
+			actual := ct.Extract(tt.inputFlowLogs)
+			require.Equal(t, tt.expected, actual)
 		})
 	}
 }

--- a/pkg/pipeline/extract/conntrack/utils_test.go
+++ b/pkg/pipeline/extract/conntrack/utils_test.go
@@ -52,16 +52,17 @@ func newMockRecordFromFlowLog(fl config.GenericMap) *mockRecord {
 func newMockRecordConnAB(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytesAB, bytesBA, packetsAB, packetsBA, numFlowLogs float64) *mockRecord {
 	mock := &mockRecord{
 		record: config.GenericMap{
-			"SrcAddr":     srcIP,
-			"SrcPort":     srcPort,
-			"DstAddr":     dstIP,
-			"DstPort":     dstPort,
-			"Proto":       protocol,
-			"Bytes_AB":    bytesAB,
-			"Bytes_BA":    bytesBA,
-			"Packets_AB":  packetsAB,
-			"Packets_BA":  packetsBA,
-			"numFlowLogs": numFlowLogs,
+			"SrcAddr":            srcIP,
+			"SrcPort":            srcPort,
+			"DstAddr":            dstIP,
+			"DstPort":            dstPort,
+			"Proto":              protocol,
+			"Bytes_AB":           bytesAB,
+			"Bytes_BA":           bytesBA,
+			"Packets_AB":         packetsAB,
+			"Packets_BA":         packetsBA,
+			"numFlowLogs":        numFlowLogs,
+			api.IsFirstFieldName: false,
 		},
 	}
 	return mock
@@ -69,7 +70,8 @@ func newMockRecordConnAB(srcIP string, srcPort int, dstIP string, dstPort int, p
 
 func newMockRecordNewConnAB(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytesAB, bytesBA, packetsAB, packetsBA, numFlowLogs float64) *mockRecord {
 	return newMockRecordConnAB(srcIP, srcPort, dstIP, dstPort, protocol, bytesAB, bytesBA, packetsAB, packetsBA, numFlowLogs).
-		withType("newConnection")
+		withType("newConnection").
+		markFirst()
 
 }
 
@@ -82,14 +84,15 @@ func newMockRecordEndConnAB(srcIP string, srcPort int, dstIP string, dstPort int
 func newMockRecordConn(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets, numFlowLogs float64) *mockRecord {
 	mock := &mockRecord{
 		record: config.GenericMap{
-			"SrcAddr":     srcIP,
-			"SrcPort":     srcPort,
-			"DstAddr":     dstIP,
-			"DstPort":     dstPort,
-			"Proto":       protocol,
-			"Bytes":       bytes,
-			"Packets":     packets,
-			"numFlowLogs": numFlowLogs,
+			"SrcAddr":            srcIP,
+			"SrcPort":            srcPort,
+			"DstAddr":            dstIP,
+			"DstPort":            dstPort,
+			"Proto":              protocol,
+			"Bytes":              bytes,
+			"Packets":            packets,
+			"numFlowLogs":        numFlowLogs,
+			api.IsFirstFieldName: false,
 		},
 	}
 	return mock
@@ -97,7 +100,8 @@ func newMockRecordConn(srcIP string, srcPort int, dstIP string, dstPort int, pro
 
 func newMockRecordNewConn(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets, numFlowLogs float64) *mockRecord {
 	return newMockRecordConn(srcIP, srcPort, dstIP, dstPort, protocol, bytes, packets, numFlowLogs).
-		withType("newConnection")
+		withType("newConnection").
+		markFirst()
 }
 
 func newMockRecordEndConn(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets, numFlowLogs float64) *mockRecord {
@@ -117,6 +121,11 @@ func (m *mockRecord) withHash(hashStr string) *mockRecord {
 
 func (m *mockRecord) withType(recordType string) *mockRecord {
 	m.record[api.RecordTypeFieldName] = recordType
+	return m
+}
+
+func (m *mockRecord) markFirst() *mockRecord {
+	m.record[api.IsFirstFieldName] = true
 	return m
 }
 


### PR DESCRIPTION
This PR adds the `_IsFirst` field to connection records (`newConnection`, `updateConnection` and `endConnection`).
It's not added to `flowLog` records.
The field is set to true only on the first record of the connection.
It is useful in cases where `newConnection` records are not outputted (to reduce the number output records)
and there is a need to count the total number of connections: simply counting `_IsFirst=true`

This solves #298