### PR TITLE
NETOBSERV-838 Group ingress+egress flows in same connection

### DIFF
--- a/pkg/config/generic_map.go
+++ b/pkg/config/generic_map.go
@@ -29,3 +29,12 @@ func (m GenericMap) Copy() GenericMap {
 
 	return result
 }
+
+func (m GenericMap) IsDuplicate() bool {
+	if duplicate, hasKey := m["Duplicate"]; hasKey {
+		if isDuplicate, ok := duplicate.(bool); ok && isDuplicate {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/config/generic_map.go
+++ b/pkg/config/generic_map.go
@@ -17,6 +17,8 @@
 
 package config
 
+import "github.com/netobserv/flowlogs-pipeline/pkg/utils"
+
 type GenericMap map[string]interface{}
 
 // Copy will create a flat copy of GenericMap
@@ -32,8 +34,8 @@ func (m GenericMap) Copy() GenericMap {
 
 func (m GenericMap) IsDuplicate() bool {
 	if duplicate, hasKey := m["Duplicate"]; hasKey {
-		if isDuplicate, ok := duplicate.(bool); ok && isDuplicate {
-			return true
+		if isDuplicate, err := utils.ConvertToBool(duplicate); err != nil {
+			return isDuplicate
 		}
 	}
 	return false

--- a/pkg/pipeline/encode/encode_prom.go
+++ b/pkg/pipeline/encode/encode_prom.go
@@ -29,7 +29,9 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
-	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	putils "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
@@ -58,7 +60,7 @@ type EncodeProm struct {
 	histos           []histoInfo
 	aggHistos        []histoInfo
 	expiryTime       time.Duration
-	mCache           *utils.TimedCache
+	mCache           *putils.TimedCache
 	exitChan         <-chan struct{}
 	server           *http.Server
 	tlsConfig        *api.PromTLSConf
@@ -381,8 +383,8 @@ func NewEncodeProm(opMetrics *operational.Metrics, params config.StageParam) (En
 		histos:           histos,
 		aggHistos:        aggHistos,
 		expiryTime:       expiryTime,
-		mCache:           utils.NewTimedCache(cfg.MaxMetrics),
-		exitChan:         utils.ExitChannel(),
+		mCache:           putils.NewTimedCache(cfg.MaxMetrics),
+		exitChan:         putils.ExitChannel(),
 		metricsProcessed: opMetrics.NewCounter(&metricsProcessed, params.Name),
 		metricsDropped:   opMetrics.NewCounter(&metricsDropped, params.Name),
 		errorsCounter:    opMetrics.NewCounterVec(&encodePromErrors),

--- a/pkg/pipeline/extract/conntrack/aggregator.go
+++ b/pkg/pipeline/extract/conntrack/aggregator.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
-	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/pipeline/extract/conntrack/aggregator_test.go
+++ b/pkg/pipeline/extract/conntrack/aggregator_test.go
@@ -128,13 +128,13 @@ func TestAddField_and_Update(t *testing.T) {
 	}{
 		{
 			name:      "flowLog 1",
-			flowLog:   newMockFlowLog(ipA, portA, ipB, portB, protocolA, 100, 10),
+			flowLog:   newMockFlowLog(ipA, portA, ipB, portB, protocolA, 100, 10, false),
 			direction: dirAB,
 			expected:  map[string]float64{"Bytes_AB": 100, "Bytes_BA": 0, "Packets": 10, "maxFlowLogBytes": 100, "minFlowLogBytes": 100, "numFlowLogs": 1},
 		},
 		{
 			name:      "flowLog 2",
-			flowLog:   newMockFlowLog(ipA, portA, ipB, portB, protocolA, 200, 20),
+			flowLog:   newMockFlowLog(ipA, portA, ipB, portB, protocolA, 200, 20, false),
 			direction: dirBA,
 			expected:  map[string]float64{"Bytes_AB": 100, "Bytes_BA": 200, "Packets": 30, "maxFlowLogBytes": 200, "minFlowLogBytes": 100, "numFlowLogs": 2},
 		},

--- a/pkg/pipeline/extract/conntrack/conn.go
+++ b/pkg/pipeline/extract/conntrack/conn.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"

--- a/pkg/pipeline/extract/conntrack/conntrack.go
+++ b/pkg/pipeline/extract/conntrack/conntrack.go
@@ -160,8 +160,10 @@ func (ct *conntrackImpl) prepareHeartbeatRecords() []config.GenericMap {
 
 func (ct *conntrackImpl) updateConnection(conn connection, flowLog config.GenericMap, flowLogHash totalHashType) {
 	d := ct.getFlowLogDirection(conn, flowLogHash)
-	for _, agg := range ct.aggregators {
-		agg.update(conn, flowLog, d)
+	if !flowLog.IsDuplicate() {
+		for _, agg := range ct.aggregators {
+			agg.update(conn, flowLog, d)
+		}
 	}
 	ct.connStore.updateConnectionExpiryTime(flowLogHash.hashTotal)
 }

--- a/pkg/pipeline/extract/conntrack/conntrack.go
+++ b/pkg/pipeline/extract/conntrack/conntrack.go
@@ -159,8 +159,8 @@ func (ct *conntrackImpl) prepareHeartbeatRecords() []config.GenericMap {
 }
 
 func (ct *conntrackImpl) updateConnection(conn connection, flowLog config.GenericMap, flowLogHash totalHashType) {
-	d := ct.getFlowLogDirection(conn, flowLogHash)
 	if !flowLog.IsDuplicate() {
+		d := ct.getFlowLogDirection(conn, flowLogHash)
 		for _, agg := range ct.aggregators {
 			agg.update(conn, flowLog, d)
 		}

--- a/pkg/pipeline/extract/conntrack/conntrack_test.go
+++ b/pkg/pipeline/extract/conntrack/conntrack_test.go
@@ -108,10 +108,11 @@ func TestTrack(t *testing.T) {
 	hashIdAB := "705baa5149302fa1"
 	hashIdBA := "cc40f571f40f3111"
 
-	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
-	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22)
-	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33)
-	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 444, 44)
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, false)
+	flAB1Duplicated := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, true)
+	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22, false)
+	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33, false)
+	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 444, 44, false)
 	table := []struct {
 		name          string
 		conf          *config.StageParam
@@ -121,7 +122,7 @@ func TestTrack(t *testing.T) {
 		{
 			"bidirectional, output new connection",
 			buildMockConnTrackConfig(true, []string{"newConnection"}, heartbeatInterval, endConnectionTimeout),
-			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
+			[]config.GenericMap{flAB1, flAB1Duplicated, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
 				newMockRecordNewConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1).withHash(hashId).get(),
 			},
@@ -129,10 +130,11 @@ func TestTrack(t *testing.T) {
 		{
 			"bidirectional, output new connection and flow log",
 			buildMockConnTrackConfig(true, []string{"newConnection", "flowLog"}, heartbeatInterval, endConnectionTimeout),
-			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
+			[]config.GenericMap{flAB1, flAB1Duplicated, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
 				newMockRecordNewConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1).withHash(hashId).get(),
 				newMockRecordFromFlowLog(flAB1).withHash(hashId).get(),
+				newMockRecordFromFlowLog(flAB1Duplicated).withHash(hashIdAB).get(),
 				newMockRecordFromFlowLog(flAB2).withHash(hashId).get(),
 				newMockRecordFromFlowLog(flBA3).withHash(hashId).get(),
 				newMockRecordFromFlowLog(flBA4).withHash(hashId).get(),
@@ -141,7 +143,7 @@ func TestTrack(t *testing.T) {
 		{
 			"unidirectional, output new connection",
 			buildMockConnTrackConfig(false, []string{"newConnection"}, heartbeatInterval, endConnectionTimeout),
-			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
+			[]config.GenericMap{flAB1, flAB1Duplicated, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
 				newMockRecordNewConn(ipA, portA, ipB, portB, protocol, 111, 11, 1).withHash(hashIdAB).get(),
 				newMockRecordNewConn(ipB, portB, ipA, portA, protocol, 333, 33, 1).withHash(hashIdBA).get(),
@@ -150,10 +152,11 @@ func TestTrack(t *testing.T) {
 		{
 			"unidirectional, output new connection and flow log",
 			buildMockConnTrackConfig(false, []string{"newConnection", "flowLog"}, heartbeatInterval, endConnectionTimeout),
-			[]config.GenericMap{flAB1, flAB2, flBA3, flBA4},
+			[]config.GenericMap{flAB1, flAB1Duplicated, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
 				newMockRecordNewConn(ipA, portA, ipB, portB, protocol, 111, 11, 1).withHash(hashIdAB).get(),
 				newMockRecordFromFlowLog(flAB1).withHash(hashIdAB).get(),
+				newMockRecordFromFlowLog(flAB1Duplicated).withHash(hashIdAB).get(),
 				newMockRecordFromFlowLog(flAB2).withHash(hashIdAB).get(),
 				newMockRecordNewConn(ipB, portB, ipA, portA, protocol, 333, 33, 1).withHash(hashIdBA).get(),
 				newMockRecordFromFlowLog(flBA3).withHash(hashIdBA).get(),
@@ -194,10 +197,10 @@ func TestEndConn_Bidirectional(t *testing.T) {
 	protocol := 6
 	hashId := "705baa5149302fa1"
 
-	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
-	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22)
-	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33)
-	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 444, 44)
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, false)
+	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22, false)
+	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33, false)
+	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 444, 44, false)
 	startTime := clk.Now()
 	table := []struct {
 		name          string
@@ -281,10 +284,10 @@ func TestEndConn_Unidirectional(t *testing.T) {
 	hashIdAB := "705baa5149302fa1"
 	hashIdBA := "cc40f571f40f3111"
 
-	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
-	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22)
-	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33)
-	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 444, 44)
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, false)
+	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22, false)
+	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33, false)
+	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 444, 44, false)
 	startTime := clk.Now()
 	table := []struct {
 		name          string
@@ -383,9 +386,9 @@ func TestHeartbeat_Unidirectional(t *testing.T) {
 	hashIdAB := "705baa5149302fa1"
 	hashIdBA := "cc40f571f40f3111"
 
-	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
-	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22)
-	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33)
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, false)
+	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22, false)
+	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33, false)
 	startTime := clk.Now()
 	table := []struct {
 		name          string
@@ -529,7 +532,7 @@ func TestIsFirst_LongConnection(t *testing.T) {
 	portB := 9002
 	protocol := 6
 	hashIdAB := "705baa5149302fa1"
-	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, false)
 	startTime := clk.Now()
 	table := []struct {
 		name          string
@@ -618,7 +621,7 @@ func TestIsFirst_ShortConnection(t *testing.T) {
 	portB := 9002
 	protocol := 6
 	hashIdAB := "705baa5149302fa1"
-	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11)
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, false)
 	startTime := clk.Now()
 	table := []struct {
 		name          string
@@ -753,10 +756,10 @@ func TestScheduling(t *testing.T) {
 	protocolICMP := 1
 	hashIdTCP := "705baa5149302fa1"
 	hashIdICMP := "3dccf73fe57ba06f"
-	flTCP1 := newMockFlowLog(ipA, portA, ipB, portB, protocolTCP, 111, 11)
-	flTCP2 := newMockFlowLog(ipB, portB, ipA, portA, protocolTCP, 222, 22)
-	flICMP1 := newMockFlowLog(ipA, portA, ipB, portB, protocolICMP, 333, 33)
-	flICMP2 := newMockFlowLog(ipB, portB, ipA, portA, protocolICMP, 444, 44)
+	flTCP1 := newMockFlowLog(ipA, portA, ipB, portB, protocolTCP, 111, 11, false)
+	flTCP2 := newMockFlowLog(ipB, portB, ipA, portA, protocolTCP, 222, 22, false)
+	flICMP1 := newMockFlowLog(ipA, portA, ipB, portB, protocolICMP, 333, 33, false)
+	flICMP2 := newMockFlowLog(ipB, portB, ipA, portA, protocolICMP, 444, 44, false)
 	startTime := clk.Now()
 	table := []struct {
 		name          string

--- a/pkg/pipeline/extract/conntrack/hash_test.go
+++ b/pkg/pipeline/extract/conntrack/hash_test.go
@@ -70,32 +70,32 @@ func TestComputeHash_Unidirectional(t *testing.T) {
 	}{
 		{
 			"Same IP, port and protocol",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 222, 11, false),
 			true,
 		},
 		{
 			"Alternating ip+port",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			newMockFlowLog(ipB, portB, ipA, portA, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
+			newMockFlowLog(ipB, portB, ipA, portA, protocolA, 222, 11, false),
 			false,
 		},
 		{
 			"Alternating ip",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			newMockFlowLog(ipB, portA, ipA, portB, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
+			newMockFlowLog(ipB, portA, ipA, portB, protocolA, 222, 11, false),
 			false,
 		},
 		{
 			"Alternating port",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			newMockFlowLog(ipA, portB, ipB, portA, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
+			newMockFlowLog(ipA, portB, ipB, portA, protocolA, 222, 11, false),
 			false,
 		},
 		{
 			"Same IP+port, different protocol",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			newMockFlowLog(ipA, portA, ipB, portB, protocolB, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolB, 222, 11, false),
 			false,
 		},
 	}
@@ -158,32 +158,32 @@ func TestComputeHash_Bidirectional(t *testing.T) {
 	}{
 		{
 			"Same IP, port and protocol",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 222, 11, false),
 			true,
 		},
 		{
 			"Alternating ip+port",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			newMockFlowLog(ipB, portB, ipA, portA, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
+			newMockFlowLog(ipB, portB, ipA, portA, protocolA, 222, 11, false),
 			true,
 		},
 		{
 			"Alternating ip",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			newMockFlowLog(ipB, portA, ipA, portB, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
+			newMockFlowLog(ipB, portA, ipA, portB, protocolA, 222, 11, false),
 			false,
 		},
 		{
 			"Alternating port",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			newMockFlowLog(ipA, portB, ipB, portA, protocolA, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
+			newMockFlowLog(ipA, portB, ipB, portA, protocolA, 222, 11, false),
 			false,
 		},
 		{
 			"Same IP+port, different protocol",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22),
-			newMockFlowLog(ipA, portA, ipB, portB, protocolB, 222, 11),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolB, 222, 11, false),
 			false,
 		},
 	}
@@ -224,7 +224,7 @@ func TestComputeHash_MissingField(t *testing.T) {
 	portB := 9002
 	protocolA := 6
 
-	fl := newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22)
+	fl := newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false)
 
 	h, err := ComputeHash(fl, keyDefinition, testHasher)
 	require.NoError(t, err)

--- a/pkg/pipeline/extract/conntrack/utils_test.go
+++ b/pkg/pipeline/extract/conntrack/utils_test.go
@@ -22,15 +22,16 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 )
 
-func newMockFlowLog(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets int) config.GenericMap {
+func newMockFlowLog(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets int, duplicate bool) config.GenericMap {
 	return config.GenericMap{
-		"SrcAddr": srcIP,
-		"SrcPort": srcPort,
-		"DstAddr": dstIP,
-		"DstPort": dstPort,
-		"Proto":   protocol,
-		"Bytes":   bytes,
-		"Packets": packets,
+		"SrcAddr":   srcIP,
+		"SrcPort":   srcPort,
+		"DstAddr":   dstIP,
+		"DstPort":   dstPort,
+		"Proto":     protocol,
+		"Bytes":     bytes,
+		"Packets":   packets,
+		"Duplicate": duplicate,
 	}
 }
 

--- a/pkg/pipeline/extract/timebased/filters.go
+++ b/pkg/pipeline/extract/timebased/filters.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
-	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/utils/convert.go
+++ b/pkg/utils/convert.go
@@ -221,6 +221,8 @@ func ConvertToBool(unk interface{}) (bool, error) {
 	switch i := unk.(type) {
 	case string:
 		return strconv.ParseBool(i)
+	case bool:
+		return i, nil
 	default:
 		v := reflect.ValueOf(unk)
 		v = reflect.Indirect(v)


### PR DESCRIPTION
This PR skip duplicates in connection tracking aggregations.

It rely on `Duplicate` field [provided by eBPF agent](https://github.com/netobserv/netobserv-ebpf-agent/pull/66)
![image](https://user-images.githubusercontent.com/91894519/218740347-5aa26615-15fb-4ab8-9e36-08fb3cc14723.png)
![image](https://user-images.githubusercontent.com/91894519/218740431-1cfd7d6c-3adc-42fe-a117-54c6fd4bc6fb.png)


