### PR TITLE
conntrack: Add operational metrics on errors for hash computation and aggregators

### DIFF
--- a/docs/operational-metrics.md
+++ b/docs/operational-metrics.md
@@ -7,10 +7,26 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 
 	
 
+### conntrack_aggregator_errors
+| **Name** | conntrack_aggregator_errors | 
+|:---|:---|
+| **Description** | The total number of errors during aggregation | 
+| **Type** | counter | 
+| **Labels** | error, field | 
+
+
+### conntrack_hash_errors
+| **Name** | conntrack_hash_errors | 
+|:---|:---|
+| **Description** | The total number of errors during hash computation | 
+| **Type** | counter | 
+| **Labels** | error, field | 
+
+
 ### conntrack_input_records
 | **Name** | conntrack_input_records | 
 |:---|:---|
-| **Description** | The total number of input records per classification. | 
+| **Description** | The total number of input records per classification | 
 | **Type** | counter | 
 | **Labels** | classification | 
 
@@ -26,7 +42,7 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 ### conntrack_output_records
 | **Name** | conntrack_output_records | 
 |:---|:---|
-| **Description** | The total number of output records. | 
+| **Description** | The total number of output records | 
 | **Type** | counter | 
 | **Labels** | type | 
 
@@ -34,7 +50,7 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 ### conntrack_tcp_flags
 | **Name** | conntrack_tcp_flags | 
 |:---|:---|
-| **Description** | The total number of actions taken based on TCP flags. | 
+| **Description** | The total number of actions taken based on TCP flags | 
 | **Type** | counter | 
 | **Labels** | action | 
 

--- a/docs/operational-metrics.md
+++ b/docs/operational-metrics.md
@@ -15,6 +15,14 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 | **Labels** | error, field | 
 
 
+### conntrack_end_connections
+| **Name** | conntrack_end_connections | 
+|:---|:---|
+| **Description** | The total number of connections ended per group and reason | 
+| **Type** | counter | 
+| **Labels** | group, reason | 
+
+
 ### conntrack_hash_errors
 | **Name** | conntrack_hash_errors | 
 |:---|:---|
@@ -34,7 +42,7 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 ### conntrack_memory_connections
 | **Name** | conntrack_memory_connections | 
 |:---|:---|
-| **Description** | The total number of tracked connections in memory per group and phase. | 
+| **Description** | The total number of tracked connections in memory per group and phase | 
 | **Type** | gauge | 
 | **Labels** | group, phase | 
 

--- a/pkg/pipeline/extract/conntrack/aggregator_test.go
+++ b/pkg/pipeline/extract/conntrack/aggregator_test.go
@@ -52,7 +52,7 @@ func TestNewAggregator_Invalid(t *testing.T) {
 		Operation: "first",
 		SplitAB:   true,
 		Input:     "Input",
-	})
+	}, nil)
 	require.NotNil(t, err)
 }
 
@@ -195,7 +195,7 @@ func TestMissingFieldError(t *testing.T) {
 	agg.addField(conn)
 
 	flowLog := config.GenericMap{}
-	agg.update(conn, flowLog, dirAB)
+	agg.update(conn, flowLog, dirAB, true)
 
 	exposed := test.ReadExposedMetrics(t)
 	require.Contains(t, exposed, `conntrack_aggregator_errors{error="MissingFieldError",field="Bytes"} 1`)
@@ -211,7 +211,7 @@ func TestFloat64ConversionError(t *testing.T) {
 	agg.addField(conn)
 
 	flowLog := config.GenericMap{"Bytes": "float64 inconvertible value"}
-	agg.update(conn, flowLog, dirAB)
+	agg.update(conn, flowLog, dirAB, true)
 
 	exposed := test.ReadExposedMetrics(t)
 	require.Contains(t, exposed, `conntrack_aggregator_errors{error="Float64ConversionError",field="Bytes"} 1`)

--- a/pkg/pipeline/extract/conntrack/aggregator_test.go
+++ b/pkg/pipeline/extract/conntrack/aggregator_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,7 +35,7 @@ func TestNewAggregator_Invalid(t *testing.T) {
 		Operation: "sum",
 		SplitAB:   true,
 		Input:     "Input",
-	})
+	}, nil)
 	require.NotNil(t, err)
 
 	// unknown OperationType
