### PR TITLE
limit memory used by FLP

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -201,7 +201,7 @@ Following is the supported API format for specifying metrics aggregations:
  aggregates:
          name: description of aggregation result
          groupByKeys: list of fields on which to aggregate
-         operationType: sum, min, max, avg or raw_values
+         operationType: sum, min, max, count, avg or raw_values
          operationKey: internal field on which to perform the operation
 </pre>
 ## Connection tracking API

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,6 +24,7 @@ Following is the supported API format for prometheus encode:
          tls: TLS configuration for the prometheus endpoint
              certPath: path to the certificate file
              keyPath: path to the key file
+         maxMetrics: maximum number of metrics to report (default: unlimited)
 </pre>
 ## Kafka encode API
 Following is the supported API format for kafka encode:
@@ -149,11 +150,22 @@ Following is the supported API format for network transformations:
                      add_location: add output location fields from input
                      add_service: add output network service field from input port and parameters protocol field
                      add_kubernetes: add output kubernetes fields from input
+                     reinterpret_direction: reinterpret flow direction at a higher level than the interface
+                     add_ip_category: categorize IPs based on known subnets configuration
                  parameters: parameters specific to type
                  assignee: value needs to assign to output field
          kubeConfigPath: path to kubeconfig file (optional)
          servicesFile: path to services file (optional, default: /etc/services)
          protocolsFile: path to protocols file (optional, default: /etc/protocols)
+         ipCategories: configure IP categories
+                 cidrs: list of CIDRs to match a category
+                 name: name of the category
+         directionInfo: information to reinterpret flow direction (optional, to use with reinterpret_direction rule)
+             reporterIPField: field providing the reporter (agent) host IP
+             srcHostField: source host field
+             dstHostField: destination host field
+             flowDirectionField: field providing the flow direction in the input entries; it will be rewritten
+             ifDirectionField: interface-level field for flow direction, to create in output
 </pre>
 ## Write Loki API
 Following is the supported API format for writing to loki:

--- a/docs/api.md
+++ b/docs/api.md
@@ -233,7 +233,7 @@ Following is the supported API format for specifying connection tracking:
                  input: The input field to base the operation on. When omitted, 'name' is used
          endConnectionTimeout: duration of time to wait from the last flow log to end a connection
          updateConnectionInterval: duration of time to wait between update reports of a connection
-         maxConnectionsTracked: maximum number of connections we keep in our cache (to limit memory usage)
+         maxConnectionsTracked: maximum number of connections we keep in our cache (0 means no limit)
 </pre>
 ## Time-based Filters API
 Following is the supported API format for specifying metrics time-based filters:

--- a/docs/api.md
+++ b/docs/api.md
@@ -233,6 +233,7 @@ Following is the supported API format for specifying connection tracking:
                  input: The input field to base the operation on. When omitted, 'name' is used
          endConnectionTimeout: duration of time to wait from the last flow log to end a connection
          updateConnectionInterval: duration of time to wait between update reports of a connection
+         maxConnectionsTracked: maximum number of connections we keep in our cache (to limit memory usage)
 </pre>
 ## Time-based Filters API
 Following is the supported API format for specifying metrics time-based filters:

--- a/docs/operational-metrics.md
+++ b/docs/operational-metrics.md
@@ -71,6 +71,14 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 | **Labels** | stage | 
 
 
+### metrics_dropped
+| **Name** | metrics_dropped | 
+|:---|:---|
+| **Description** | Number of metrics dropped | 
+| **Type** | counter | 
+| **Labels** | stage | 
+
+
 ### metrics_processed
 | **Name** | metrics_processed | 
 |:---|:---|

