### PR TITLE
Conntrack output field copy operations + fix duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,9 +631,11 @@ parameters:
           Proto: 17
         endConnectionTimeout: 5s
         heartbeatInterval: 40s
+        terminatingTimeout: 5s
       - selector: {} # Default group
         endConnectionTimeout: 10s
         heartbeatInterval: 30s
+        terminatingTimeout: 5s
       tcpFlags:
         fieldName: Flags
         detectEndConnection: true

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -107,6 +107,7 @@ parameters:
       scheduling:
       - endConnectionTimeout: 10s
         heartbeatInterval: 30s
+        terminatingTimeout: 5s
       tcpFlags:
         fieldName: TCPFlags
         detectEndConnection: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -225,16 +225,19 @@ Following is the supported API format for specifying connection tracking:
                      count: count
                      min: min
                      max: max
+                     first: first
+                     last: last
                  splitAB: When true, 2 output fields will be created. One for A->B and one for B->A flows.
                  input: The input field to base the operation on. When omitted, 'name' is used
          scheduling: list of timeouts and intervals to apply per selector
                  selector: key-value map to match against connection fields to apply this scheduling
                  endConnectionTimeout: duration of time to wait from the last flow log to end a connection
+                 terminatingTimeout: duration of time to wait from detected FIN flag to end a connection
                  heartbeatInterval: duration of time to wait between heartbeat reports of a connection
          maxConnectionsTracked: maximum number of connections we keep in our cache (0 means no limit)
          tcpFlags: settings for handling TCP flags
              fieldName: name of the field containing TCP flags
-             detectEndConnection: detect end connections by FIN_ACK flag
+             detectEndConnection: detect end connections by FIN flag
              swapAB: swap source and destination when the first flowlog contains the SYN_ACK flag
 </pre>
 ## Time-based Filters API

--- a/docs/operational-metrics.md
+++ b/docs/operational-metrics.md
@@ -18,9 +18,9 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 ### conntrack_memory_connections
 | **Name** | conntrack_memory_connections | 
 |:---|:---|
-| **Description** | The total number of tracked connections in memory. | 
+| **Description** | The total number of tracked connections in memory per group and phase. | 
 | **Type** | gauge | 
-| **Labels** | group | 
+| **Labels** | group, phase | 
 
 
 ### conntrack_output_records

--- a/network_definitions/config.yaml
+++ b/network_definitions/config.yaml
@@ -41,6 +41,7 @@ extract:
       - selector: {}
         heartbeatInterval: 30s
         endConnectionTimeout: 10s
+        terminatingTimeout: 5s
     outputRecordTypes:
       - newConnection
       - flowLog

--- a/pkg/pipeline/conntrack_integ_test.go
+++ b/pkg/pipeline/conntrack_integ_test.go
@@ -51,6 +51,8 @@ parameters:
         scheduling:
           - selector: {}
             endConnectionTimeout: 1s
+            heartbeatInterval: 10s
+            terminatingTimeout: 5s
         outputRecordTypes:
           - newConnection
           - flowLog
@@ -120,7 +122,7 @@ func TestConnTrack(t *testing.T) {
 	}, test2.Interval(10*time.Millisecond))
 
 	// Wait a moment to make the connections expired
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// Send something to the pipeline to allow the connection tracking output end connection records
 	in <- config.GenericMap{"DstAddr": "1.2.3.4"}

--- a/pkg/pipeline/extract/conntrack/hash_test.go
+++ b/pkg/pipeline/extract/conntrack/hash_test.go
@@ -62,6 +62,7 @@ func TestComputeHash_Unidirectional(t *testing.T) {
 	portB := 9002
 	protocolA := 6
 	protocolB := 7
+	flowDir := 0
 	table := []struct {
 		name     string
 		flowLog1 config.GenericMap
@@ -70,32 +71,32 @@ func TestComputeHash_Unidirectional(t *testing.T) {
 	}{
 		{
 			"Same IP, port and protocol",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 222, 11, false),
 			true,
 		},
 		{
 			"Alternating ip+port",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipB, portB, ipA, portA, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipB, portB, ipA, portA, protocolA, flowDir, 222, 11, false),
 			false,
 		},
 		{
 			"Alternating ip",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipB, portA, ipA, portB, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipB, portA, ipA, portB, protocolA, flowDir, 222, 11, false),
 			false,
 		},
 		{
 			"Alternating port",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipA, portB, ipB, portA, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipA, portB, ipB, portA, protocolA, flowDir, 222, 11, false),
 			false,
 		},
 		{
 			"Same IP+port, different protocol",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipA, portA, ipB, portB, protocolB, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolB, flowDir, 222, 11, false),
 			false,
 		},
 	}