@@ -43,7 +44,7 @@ func TestNewAggregator_Invalid(t *testing.T) {
 		Operation: "unknown",
 		SplitAB:   true,
 		Input:     "Input",
-	})
+	}, nil)
 	require.NotNil(t, err)
 
 	// invalid first agg
@@ -64,58 +65,58 @@ func TestNewAggregator_Valid(t *testing.T) {
 		{
 			name:        "Default SplitAB",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "sum"},
-			expected:    &aSum{aggregateBase{"MyAgg", "MyAgg", false, float64(0)}},
+			expected:    &aSum{aggregateBase{"MyAgg", "MyAgg", false, float64(0), nil}},
 		},
 		{
 			name:        "Default input",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "sum", SplitAB: true},
-			expected:    &aSum{aggregateBase{"MyAgg", "MyAgg", true, float64(0)}},
+			expected:    &aSum{aggregateBase{"MyAgg", "MyAgg", true, float64(0), nil}},
 		},
 		{
 			name:        "Custom input",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "sum", Input: "MyInput"},
-			expected:    &aSum{aggregateBase{"MyInput", "MyAgg", false, float64(0)}},
+			expected:    &aSum{aggregateBase{"MyInput", "MyAgg", false, float64(0), nil}},
 		},
 		{
 			name:        "OperationType sum",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "sum"},
-			expected:    &aSum{aggregateBase{"MyAgg", "MyAgg", false, float64(0)}},
+			expected:    &aSum{aggregateBase{"MyAgg", "MyAgg", false, float64(0), nil}},
 		},
 		{
 			name:        "OperationType count",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "count"},
-			expected:    &aCount{aggregateBase{"MyAgg", "MyAgg", false, float64(0)}},
+			expected:    &aCount{aggregateBase{"MyAgg", "MyAgg", false, float64(0), nil}},
 		},
 		{
 			name:        "OperationType max",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "max"},
-			expected:    &aMax{aggregateBase{"MyAgg", "MyAgg", false, -math.MaxFloat64}},
+			expected:    &aMax{aggregateBase{"MyAgg", "MyAgg", false, -math.MaxFloat64, nil}},
 		},
 		{
 			name:        "OperationType min",
 			outputField: api.OutputField{Name: "MyAgg", Operation: "min"},
-			expected:    &aMin{aggregateBase{"MyAgg", "MyAgg", false, math.MaxFloat64}},
+			expected:    &aMin{aggregateBase{"MyAgg", "MyAgg", false, math.MaxFloat64, nil}},
 		},
 		{
 			name:        "Default first",
 			outputField: api.OutputField{Name: "MyCp", Operation: "first"},
-			expected:    &aFirst{aggregateBase{"MyCp", "MyCp", false, nil}},
+			expected:    &aFirst{aggregateBase{"MyCp", "MyCp", false, nil, nil}},
 		},
 		{
 			name:        "Custom input first",
 			outputField: api.OutputField{Name: "MyCp", Operation: "first", Input: "MyInput"},
-			expected:    &aFirst{aggregateBase{"MyInput", "MyCp", false, nil}},
+			expected:    &aFirst{aggregateBase{"MyInput", "MyCp", false, nil, nil}},
 		},
 		{
 			name:        "Default last",
 			outputField: api.OutputField{Name: "MyCp", Operation: "last"},
-			expected:    &aLast{aggregateBase{"MyCp", "MyCp", false, nil}},
+			expected:    &aLast{aggregateBase{"MyCp", "MyCp", false, nil, nil}},
 		},
 	}
 
 	for _, test := range table {
 		t.Run(test.name, func(t *testing.T) {
-			agg, err := newAggregator(test.outputField)
+			agg, err := newAggregator(test.outputField, nil)
 			require.NoError(t, err)
 			require.Equal(t, test.expected, agg)
 		})
@@ -134,7 +135,7 @@ func TestAddField_and_Update(t *testing.T) {
 	}
 	var aggs []aggregator
 	for _, of := range ofs {
-		agg, err := newAggregator(of)
+		agg, err := newAggregator(of, nil)
 		require.NoError(t, err)
 		aggs = append(aggs, agg)
 	}
@@ -182,4 +183,36 @@ func TestAddField_and_Update(t *testing.T) {
 			require.Equal(t, test.expected, conn.(*connType).aggFields)
 		})
 	}
