### PR TITLE
fix e2e test

### DIFF
--- a/pkg/test/e2e/pipline/flp-config.yaml
+++ b/pkg/test/e2e/pipline/flp-config.yaml
@@ -5,6 +5,8 @@ metadata:
 data:
   flowlogs-pipeline.conf.yaml: |
     log-level: error
+    metricsSettings:
+      port: 9102
     parameters:
       - ingest:
           collector:
@@ -267,7 +269,6 @@ data:
                   - groupByKeys
                   - aggregate
                 buckets: []
-            port: 9102
             prefix: flp_
           type: prom
         name: encode_prom


### PR DESCRIPTION
Since the prometheus port moved from encode_prom to metricsSettings, the e2e test that uses this field must be updated.