### PR TITLE
NETOBSERV-962 - ADD write ipfix stage to pipeline builder

### DIFF
--- a/pkg/config/pipeline_builder.go
+++ b/pkg/config/pipeline_builder.go
@@ -145,6 +145,11 @@ func (b *PipelineBuilderStage) WriteLoki(name string, loki api.WriteLoki) Pipeli
 	return b.next(name, NewWriteLokiParams(name, loki))
 }
 
+// WriteIpfix chains the current stage with a WriteIpfix stage and returns that new stage
+func (b *PipelineBuilderStage) WriteIpfix(name string, ipfix api.WriteIpfix) PipelineBuilderStage {
+	return b.next(name, NewWriteIpfixParams(name, ipfix))
+}
+
 // GetStages returns the current pipeline stages. It can be called from any of the stages, they share the same pipeline reference.
 func (b *PipelineBuilderStage) GetStages() []Stage {
 	return b.pipeline.stages

--- a/pkg/config/stage_params.go
+++ b/pkg/config/stage_params.go
@@ -72,3 +72,7 @@ func NewWriteStdoutParams(name string, stdout api.WriteStdout) StageParam {
 func NewWriteLokiParams(name string, loki api.WriteLoki) StageParam {
 	return StageParam{Name: name, Write: &Write{Type: api.LokiType, Loki: &loki}}
 }
+
+func NewWriteIpfixParams(name string, ipfix api.WriteIpfix) StageParam {
+	return StageParam{Name: name, Write: &Write{Type: api.IpfixType, Ipfix: &ipfix}}
+}


### PR DESCRIPTION
@jotak @jpinsonneau , as we spoke:

This PR adds the write ipfix stage under the FLP pipeline builder in order to be used by the operator. The methods are reachable by the operator code this way. I tested by replacing the source while I made the changes.

Changes:
- Add WriteIpfix to pipeline_builder.go
- Add NewWriteIpfixParams to stage_params