+}
+
+func TestMissingFieldError(t *testing.T) {
+	test.ResetPromRegistry()
+	metrics := newMetrics(opMetrics)
+	agg, err := newAggregator(api.OutputField{Name: "Bytes", Operation: "sum", SplitAB: true}, metrics)
+	require.NoError(t, err)
+
+	conn := NewConnBuilder(metrics).Build()
+	agg.addField(conn)
+
+	flowLog := config.GenericMap{}
+	agg.update(conn, flowLog, dirAB)
+
+	exposed := test.ReadExposedMetrics(t)
+	require.Contains(t, exposed, `conntrack_aggregator_errors{error="MissingFieldError",field="Bytes"} 1`)
+}
+
+func TestFloat64ConversionError(t *testing.T) {
+	test.ResetPromRegistry()
+	metrics := newMetrics(opMetrics)
+	agg, err := newAggregator(api.OutputField{Name: "Bytes", Operation: "sum", SplitAB: true}, metrics)
+	require.NoError(t, err)
+
+	conn := NewConnBuilder(metrics).Build()
+	agg.addField(conn)
+
+	flowLog := config.GenericMap{"Bytes": "float64 inconvertible value"}
+	agg.update(conn, flowLog, dirAB)
+
+	exposed := test.ReadExposedMetrics(t)
+	require.Contains(t, exposed, `conntrack_aggregator_errors{error="Float64ConversionError",field="Bytes"} 1`)
 }

--- a/pkg/pipeline/extract/conntrack/conntrack_test.go
+++ b/pkg/pipeline/extract/conntrack/conntrack_test.go
@@ -898,6 +898,8 @@ func TestScheduling(t *testing.T) {
 			assertStoreConsistency(t, ct)
 		})
 	}
+	exposed := test.ReadExposedMetrics(t)
+	require.Contains(t, exposed, `conntrack_end_connections{group="0: Proto=1, ",reason="timeout"} 1`)
 }
 
 func assertStoreConsistency(t *testing.T, extractor extract.Extractor) {
@@ -1265,4 +1267,6 @@ func TestExpiringConnection(t *testing.T) {
 			assertStoreConsistency(t, ct)
 		})
 	}
+	exposed := test.ReadExposedMetrics(t)
+	require.Contains(t, exposed, `conntrack_end_connections{group="0: DEFAULT",reason="FIN_flag"} 1`)
 }

