### PR TITLE
Avoid searching new connections in the multi-ordered-map

### DIFF
--- a/pkg/pipeline/extract/conntrack/store.go
+++ b/pkg/pipeline/extract/conntrack/store.go
@@ -78,7 +78,10 @@ func (cs *connectionStore) addConnection(hashId uint64, conn connection) {
 }
 
 func (cs *connectionStore) getConnection(hashId uint64) (connection, bool) {
-	groupIdx := cs.hashId2groupIdx[hashId]
+	groupIdx, found := cs.hashId2groupIdx[hashId]
+	if !found {
+		return nil, false
+	}
 	mom := cs.groups[groupIdx].mom
 
 	record, ok := mom.GetRecord(utils.Key(hashId))


### PR DESCRIPTION
This is a small optimization for the `getConnection()` method.
Normally, the record of a connection is stored in one of the scheduling groups.
Given the hash id of a connection, retrieving its record comprises of 2 steps:
1. retrieving the scheduling group.
2. retrieving the record from the scheduling group.

This PR avoids the second step when the scheduling group isn't found in the first step.