### PR TITLE
NETOBSERV-743: update build image & CI tests to Go 1.18 (4.12 backport)

### DIFF
--- a/.bingo/Variables.mk
+++ b/.bingo/Variables.mk
@@ -32,7 +32,7 @@ $(BINGO): $(BINGO_DIR)/bingo.mod
 GOLANGCI_LINT := $(GOBIN)/golangci-lint-v1.47.2
 $(GOLANGCI_LINT): $(BINGO_DIR)/golangci-lint.mod
 	@# Install binary/ries using Go 1.14+ build command. This is using bwplotka/bingo-controlled, separate go module with pinned dependencies.
-	@echo "(re)installing $(GOBIN)/golangci-lint-v1.47.2"
+	@echo "(re)installing $(GOBIN)/golangci-lint-v1.50.1"
 	@cd $(BINGO_DIR) && $(GO) build -mod=mod -modfile=golangci-lint.mod -o=$(GOBIN)/golangci-lint-v1.47.2 "github.com/golangci/golangci-lint/cmd/golangci-lint"
 
 JB := $(GOBIN)/jb-v0.4.0

--- a/.bingo/variables.env
+++ b/.bingo/variables.env
@@ -12,7 +12,7 @@ BENCHSTAT="${GOBIN}/benchstat-v0.0.0-20211012211434-03971e389cd3"
 
 BINGO="${GOBIN}/bingo-v0.5.1"
 
-GOLANGCI_LINT="${GOBIN}/golangci-lint-v1.47.2"
+GOLANGCI_LINT="${GOBIN}/golangci-lint-v1.50.1"
 
 JB="${GOBIN}/jb-v0.4.0"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17', '1.18']
+        go: ['1.18']
         
     steps:
     - name: install make

--- a/.github/workflows/pull_request_e2e.yml
+++ b/.github/workflows/pull_request_e2e.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.17', '1.18']
+        go: ['1.18']
         
     steps:
     - name: install make

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
       - name: install make
         run: sudo apt-get install make

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
       - name: install make
         run: sudo apt-get install make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go: ['1.17']
+        go: ['1.18']
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ SHELL := /bin/bash
 DOCKER_TAG ?= latest
 DOCKER_IMG ?= quay.io/netobserv/flowlogs-pipeline
 OCI_RUNTIME ?= $(shell which podman  || which docker)
-MIN_GO_VERSION := 1.17.0
+MIN_GO_VERSION := 1.18.0
 FLP_BIN_FILE=flowlogs-pipeline
 CG_BIN_FILE=confgenerator
 NETFLOW_GENERATOR=nflow-generator
@@ -65,11 +65,7 @@ validate_go:
 
 .PHONY: validate_go lint
 lint: $(GOLANGCI_LINT) ## Lint the code
-	@current_ver=$$(go version | { read _ _ v _; echo $${v#go}; }); \
-	if [[ "$$current_ver" == *"1.18"* ]]; then echo "Linting is not fully supported for golang 1.18. Consider using golang 1.17";\
-		$(GOLANGCI_LINT) run --disable-all --enable goimports --enable gofmt --enable ineffassign --timeout 5m; else \
-		$(GOLANGCI_LINT) run --enable goimports --timeout 5m; \
-	fi
+	$(GOLANGCI_LINT) run --enable goimports --enable gofmt --enable ineffassign --timeout 5m
 
 .PHONY: build_code
 build_code:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ These instructions apply for deploying FLP development and exploration environme
 tested on Ubuntu 20.4 and Fedora 34.
 1. Make sure the following commands are installed and can be run from the current shell:
    - make
-   - go (version 1.17)
+   - go (version 1.18)
    - docker
 2. To deploy the full simulated environment which includes a kind cluster with FLP, Prometheus, Grafana, and
    netflow-simulator, run (note that depending on your user permissions, you may have to run this command under sudo):

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/golang:1.17 as builder
+FROM docker.io/library/golang:1.18 as builder
 
 WORKDIR /app
 


### PR DESCRIPTION
backport of https://github.com/netobserv/flowlogs-pipeline/pull/341