--- a/pkg/pipeline/extract/conntrack/metrics.go
+++ b/pkg/pipeline/extract/conntrack/metrics.go
@@ -25,7 +25,7 @@ import (
 var (
 	connStoreLengthDef = operational.DefineMetric(
 		"conntrack_memory_connections",
-		"The total number of tracked connections in memory per group and phase.",
+		"The total number of tracked connections in memory per group and phase",
 		operational.TypeGauge,
 		"group", "phase",
 	)
@@ -64,6 +64,13 @@ var (
 		operational.TypeCounter,
 		"error", "field",
 	)
+
+	endConnectionsDef = operational.DefineMetric(
+		"conntrack_end_connections",
+		"The total number of connections ended per group and reason",
+		operational.TypeCounter,
+		"group", "reason",
+	)
 )
 
 type metricsType struct {
@@ -73,6 +80,7 @@ type metricsType struct {
 	tcpFlags         *prometheus.CounterVec
 	hashErrors       *prometheus.CounterVec
 	aggregatorErrors *prometheus.CounterVec
+	endConnections   *prometheus.CounterVec
 }
 
 func newMetrics(opMetrics *operational.Metrics) *metricsType {
@@ -83,5 +91,6 @@ func newMetrics(opMetrics *operational.Metrics) *metricsType {
 		tcpFlags:         opMetrics.NewCounterVec(&tcpFlagsDef),
 		hashErrors:       opMetrics.NewCounterVec(&hashErrorsDef),
 		aggregatorErrors: opMetrics.NewCounterVec(&aggregatorErrorsDef),
+		endConnections:   opMetrics.NewCounterVec(&endConnectionsDef),
 	}
 }

--- a/pkg/pipeline/extract/conntrack/metrics.go
+++ b/pkg/pipeline/extract/conntrack/metrics.go
@@ -32,38 +32,56 @@ var (
 
 	inputRecordsDef = operational.DefineMetric(
 		"conntrack_input_records",
-		"The total number of input records per classification.",
+		"The total number of input records per classification",
 		operational.TypeCounter,
 		"classification",
 	)
 
 	outputRecordsDef = operational.DefineMetric(
 		"conntrack_output_records",
-		"The total number of output records.",
+		"The total number of output records",
 		operational.TypeCounter,
 		"type",
 	)
 
 	tcpFlagsDef = operational.DefineMetric(
 		"conntrack_tcp_flags",
-		"The total number of actions taken based on TCP flags.",
+		"The total number of actions taken based on TCP flags",
 		operational.TypeCounter,
 		"action",
+	)
+
+	hashErrorsDef = operational.DefineMetric(
+		"conntrack_hash_errors",
+		"The total number of errors during hash computation",
+		operational.TypeCounter,
+		"error", "field",
+	)
+
+	aggregatorErrorsDef = operational.DefineMetric(
+		"conntrack_aggregator_errors",
+		"The total number of errors during aggregation",
+		operational.TypeCounter,
+		"error", "field",
 	)
 )
 
 type metricsType struct {
-	connStoreLength *prometheus.GaugeVec
-	inputRecords    *prometheus.CounterVec
-	outputRecords   *prometheus.CounterVec
-	tcpFlags        *prometheus.CounterVec
+	connStoreLength  *prometheus.GaugeVec
+	inputRecords     *prometheus.CounterVec
+	outputRecords    *prometheus.CounterVec
+	tcpFlags         *prometheus.CounterVec
+	hashErrors       *prometheus.CounterVec
+	aggregatorErrors *prometheus.CounterVec
 }
 
 func newMetrics(opMetrics *operational.Metrics) *metricsType {
 	return &metricsType{
-		connStoreLength: opMetrics.NewGaugeVec(&connStoreLengthDef),
-		inputRecords:    opMetrics.NewCounterVec(&inputRecordsDef),
-		outputRecords:   opMetrics.NewCounterVec(&outputRecordsDef),
-		tcpFlags:        opMetrics.NewCounterVec(&tcpFlagsDef),
+		connStoreLength:  opMetrics.NewGaugeVec(&connStoreLengthDef),
+		inputRecords:     opMetrics.NewCounterVec(&inputRecordsDef),
+		outputRecords:    opMetrics.NewCounterVec(&outputRecordsDef),
+		tcpFlags:         opMetrics.NewCounterVec(&tcpFlagsDef),
+		hashErrors:       opMetrics.NewCounterVec(&hashErrorsDef),
+		aggregatorErrors: opMetrics.NewCounterVec(&aggregatorErrorsDef),
 	}
 }

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -192,6 +192,8 @@ func GetExtractMockEntries2() []config.GenericMap {
 	return entries
 }
 
+// ResetPromRegistry resets the prometheus registry. Invoke this function on tests that may register metrics that were
+// already registered by other tests.
 func ResetPromRegistry() {
 	reg := prometheus.NewRegistry()
 	prometheus.DefaultRegisterer = reg


### PR DESCRIPTION
This PR adds the following operational metrics that count errors during hash computation and in the aggregators.
```
conntrack_aggregator_errors{error="MissingFieldError",field="Bytes"} 11
conntrack_aggregator_errors{error="Float64ConversionError",field="Bytes"} 22
conntrack_hash_errors{error="MissingFieldError",field="Missing"} 33
```