### PR TITLE
NETOBSERV-666: K8s decoration not adding namespace if empty

### DIFF
--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -119,7 +119,11 @@ func (n *Network) Transform(inputEntry config.GenericMap) (config.GenericMap, bo
 				log.Debugf("Can't find kubernetes info for IP %v err %v", outputEntry[rule.Input], err)
 				continue
 			}
-			outputEntry[rule.Output+"_Namespace"] = kubeInfo.Namespace
+			// NETOBSERV-666: avoid putting empty namespaces or Loki aggregation queries will
+			// differentiate between empty and nil namespaces.
+			if kubeInfo.Namespace != "" {
+				outputEntry[rule.Output+"_Namespace"] = kubeInfo.Namespace
+			}
 			outputEntry[rule.Output+"_Name"] = kubeInfo.Name
 			outputEntry[rule.Output+"_Type"] = kubeInfo.Type
 			outputEntry[rule.Output+"_OwnerName"] = kubeInfo.Owner.Name

--- a/pkg/pipeline/transform/transform_network_test.go
+++ b/pkg/pipeline/transform/transform_network_test.go
@@ -18,15 +18,18 @@
 package transform
 
 import (
+	"errors"
 	"os"
 	"path"
 	"testing"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/location"
 	netdb "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/netdb"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -324,4 +327,42 @@ func Test_Transform_AddIfScientificNotation(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, true, output["dir_Evaluate"])
 	require.Equal(t, "out", output["dir"])
+}
+
+func TestTransform_K8sEmptyNamespace(t *testing.T) {
+	kubernetes.Data = &fakeKubeData{}
+	nt := Network{
+		TransformNetwork: api.TransformNetwork{
+			Rules: api.NetworkTransformRules{{
+				Type:   api.OpAddKubernetes,
+				Input:  "SrcAddr",
+				Output: "SrcK8s",
+			}, {
+				Type:   api.OpAddKubernetes,
+				Input:  "DstAddr",
+				Output: "DstK8s",
+			}},
+		},
+	}
+	// We need to check that, whether it returns NotFound or just an empty namespace,
+	// there is no map entry for that namespace (an empty-valued map entry is not valid)
+	out, _ := nt.Transform(config.GenericMap{
+		"SrcAddr": "1.2.3.4", // would return an empty namespace
+		"DstAddr": "3.2.1.0", // would return NotFound
+	})
+	assert.NotContains(t, out, "SrcK8s_Namespace")
+	assert.NotContains(t, out, "DstK8s_Namespace")
+}
+
+type fakeKubeData struct{}
+
+func (d *fakeKubeData) InitFromConfig(_ string) error {
+	return nil
+}
+func (*fakeKubeData) GetInfo(n string) (*kubernetes.Info, error) {
+	// If found, returns an empty info (empty namespace)
+	if n == "1.2.3.4" {
+		return &kubernetes.Info{}, nil
+	}
+	return nil, errors.New("notFound")
 }


### PR DESCRIPTION
This caused that empty-string and nil namespaces were treated differently in some metrics aggregations:
<img width="1314" alt="image" src="https://user-images.githubusercontent.com/939550/203977800-779c8913-afb3-4abc-beb8-f0d2bd985a42.png">

Now there are no duplicities:
<img width="1577" alt="image" src="https://user-images.githubusercontent.com/939550/203982180-b71f63c3-e5f6-422f-b5c5-90ae0f80794f.png">