@@ -150,6 +151,7 @@ func TestComputeHash_Bidirectional(t *testing.T) {
 	portB := 9002
 	protocolA := 6
 	protocolB := 7
+	flowDir := 0
 	table := []struct {
 		name     string
 		flowLog1 config.GenericMap
@@ -158,32 +160,32 @@ func TestComputeHash_Bidirectional(t *testing.T) {
 	}{
 		{
 			"Same IP, port and protocol",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 222, 11, false),
 			true,
 		},
 		{
 			"Alternating ip+port",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipB, portB, ipA, portA, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipB, portB, ipA, portA, protocolA, flowDir, 222, 11, false),
 			true,
 		},
 		{
 			"Alternating ip",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipB, portA, ipA, portB, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipB, portA, ipA, portB, protocolA, flowDir, 222, 11, false),
 			false,
 		},
 		{
 			"Alternating port",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipA, portB, ipB, portA, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipA, portB, ipB, portA, protocolA, flowDir, 222, 11, false),
 			false,
 		},
 		{
 			"Same IP+port, different protocol",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipA, portA, ipB, portB, protocolB, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolB, flowDir, 222, 11, false),
 			false,
 		},
 	}
@@ -223,8 +225,9 @@ func TestComputeHash_MissingField(t *testing.T) {
 	portA := 1
 	portB := 9002
 	protocolA := 6
+	flowDir := 0
 
-	fl := newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false)
+	fl := newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false)
 
 	h, err := ComputeHash(fl, keyDefinition, testHasher)
 	require.NoError(t, err)

--- a/pkg/pipeline/extract/conntrack/metrics.go
+++ b/pkg/pipeline/extract/conntrack/metrics.go
@@ -25,9 +25,9 @@ import (
 var (
 	connStoreLengthDef = operational.DefineMetric(
 		"conntrack_memory_connections",
-		"The total number of tracked connections in memory.",
+		"The total number of tracked connections in memory per group and phase.",
 		operational.TypeGauge,
-		"group",
+		"group", "phase",
 	)
 
 	inputRecordsDef = operational.DefineMetric(

--- a/pkg/pipeline/extract/conntrack/utils_test.go
+++ b/pkg/pipeline/extract/conntrack/utils_test.go
@@ -22,16 +22,17 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 )
 
-func newMockFlowLog(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets int, duplicate bool) config.GenericMap {
+func newMockFlowLog(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, direction int, bytes, packets int, duplicate bool) config.GenericMap {
 	return config.GenericMap{
-		"SrcAddr":   srcIP,
-		"SrcPort":   srcPort,
-		"DstAddr":   dstIP,
-		"DstPort":   dstPort,
-		"Proto":     protocol,
-		"Bytes":     bytes,
-		"Packets":   packets,
-		"Duplicate": duplicate,
+		"SrcAddr":       srcIP,
+		"SrcPort":       srcPort,
+		"DstAddr":       dstIP,
+		"DstPort":       dstPort,
+		"Proto":         protocol,
+		"FlowDirection": direction,
+		"Bytes":         bytes,
+		"Packets":       packets,
+		"Duplicate":     duplicate,
 	}
 }
 


### PR DESCRIPTION
This PR brings `first` and `last` operations for connection tracking `OutputFields` in order to be able to keep first flow direction informations as:
```go
			OutputFields: []api.OutputField{
...
				{
					Name:      "FlowDirection",
					Operation: "first",
				},
				{
					Name:      "IfDirection",
					Operation: "first",
				},
				{
					Name:      "AgentIP",
					Operation: "first",
				},
			},
```

Also fix duplicates:
- ~~[bypasing these on top of Extract loop](https://github.com/netobserv/flowlogs-pipeline/pull/413/files#diff-ad9d7ad5fe71050e459358c0cd62a24d04733e5607adef15fbe15ea37e099ffbR65-R69) that can generate multiple connection events~~ => https://github.com/netobserv/flowlogs-pipeline/pull/421
- [keeping terminating connection](https://github.com/netobserv/flowlogs-pipeline/pull/413/files#diff-949ee8972308321191c5cac4ea0dc6d786a8d1ac301bf7684e248091f2a7f564R54) in a separated map during a new configurable `terminatingTimeout`

These changes would fix [NETOBSERV-973](https://issues.redhat.com/browse/NETOBSERV-973)