### PR TITLE
conntrack: Fix a bug in swapAB

### DIFF
--- a/pkg/pipeline/extract/conntrack/conn.go
+++ b/pkg/pipeline/extract/conntrack/conn.go
@@ -180,6 +180,9 @@ func NewConnBuilder(metrics *metricsType) *connBuilder {
 }
 
 func (cb *connBuilder) Hash(h totalHashType) *connBuilder {
+	if cb.shouldSwapAB {
+		h.hashA, h.hashB = h.hashB, h.hashA
+	}
 	cb.conn.hash = h
 	return cb
 }

--- a/pkg/pipeline/extract/conntrack/conntrack.go
+++ b/pkg/pipeline/extract/conntrack/conntrack.go
@@ -75,10 +75,10 @@ func (ct *conntrackImpl) Extract(flowLogs []config.GenericMap) []config.GenericM
 			} else {
 				builder := NewConnBuilder(ct.metrics)
 				conn = builder.
-					Hash(computedHash).
 					ShouldSwapAB(ct.config.TCPFlags.SwapAB && ct.shouldSwapAB(fl)).
 					KeysFrom(fl, ct.config.KeyDefinition, ct.endpointAFields, ct.endpointBFields).
 					Aggregators(ct.aggregators).
+					Hash(computedHash).
 					Build()
 				ct.connStore.addConnection(computedHash.hashTotal, conn)
 				ct.connStore.updateNextHeartbeatTime(computedHash.hashTotal)

--- a/pkg/pipeline/extract/conntrack/conntrack_test.go
+++ b/pkg/pipeline/extract/conntrack/conntrack_test.go
@@ -1094,7 +1094,7 @@ func TestSwapAB(t *testing.T) {
 			startTime.Add(0 * time.Second),
 			[]config.GenericMap{flTCP1},
 			[]config.GenericMap{
-				newMockRecordNewConnAB(ipA, portA, ipB, portB, protocolTCP, 111, 0, 11, 0, 1).withHash(hashIdTCP).markFirst().get(),
+				newMockRecordNewConnAB(ipA, portA, ipB, portB, protocolTCP, 0, 111, 0, 11, 1).withHash(hashIdTCP).markFirst().get(),
 			},
 		},
 	}


### PR DESCRIPTION
When implementing the swapAB logic I missed the fact that in addition to swapping the values of the connection source and destination, their hashes should be swapped as well. Without this, aggregates such as `Bytes_AB` and `Bytes_BA` would be wrong.
I realized that I had the same bug in the unit test the was supposed to test it.
This PR fixes the problem and the test.

Once merged, this will allow us to spot connections that their source and destination were swapped by inspecting their `newConnection` record. The `Bytes_AB` would be 0 while `Bytes_BA` would be >0.