### PR TITLE
Remove unused (?) codecov secret

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,6 +31,5 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: /tmp/coverage.out
-        token: ${{ secrets.CODECOV_SECRET }}
         flags: unittests
         fail_ci_if_error: true


### PR DESCRIPTION
cc @eranra @ronensc @KalmanMeth 
I'm not sure who initialized the codecov action, I think Eran?
But afaik the codecov secret [is only required for private repos](https://github.com/codecov/codecov-action#arguments), and moreover, I don't think it is actually set in this workflow because "[GitHub’s standard pull_request workflow trigger by default prevents write permissions and secrets access to the target repository.](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)".