### PR TITLE
Updated Dockefile for crosscompilation compatibility

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,4 +35,4 @@ jobs:
         flags: unittests
         fail_ci_if_error: true
     - name: build images
-      run: DOCKER_TAG=${{ steps.validate_tag.outputs.tag }} make build-image-multiarch
+      run: DOCKER_TAG=test-multi-arch make build-image-multiarch

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         go: ['1.18']
-        
+
     steps:
     - name: install make
       run: sudo apt-get install make
@@ -34,3 +34,5 @@ jobs:
         token: ${{ secrets.CODECOV_SECRET }}
         flags: unittests
         fail_ci_if_error: true
+    - name: build images
+      run: DOCKER_TAG=${{ steps.validate_tag.outputs.tag }} make build-image-multiarch

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,5 +34,3 @@ jobs:
         token: ${{ secrets.CODECOV_SECRET }}
         flags: unittests
         fail_ci_if_error: true
-    - name: build images
-      run: DOCKER_TAG=test-multi-arch make build-image-multiarch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
       - name: build images
-        run: DOCKER_TAG=${{ steps.validate_tag.outputs.tag }} make build-image
+        run: DOCKER_TAG=${{ steps.validate_tag.outputs.tag }} make build-image-multiarch
       - name: podman login to quay.io
         uses: redhat-actions/podman-login@v1
         with:

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,28 @@ run: build ## Run
 build-image:
 	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) build -t $(DOCKER_IMG):$(DOCKER_TAG) -f contrib/docker/Dockerfile .
 
+# note: to build and push custom image tag use: DOCKER_TAG=test make push-image
+.PHONY: build-image-multiarch
+build-image-multiarch:
+	#The --load option is ignored by podman but required for docker
+	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) buildx build --load --platform=linux/amd64 -t $(DOCKER_IMG):$(DOCKER_TAG)-amd64 -f contrib/docker/Dockerfile .
+	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) buildx build --load --platform=linux/arm64 -t $(DOCKER_IMG):$(DOCKER_TAG)-arm64 -f contrib/docker/Dockerfile .
+	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) buildx build --load --platform=linux/ppc64le -t $(DOCKER_IMG):$(DOCKER_TAG)-ppc64le -f contrib/docker/Dockerfile .
+
+.PHONY: push-image-multiarch
+push-image-multiarch: build-image-multiarch
+	@echo 'build and publish manifest $(DOCKER_TAG) to $(DOCKER_IMG)'
+	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) push $(DOCKER_IMG):$(DOCKER_TAG)-amd64
+	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) push $(DOCKER_IMG):$(DOCKER_TAG)-arm64
+	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) push $(DOCKER_IMG):$(DOCKER_TAG)-ppc64le
+	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) manifest create $(DOCKER_IMG):$(DOCKER_TAG) --amend $(DOCKER_IMG):$(DOCKER_TAG)-amd64 --amend $(DOCKER_IMG):$(DOCKER_TAG)-arm64 --amend $(DOCKER_IMG):$(DOCKER_TAG)-ppc64le
+ifeq ($(shell basename $(OCI_RUNTIME)), docker)
+		DOCKER_BUILDKIT=1 $(OCI_RUNTIME) manifest push $(DOCKER_IMG):$(DOCKER_TAG)
+else
+		DOCKER_BUILDKIT=1 $(OCI_RUNTIME) manifest push $(DOCKER_IMG):$(DOCKER_TAG) docker://$(DOCKER_IMG):$(DOCKER_TAG)
+endif
+
+
 .PHONY: build-ci-images
 build-ci-images:
 ifeq ($(DOCKER_TAG), main)

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ build-image:
 
 build-image-multiarch-linux/%:
 #The --load option is ignored by podman but required for docker
-	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) buildx build --load --platform=linux/$* -t $(DOCKER_IMG):$(DOCKER_TAG)-$* -f contrib/docker/Dockerfile .
+	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) buildx build --load --build-arg TARGETPLATFORM=linux/$* --build-arg TARGETARCH=$* --build-arg BUILDPLATFORM=linux/amd64 -t $(DOCKER_IMG):$(DOCKER_TAG)-$* -f contrib/docker/Dockerfile .
 
 # note: to build and push custom image tag use: DOCKER_TAG=test make push-image
 .PHONY: build-image-multiarch

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,10 @@ export GOFLAGS=-mod=vendor
 export GO111MODULE=on
 export CGO_ENABLED=0
 export GOOS=linux
-export GOARCH=amd64
 
-SHELL := /bin/bash
+GOARCH ?= amd64
+
+SHELL := /usr/bin/env bash
 DOCKER_TAG ?= latest
 DOCKER_IMG ?= quay.io/netobserv/flowlogs-pipeline
 OCI_RUNTIME ?= $(shell which podman  || which docker)
@@ -69,8 +70,8 @@ lint: $(GOLANGCI_LINT) ## Lint the code
 
 .PHONY: build_code
 build_code:
