### PR TITLE
Add sampling factor multiplier

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ Using `remove_entry_if_not_equal` will remove the entry if the specified field e
 1. Compute geo-location from IP addresses
 1. Resolve kubernetes information from IP addresses
 1. Perform regex operations on field values
+1. Multiply a field by a value (e.g. when receiving only a sampling of bytes transferred)
 
 Example configuration:
 
@@ -416,6 +417,10 @@ parameters:
             output: match-10.0
             type: add_regex_if
             parameters: 10.0.*
+          - input: bytes
+            output: bytes
+            type: multiplier
+            parameters: "20"
 ```
 
 The first rule `add_subnet` generates a new field named `srcSubnet` with the 
@@ -459,6 +464,12 @@ The sixth rule `add_regex_if` generates a new field named `match-10.0` that cont
 the contents of the `srcSubnet` field for entries that match regex expression specified 
 in the `parameters` variable. In addition, the field `match-10.0_Matched` with 
 value `true` is added to all matched entries
+
+The rule `multiplier` takes the input field, multiplies by the value in `parameter` and
+places the result in the output field.
+This is useful to use when provided with only a sample of the flow logs (e.g. 1 our of 20),
+and some of the variables need to be adjusted accordingly.
+Note that the `parameter` is a string variable, but it must represent a number.
 
 
 > Note: above example describes all available transform network `Type` options

--- a/docs/api.md
+++ b/docs/api.md
@@ -147,6 +147,7 @@ Following is the supported API format for network transformations:
                      add_location: add output location fields from input
                      add_service: add output network service field from input port and parameters protocol field
                      add_kubernetes: add output kubernetes fields from input
+                     multiplier: multiply value of input variable by parameter
                  parameters: parameters specific to type
                  assignee: value needs to assign to output field
          kubeConfigPath: path to kubeconfig file (optional)

--- a/network_definitions/bandwidth_per_network_service.yaml
+++ b/network_definitions/bandwidth_per_network_service.yaml
@@ -12,6 +12,10 @@ tags:
   - network-service
 transform:
   rules:
+    - input: bytes
+      output: bytes
+      type: multiplier
+      parameters: "1"
     - input: dstPort
       output: service
       type: add_service

--- a/network_definitions/bandwidth_per_src_dest_subnet.yaml
+++ b/network_definitions/bandwidth_per_src_dest_subnet.yaml
@@ -12,6 +12,10 @@ tags:
   - subnet
 transform:
   rules:
+    - input: bytes
+      output: bytes
+      type: multiplier
+      parameters: "1"
     - input: dstIP
       output: dstSubnet24
       type: add_subnet

--- a/network_definitions/bandwidth_per_src_subnet.yaml
+++ b/network_definitions/bandwidth_per_src_subnet.yaml
@@ -12,6 +12,10 @@ tags:
   - subnet
 transform:
   rules:
+    - input: bytes
+      output: bytes
+      type: multiplier
+      parameters: "1"
     - input: srcIP
       output: srcSubnet
       type: add_subnet

--- a/network_definitions/egress_bandwidth_per_dest_subnet.yaml
+++ b/network_definitions/egress_bandwidth_per_dest_subnet.yaml
@@ -12,6 +12,10 @@ tags:
   - subnet
 transform:
   rules:
+    - input: bytes
+      output: bytes
+      type: multiplier
+      parameters: "1"
     - input: dstIP
       output: dstSubnet
       type: add_subnet

--- a/network_definitions/egress_bandwidth_per_namespace.yaml
+++ b/network_definitions/egress_bandwidth_per_namespace.yaml
@@ -11,6 +11,10 @@ tags:
   - graph
 transform:
   rules:
+    - input: bytes
+      output: bytes
+      type: multiplier
+      parameters: "1"
     - input: srcIP
       output: srcK8S
       type: add_kubernetes

--- a/network_definitions/flows_length_histogram.yaml
+++ b/network_definitions/flows_length_histogram.yaml
@@ -13,6 +13,10 @@ tags:
 transform:
   rules:
     - input: bytes
+      output: bytes
+      type: multiplier
+      parameters: 1
+    - input: bytes
       output: all
       type: add_if
       parameters: ">=0"

--- a/pkg/api/transform_network.go
+++ b/pkg/api/transform_network.go
@@ -43,6 +43,7 @@ const (
 	OpAddLocation   = "add_location"
 	OpAddService    = "add_service"
 	OpAddKubernetes = "add_kubernetes"
+	OpMultiplier    = "multiplier"
 )
 
 type TransformNetworkOperationEnum struct {
@@ -52,6 +53,7 @@ type TransformNetworkOperationEnum struct {
 	AddLocation   string `yaml:"add_location" json:"add_location" doc:"add output location fields from input"`
 	AddService    string `yaml:"add_service" json:"add_service" doc:"add output network service field from input port and parameters protocol field"`
 	AddKubernetes string `yaml:"add_kubernetes" json:"add_kubernetes" doc:"add output kubernetes fields from input"`
+	Multiplier    string `yaml:"multiplier" json:"multiplier" doc:"multiply value of input variable by parameter"`
 }
 
 func TransformNetworkOperationName(operation string) string {

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -84,7 +84,7 @@ func (n *Network) Transform(inputEntry config.GenericMap) (config.GenericMap, bo
 			var locationInfo *location.Info
 			err, locationInfo := location.GetLocation(fmt.Sprintf("%s", outputEntry[rule.Input]))
 			if err != nil {
-				log.Errorf("Can't find location for IP %v err %v", outputEntry[rule.Input], err)
+				log.Warningf("Can't find location for IP %v err %v", outputEntry[rule.Input], err)
 				continue
 			}
 			outputEntry[rule.Output+"_CountryName"] = locationInfo.CountryName


### PR DESCRIPTION
This PR allows to add in the configuration file a multiplier to apply to particular fields in a flow log.
For example, if we know that we only get a sampling of the flow logs (e.g. 1/20), then the administrator may want us to multiply the measured number of bytes and/or packets in the flow log entries in order to get a closer estimate of the actual number of bytes and/or packets.
Each field that requires a multiplier must be individually marked.
The implementation in this PR adds the functionality in the transform_network stage, where we already have fields that can be used to represent this operation.
We should consider whether it makes more sense to place the operation in the transform_generic stage.