--- a/pkg/api/conntrack.go
+++ b/pkg/api/conntrack.go
@@ -34,7 +34,7 @@ type ConnTrack struct {
 	OutputFields             []OutputField `yaml:"outputFields,omitempty" doc:"list of output fields"`
 	EndConnectionTimeout     Duration      `yaml:"endConnectionTimeout,omitempty" doc:"duration of time to wait from the last flow log to end a connection"`
 	UpdateConnectionInterval Duration      `yaml:"updateConnectionInterval,omitempty" doc:"duration of time to wait between update reports of a connection"`
-	MaxConnectionsTracked    int           `yaml:"maxConnectionsTracked,omitempty" doc:"maximum number of connections we keep in our cache (to limit memory usage)"`
+	MaxConnectionsTracked    int           `yaml:"maxConnectionsTracked,omitempty" doc:"maximum number of connections we keep in our cache (0 means no limit)"`
 }
 
 type ConnTrackOutputRecordTypeEnum struct {

--- a/pkg/api/conntrack.go
+++ b/pkg/api/conntrack.go
@@ -34,6 +34,7 @@ type ConnTrack struct {
 	OutputFields             []OutputField `yaml:"outputFields,omitempty" doc:"list of output fields"`
 	EndConnectionTimeout     Duration      `yaml:"endConnectionTimeout,omitempty" doc:"duration of time to wait from the last flow log to end a connection"`
 	UpdateConnectionInterval Duration      `yaml:"updateConnectionInterval,omitempty" doc:"duration of time to wait between update reports of a connection"`
+	MaxConnectionsTracked    int           `yaml:"maxConnectionsTracked,omitempty" doc:"maximum number of connections we keep in our cache (to limit memory usage)"`
 }
 
 type ConnTrackOutputRecordTypeEnum struct {

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -29,6 +29,7 @@ type PromEncode struct {
 	Prefix     string           `yaml:"prefix,omitempty" json:"prefix,omitempty" doc:"prefix added to each metric name"`
 	ExpiryTime int              `yaml:"expiryTime,omitempty" json:"expiryTime,omitempty" doc:"seconds of no-flow to wait before deleting prometheus data item"`
 	TLS        *PromTLSConf     `yaml:"tls,omitempty" json:"tls,omitempty" doc:"TLS configuration for the prometheus endpoint"`
+	MaxMetrics int              `yaml:"maxMetrics,omitempty" json:"maxMetrics,omitempty" doc:"maximum number of metrics to report (default: unlimited)"`
 }
 
 type PromEncodeOperationEnum struct {

--- a/pkg/api/extract_aggregate.go
+++ b/pkg/api/extract_aggregate.go
@@ -23,6 +23,6 @@ type AggregateOperation string
 type AggregateDefinition struct {
 	Name          string             `yaml:"name,omitempty" json:"name,omitempty" doc:"description of aggregation result"`
 	GroupByKeys   AggregateBy        `yaml:"groupByKeys,omitempty" json:"groupByKeys,omitempty" doc:"list of fields on which to aggregate"`
-	OperationType AggregateOperation `yaml:"operationType,omitempty" json:"operationType,omitempty" doc:"sum, min, max, avg or raw_values"`
+	OperationType AggregateOperation `yaml:"operationType,omitempty" json:"operationType,omitempty" doc:"sum, min, max, count, avg or raw_values"`
 	OperationKey  string             `yaml:"operationKey,omitempty" json:"operationKey,omitempty" doc:"internal field on which to perform the operation"`
 }

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -152,7 +152,7 @@ func TestKafkaPromPipeline(t *testing.T) {
 
 	b, err = json.Marshal(params[2])
 	require.NoError(t, err)
-	require.JSONEq(t, `{"name":"conntrack","extract":{"type":"conntrack","conntrack":{"KeyDefinition":{"FieldGroups":null,"Hash":{"FieldGroupRefs":null,"FieldGroupARef":"","FieldGroupBRef":""}},"OutputRecordTypes":null,"OutputFields":null,"EndConnectionTimeout":"0s","UpdateConnectionInterval":"0s"}}}`, string(b))
+	require.JSONEq(t, `{"name":"conntrack","extract":{"type":"conntrack","conntrack":{"KeyDefinition":{"FieldGroups":null,"Hash":{"FieldGroupRefs":null,"FieldGroupARef":"","FieldGroupBRef":""}},"OutputRecordTypes":null,"MaxConnectionsTracked":0,"OutputFields":null,"EndConnectionTimeout":"0s","UpdateConnectionInterval":"0s"}}}`, string(b))
 
 	b, err = json.Marshal(params[3])
 	require.NoError(t, err)

--- a/pkg/pipeline/encode/prom_cache_test.go
+++ b/pkg/pipeline/encode/prom_cache_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 IBM, Inc.
+ * Copyright (C) 2023 IBM, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/pipeline/encode/prom_cache_test.go
+++ b/pkg/pipeline/encode/prom_cache_test.go
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2022 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package encode
+
+import (
+	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/test"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	yamlConfig1 = `
+pipeline:
+ - name: encode
+parameters:
+ - name: encode_prom
+   encode:
+     type: prom
+     prom:
+       port: 9103
+       prefix: test_
+       expiryTime: 1
+       maxMetrics: 30
+       metrics:
+         - name: bytes_count
+           type: counter
+           valueKey: Bytes
+           labels:
+             - SrcAddr
+`
+
+	yamlConfig2 = `
+pipeline:
+ - name: encode
+parameters:
+ - name: encode_prom
+   encode:
+     type: prom
+     prom:
+       port: 9103
+       prefix: test_
+       expiryTime: 1
+       maxMetrics: 30
+       metrics:
+         - name: bytes_count
+           type: counter
+           valueKey: Bytes
+           labels:
+             - SrcAddr
+         - name: packets_count
+           type: counter
+           valueKey: Packets
+           labels:
+             - SrcAddr
+`
+
+	yamlConfig3 = `
+pipeline:
+ - name: encode
+parameters:
+ - name: encode_prom
+   encode:
+     type: prom
+     prom:
+       port: 9103
+       prefix: test_
+       expiryTime: 1
+       metrics:
+         - name: bytes_count
+           type: counter
+           valueKey: Bytes
+           labels:
+             - SrcAddr
+         - name: packets_count
+           type: counter
+           valueKey: Packets
+           labels:
+             - SrcAddr
+`
+)
+
+func encodeEntries(promEncode *EncodeProm, entries []config.GenericMap) {
+	for _, entry := range entries {
+		promEncode.Encode(entry)
+	}
+}
+
+// Test_Prom_Cache tests the integration between encode_prom and timebased_cache.
+// Set a cache size, create many prom metrics, and verify that they interact properly.
+func Test_Prom_Cache1(t *testing.T) {
+	var entries []config.GenericMap
+
+	v, cfg := test.InitConfig(t, yamlConfig1)
+	require.NotNil(t, v)
+
+	promEncode, cleanup, err := initPromWithServer(cfg.Parameters[0].Encode.Prom)
+	require.NoError(t, err)
+	defer cleanup()
+
+	entries = test.GenerateConnectionEntries(10)
+	require.Equal(t, 10, len(entries))
+	encodeEntries(promEncode, entries)
+	require.Equal(t, 10, promEncode.mCache.GetCacheLen())
+
+	entries = test.GenerateConnectionEntries(40)
+	require.Equal(t, 40, len(entries))
+	encodeEntries(promEncode, entries)
+	require.Equal(t, 30, promEncode.mCache.GetCacheLen())
+}
+
+func Test_Prom_Cache2(t *testing.T) {
+	var entries []config.GenericMap
+
+	v, cfg := test.InitConfig(t, yamlConfig2)
+	require.NotNil(t, v)
+
+	promEncode, cleanup, err := initPromWithServer(cfg.Parameters[0].Encode.Prom)
+	require.NoError(t, err)
+	defer cleanup()
+
+	entries = test.GenerateConnectionEntries(10)
+	require.Equal(t, 10, len(entries))
+	encodeEntries(promEncode, entries)
+	require.Equal(t, 20, promEncode.mCache.GetCacheLen())
+
+	entries = test.GenerateConnectionEntries(40)
+	require.Equal(t, 40, len(entries))
+	encodeEntries(promEncode, entries)
+	require.Equal(t, 30, promEncode.mCache.GetCacheLen())
+}
+
+func Test_Prom_Cache3(t *testing.T) {
+	var entries []config.GenericMap
+
+	v, cfg := test.InitConfig(t, yamlConfig3)
+	require.NotNil(t, v)
+
+	promEncode, cleanup, err := initPromWithServer(cfg.Parameters[0].Encode.Prom)
+	require.NoError(t, err)
+	defer cleanup()
+
+	entries = test.GenerateConnectionEntries(10)
+	require.Equal(t, 10, len(entries))
+	encodeEntries(promEncode, entries)
+	require.Equal(t, 20, promEncode.mCache.GetCacheLen())
+
+	entries = test.GenerateConnectionEntries(40)
+	require.Equal(t, 40, len(entries))
+	encodeEntries(promEncode, entries)
+	require.Equal(t, 80, promEncode.mCache.GetCacheLen())
+}

--- a/pkg/pipeline/extract/aggregate/aggregate_test.go
+++ b/pkg/pipeline/extract/aggregate/aggregate_test.go
@@ -37,7 +37,7 @@ func GetMockAggregate() Aggregate {
 			OperationType: "avg",
 			OperationKey:  "value",
 		},
-		cache:      utils.NewTimedCache(),
+		cache:      utils.NewTimedCache(0),
 		mutex:      &sync.Mutex{},
 		expiryTime: 30 * time.Second,
 	}

--- a/pkg/pipeline/extract/aggregate/aggregates.go
+++ b/pkg/pipeline/extract/aggregate/aggregates.go
@@ -61,7 +61,7 @@ func (aggregates *Aggregates) GetMetrics() []config.GenericMap {
 func (aggregates *Aggregates) AddAggregate(aggregateDefinition api.AggregateDefinition) []Aggregate {
 	aggregate := Aggregate{
 		Definition: aggregateDefinition,
-		cache:      utils.NewTimedCache(),
+		cache:      utils.NewTimedCache(0),
 		mutex:      &sync.Mutex{},
 		expiryTime: aggregates.expiryTime,
 	}

--- a/pkg/pipeline/extract/conntrack/conntrack.go
+++ b/pkg/pipeline/extract/conntrack/conntrack.go
@@ -68,6 +68,8 @@ func (ct *conntrackImpl) Extract(flowLogs []config.GenericMap) []config.GenericM
 		conn, exists := ct.connStore.getConnection(computedHash.hashTotal)
 		if !exists {
 			if (ct.config.MaxConnectionsTracked > 0) && (ct.config.MaxConnectionsTracked <= ct.connStore.mom.Len()) {
+				log.Warningf("too many connections; skipping flow log %v: ", fl)
+				ct.metrics.inputRecords.WithLabelValues("discarded").Inc()
 				continue
 			}
 			builder := NewConnBuilder()

--- a/pkg/pipeline/extract/conntrack/conntrack.go
+++ b/pkg/pipeline/extract/conntrack/conntrack.go
@@ -67,6 +67,9 @@ func (ct *conntrackImpl) Extract(flowLogs []config.GenericMap) []config.GenericM
 		}
 		conn, exists := ct.connStore.getConnection(computedHash.hashTotal)
 		if !exists {
+			if (ct.config.MaxConnectionsTracked > 0) && (ct.config.MaxConnectionsTracked <= ct.connStore.mom.Len()) {
+				continue
+			}
 			builder := NewConnBuilder()
 			conn = builder.
 				Hash(computedHash).

--- a/pkg/pipeline/utils/timed_cache.go
+++ b/pkg/pipeline/utils/timed_cache.go
@@ -76,7 +76,7 @@ func (tc *TimedCache) UpdateCacheEntry(key string, entry interface{}) (*cacheEnt
 		tc.cacheList.MoveToBack(cEntry.e)
 	} else {
 		// create new entry for cache
-		if (tc.maxEntries > 0) && (tc.cacheList.Len() > tc.maxEntries) {
+		if (tc.maxEntries > 0) && (tc.cacheList.Len() >= tc.maxEntries) {
 			return nil, false
 		}
 		cEntry = &cacheEntry{

--- a/pkg/pipeline/utils/timed_cache.go
+++ b/pkg/pipeline/utils/timed_cache.go
@@ -29,6 +29,7 @@ var log = logrus.WithField("component", "utils.TimedCache")
 
 // Functions to manage an LRU cache with an expiry
 // When an item expires, allow a callback to allow the specific implementation to perform its particular cleanup
+// Size of cache may be limited by setting maxEntries; if cache is full, do not enter new items.
 
 type CacheCallback func(entry interface{})
 
@@ -42,9 +43,10 @@ type cacheEntry struct {
 type TimedCacheMap map[string]*cacheEntry
 
 type TimedCache struct {
-	mu        sync.RWMutex
-	cacheList *list.List
-	cacheMap  TimedCacheMap
+	mu         sync.RWMutex
+	cacheList  *list.List
+	cacheMap   TimedCacheMap
+	maxEntries int
 }
 
 func (tc *TimedCache) GetCacheEntry(key string) (interface{}, bool) {
@@ -60,7 +62,9 @@ func (tc *TimedCache) GetCacheEntry(key string) (interface{}, bool) {
 
 var uclog = log.WithField("method", "UpdateCacheEntry")
 
-func (tc *TimedCache) UpdateCacheEntry(key string, entry interface{}) *cacheEntry {
+// If cache entry exists, update it and return it; if it does not exist, create it if there is room.
+// If we exceed the size of the cache, then do not allocate new entry
+func (tc *TimedCache) UpdateCacheEntry(key string, entry interface{}) (*cacheEntry, bool) {
 	nowInSecs := time.Now()
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
@@ -72,6 +76,9 @@ func (tc *TimedCache) UpdateCacheEntry(key string, entry interface{}) *cacheEntr
 		tc.cacheList.MoveToBack(cEntry.e)
 	} else {
 		// create new entry for cache
+		if (tc.maxEntries > 0) && (tc.cacheList.Len() > tc.maxEntries) {
+			return nil, false
+		}
 		cEntry = &cacheEntry{
 			lastUpdatedTime: nowInSecs,
 			key:             key,
@@ -82,7 +89,7 @@ func (tc *TimedCache) UpdateCacheEntry(key string, entry interface{}) *cacheEntr
 		cEntry.e = tc.cacheList.PushBack(cEntry)
 		tc.cacheMap[key] = cEntry
 	}
-	return cEntry
+	return cEntry, true
 }
 
 func (tc *TimedCache) GetCacheLen() int {
@@ -134,10 +141,11 @@ func (tc *TimedCache) CleanupExpiredEntries(expiry time.Duration, callback Cache
 	}
 }
 
-func NewTimedCache() *TimedCache {
+func NewTimedCache(maxEntries int) *TimedCache {
 	l := &TimedCache{
-		cacheList: list.New(),
-		cacheMap:  make(TimedCacheMap),
+		cacheList:  list.New(),
+		cacheMap:   make(TimedCacheMap),
+		maxEntries: maxEntries,
 	}
 	return l
 }

--- a/pkg/pipeline/utils/timed_cache.go
+++ b/pkg/pipeline/utils/timed_cache.go
@@ -42,6 +42,8 @@ type cacheEntry struct {
 
 type TimedCacheMap map[string]*cacheEntry
 
+// If maxEntries is non-zero, this limits the number of entries in the cache to the number specified.
+// If maxEntries is zero, the cache has no size limit.
 type TimedCache struct {
 	mu         sync.RWMutex
 	cacheList  *list.List

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -197,3 +197,34 @@ func ResetPromRegistry() {
 	prometheus.DefaultRegisterer = reg
 	prometheus.DefaultGatherer = reg
 }
+
+const subnetBatchSize = 200
+
+// GenerateConnectionEntries generates data with one entry for each of nConnections
+// Create the entries in a predictable manner so that the first K entries in each call
+// to the function reproduce the same connection.
+func GenerateConnectionEntries(nConnections int) []config.GenericMap {
+	entries := make([]config.GenericMap, 0)
+	nSubnets := (nConnections / subnetBatchSize) + 1
+	if nSubnets > 254 {
+		nSubnets = 254
+	}
+	count := 0
+	for i := 1; i <= nSubnets; i++ {
+		for j := 1; j <= subnetBatchSize; j++ {
+			srcAddr := fmt.Sprintf("10.1.%d.%d", i, j)
+			count++
+			entry := config.GenericMap{
+				"SrcAddr": srcAddr,
+				"DstAddr": "11.1.1.1",
+				"Bytes":   100,
+				"Packets": 1,
+			}
+			entries = append(entries, entry)
+			if count >= nConnections {
+				return entries
+			}
+		}
+	}
+	return entries
+}


### PR DESCRIPTION
The memory usage of FLP seems to grow linearly with the number of concurrent connections being handled at the same time.
For encode_prom, state is saved (both in FLP and in the prometheus Go client) for each metric/labels combination that is reported. This results in memory growth that is linear with respect to the number of connections currently identified as active. In a configuration with limited memory resources it is desirable to instruct FLP to limit the amount of memory usage.
The tradeoff would be to not report on new connections once the memory limit is hit.

The conntrack stage memory usage also grows with the number of connections and should have the possibility of limiting the number of connections tracked.