-	go build -ldflags "-X 'main.BuildVersion=$(BUILD_VERSION)' -X 'main.BuildDate=$(BUILD_DATE)'" "${CMD_DIR}${FLP_BIN_FILE}"
-	go build -ldflags "-X 'main.BuildVersion=$(BUILD_VERSION)' -X 'main.BuildDate=$(BUILD_DATE)'" "${CMD_DIR}${CG_BIN_FILE}"
+	GOARCH=${GOARCH} go build -ldflags "-X 'main.BuildVersion=$(BUILD_VERSION)' -X 'main.BuildDate=$(BUILD_DATE)'" "${CMD_DIR}${FLP_BIN_FILE}"
+	GOARCH=${GOARCH} go build -ldflags "-X 'main.BuildVersion=$(BUILD_VERSION)' -X 'main.BuildDate=$(BUILD_DATE)'" "${CMD_DIR}${CG_BIN_FILE}"
 
 .PHONY: build
 build: validate_go lint build_code docs ## Build flowlogs-pipeline executable and update the docs

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ build-image-multiarch-linux/%:
 # note: to build and push custom image tag use: DOCKER_TAG=test make push-image
 .PHONY: build-image-multiarch
 build-image-multiarch: build-image-multiarch-linux/amd64 build-image-multiarch-linux/arm64 build-image-multiarch-linux/ppc64le
+	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) manifest create $(DOCKER_IMG):$(DOCKER_TAG) --amend $(DOCKER_IMG):$(DOCKER_TAG)-amd64 --amend $(DOCKER_IMG):$(DOCKER_TAG)-arm64 --amend $(DOCKER_IMG):$(DOCKER_TAG)-ppc64le
 
 push-image-multiarch-linux/%:
 	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) push $(DOCKER_IMG):$(DOCKER_TAG)-$*
@@ -144,8 +145,7 @@ push-image-multiarch-linux/%:
 
 .PHONY: push-image-multiarch
 push-image-multiarch: build-image-multiarch push-image-multiarch-linux/amd64 push-image-multiarch-linux/arm64 push-image-multiarch-linux/ppc64le
-	@echo 'build and publish manifest $(DOCKER_TAG) to $(DOCKER_IMG)'
-	DOCKER_BUILDKIT=1 $(OCI_RUNTIME) manifest create $(DOCKER_IMG):$(DOCKER_TAG) --amend $(DOCKER_IMG):$(DOCKER_TAG)-amd64 --amend $(DOCKER_IMG):$(DOCKER_TAG)-arm64 --amend $(DOCKER_IMG):$(DOCKER_TAG)-ppc64le
+	@echo 'publish manifest $(DOCKER_TAG) to $(DOCKER_IMG)'
 ifeq ($(shell basename $(OCI_RUNTIME)), docker)
 		DOCKER_BUILDKIT=1 $(OCI_RUNTIME) manifest push $(DOCKER_IMG):$(DOCKER_TAG)
 else

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,4 @@
-# TARGETPLATFORM and BUILDPLATFORM are automatically field when specifying an architecture during build but they need to be declared
+# We do not use --platform feature to auto fill this ARG because of incompatibility between podman and docker
 ARG TARGETPLATFORM=linux/amd64
 ARG BUILDPLATFORM=linux/amd64
 FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.18 as builder

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,10 +1,10 @@
 # TARGETPLATFORM and BUILDPLATFORM are automatically field when specifying an architecture during build but they need to be declared
+ARG TARGETPLATFORM=linux/amd64
+ARG BUILDPLATFORM=linux/amd64
 FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.18 as builder
 
 ARG TARGETPLATFORM
-ARG BUILDPLATFORM
-ARG TARGETARCH
-
+ARG TARGETARCH=amd64
 WORKDIR /app
 
 # Copy source code

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,9 @@
-FROM docker.io/library/golang:1.18 as builder
+# TARGETPLATFORM and BUILDPLATFORM are automatically field when specifying an architecture during build but they need to be declared
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.18 as builder
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -13,15 +18,10 @@ COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 RUN git status --porcelain
-RUN make build_code
+RUN GOARCH=$TARGETARCH make build_code
 
 # final stage
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
-RUN microdnf install -y \
-  iputils \
-  curl \
-  net-tools \
-  && microdnf -y clean all  && rm -rf /var/cache
+FROM  --platform=$TARGETPLATFORM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
 COPY --from=builder /app/flowlogs-pipeline /app/
 COPY --from=builder /app/confgenerator /app/

--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 


### PR DESCRIPTION
This update the Dockerfile to make it possible to cross build FLP container image.

Example of manual cross build command:
`podman buildx build --platform=linux/ppc64le -t test -f ./contrib/docker/Dockerfile .`

Could someone with docker installed could confirm that the cli API is identical and the example above also works with docker?