### PR TITLE
[Backport] Conntrack output field copy operations + fix duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,9 +631,11 @@ parameters:
           Proto: 17
         endConnectionTimeout: 5s
         heartbeatInterval: 40s
+        terminatingTimeout: 5s
       - selector: {} # Default group
         endConnectionTimeout: 10s
         heartbeatInterval: 30s
+        terminatingTimeout: 5s
       tcpFlags:
         fieldName: Flags
         detectEndConnection: true

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -107,6 +107,7 @@ parameters:
       scheduling:
       - endConnectionTimeout: 10s
         heartbeatInterval: 30s
+        terminatingTimeout: 5s
       tcpFlags:
         fieldName: TCPFlags
         detectEndConnection: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -225,16 +225,19 @@ Following is the supported API format for specifying connection tracking:
                      count: count
                      min: min
                      max: max
+                     first: first
+                     last: last
                  splitAB: When true, 2 output fields will be created. One for A->B and one for B->A flows.
                  input: The input field to base the operation on. When omitted, 'name' is used
          scheduling: list of timeouts and intervals to apply per selector
                  selector: key-value map to match against connection fields to apply this scheduling
                  endConnectionTimeout: duration of time to wait from the last flow log to end a connection
+                 terminatingTimeout: duration of time to wait from detected FIN flag to end a connection
                  heartbeatInterval: duration of time to wait between heartbeat reports of a connection
          maxConnectionsTracked: maximum number of connections we keep in our cache (0 means no limit)
          tcpFlags: settings for handling TCP flags
              fieldName: name of the field containing TCP flags
-             detectEndConnection: detect end connections by FIN_ACK flag
+             detectEndConnection: detect end connections by FIN flag
              swapAB: swap source and destination when the first flowlog contains the SYN_ACK flag
 </pre>
 ## Time-based Filters API

--- a/docs/operational-metrics.md
+++ b/docs/operational-metrics.md
@@ -18,9 +18,9 @@ Each table below provides documentation for an exported flowlogs-pipeline operat
 ### conntrack_memory_connections
 | **Name** | conntrack_memory_connections | 
 |:---|:---|
-| **Description** | The total number of tracked connections in memory. | 
+| **Description** | The total number of tracked connections in memory per group and phase. | 
 | **Type** | gauge | 
-| **Labels** | group | 
+| **Labels** | group, phase | 
 
 
 ### conntrack_output_records

--- a/network_definitions/config.yaml
+++ b/network_definitions/config.yaml
@@ -41,6 +41,7 @@ extract:
       - selector: {}
         heartbeatInterval: 30s
         endConnectionTimeout: 10s
+        terminatingTimeout: 5s
     outputRecordTypes:
       - newConnection
       - flowLog

--- a/pkg/pipeline/conntrack_integ_test.go
+++ b/pkg/pipeline/conntrack_integ_test.go
@@ -51,6 +51,8 @@ parameters:
         scheduling:
           - selector: {}
             endConnectionTimeout: 1s
+            heartbeatInterval: 10s
+            terminatingTimeout: 5s
         outputRecordTypes:
           - newConnection
           - flowLog
@@ -120,7 +122,7 @@ func TestConnTrack(t *testing.T) {
 	}, test2.Interval(10*time.Millisecond))
 
 	// Wait a moment to make the connections expired
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 
 	// Send something to the pipeline to allow the connection tracking output end connection records
 	in <- config.GenericMap{"DstAddr": "1.2.3.4"}

--- a/pkg/pipeline/extract/conntrack/conntrack_test.go
+++ b/pkg/pipeline/extract/conntrack/conntrack_test.go
@@ -36,7 +36,7 @@ import (
 var opMetrics = operational.NewMetrics(&config.MetricsSettings{})
 
 func buildMockConnTrackConfig(isBidirectional bool, outputRecordType []string,
-	heartbeatInterval, endConnectionTimeout time.Duration) *config.StageParam {
+	heartbeatInterval, endConnectionTimeout time.Duration, terminatingTimeout time.Duration) *config.StageParam {
 	splitAB := isBidirectional
 	var hash api.ConnTrackHash
 	if isBidirectional {
@@ -90,6 +90,7 @@ func buildMockConnTrackConfig(isBidirectional bool, outputRecordType []string,
 						Selector:             map[string]interface{}{},
 						HeartbeatInterval:    api.Duration{Duration: heartbeatInterval},
 						EndConnectionTimeout: api.Duration{Duration: endConnectionTimeout},
+						TerminatingTimeout:   api.Duration{Duration: terminatingTimeout},
 					},
 				},
 			}, // end of api.ConnTrack
@@ -100,20 +101,24 @@ func buildMockConnTrackConfig(isBidirectional bool, outputRecordType []string,
 func TestTrack(t *testing.T) {
 	heartbeatInterval := 10 * time.Second
 	endConnectionTimeout := 30 * time.Second
+	terminatingTimeout := 5 * time.Second
+
 	ipA := "10.0.0.1"
 	ipB := "10.0.0.2"
 	portA := 9001
 	portB := 9002
 	protocol := 6
+	flowDir := 0
 	hashId := "705baa5149302fa1"
 	hashIdAB := "705baa5149302fa1"
 	hashIdBA := "cc40f571f40f3111"
 
-	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, false)
-	flAB1Duplicated := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, true)
-	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22, false)
-	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33, false)
-	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 444, 44, false)
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, flowDir, 111, 11, false)
+	// duplicates should be ignored
+	flAB1Duplicated := newMockFlowLog(ipA, portA, ipB, portB, protocol, flowDir, 111, 11, true)
+	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, flowDir, 222, 22, false)
+	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, flowDir, 333, 33, false)
+	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, flowDir, 444, 44, false)
 	table := []struct {
 		name          string
 		conf          *config.StageParam
@@ -121,8 +126,16 @@ func TestTrack(t *testing.T) {
 		expected      []config.GenericMap
 	}{
 		{
+			"duplicates, doesn't output connection events",
+			buildMockConnTrackConfig(true, []string{"newConnection", "heartbeat", "endConnection"},
+				heartbeatInterval, endConnectionTimeout, terminatingTimeout),
+			[]config.GenericMap{flAB1Duplicated},
+			[]config.GenericMap(nil),
+		},
+		{
 			"bidirectional, output new connection",
-			buildMockConnTrackConfig(true, []string{"newConnection"}, heartbeatInterval, endConnectionTimeout),
+			buildMockConnTrackConfig(true, []string{"newConnection"},
+				heartbeatInterval, endConnectionTimeout, terminatingTimeout),
 			[]config.GenericMap{flAB1, flAB1Duplicated, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
 				newMockRecordNewConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1).withHash(hashId).get(),
@@ -130,7 +143,8 @@ func TestTrack(t *testing.T) {
 		},
 		{
 			"bidirectional, output new connection and flow log",
-			buildMockConnTrackConfig(true, []string{"newConnection", "flowLog"}, heartbeatInterval, endConnectionTimeout),
+			buildMockConnTrackConfig(true, []string{"newConnection", "flowLog"},
+				heartbeatInterval, endConnectionTimeout, terminatingTimeout),
 			[]config.GenericMap{flAB1, flAB1Duplicated, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
 				newMockRecordNewConnAB(ipA, portA, ipB, portB, protocol, 111, 0, 11, 0, 1).withHash(hashId).get(),
@@ -143,7 +157,8 @@ func TestTrack(t *testing.T) {
 		},
 		{
 			"unidirectional, output new connection",
-			buildMockConnTrackConfig(false, []string{"newConnection"}, heartbeatInterval, endConnectionTimeout),
+			buildMockConnTrackConfig(false, []string{"newConnection"},
+				heartbeatInterval, endConnectionTimeout, terminatingTimeout),
 			[]config.GenericMap{flAB1, flAB1Duplicated, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
 				newMockRecordNewConn(ipA, portA, ipB, portB, protocol, 111, 11, 1).withHash(hashIdAB).get(),
@@ -152,7 +167,8 @@ func TestTrack(t *testing.T) {
 		},
 		{
 			"unidirectional, output new connection and flow log",
-			buildMockConnTrackConfig(false, []string{"newConnection", "flowLog"}, heartbeatInterval, endConnectionTimeout),
+			buildMockConnTrackConfig(false, []string{"newConnection", "flowLog"},
+				heartbeatInterval, endConnectionTimeout, terminatingTimeout),
 			[]config.GenericMap{flAB1, flAB1Duplicated, flAB2, flBA3, flBA4},
 			[]config.GenericMap{
 				newMockRecordNewConn(ipA, portA, ipB, portB, protocol, 111, 11, 1).withHash(hashIdAB).get(),
@@ -187,7 +203,10 @@ func TestEndConn_Bidirectional(t *testing.T) {
 	clk := clock.NewMock()
 	heartbeatInterval := 10 * time.Second
 	endConnectionTimeout := 30 * time.Second
-	conf := buildMockConnTrackConfig(true, []string{"newConnection", "flowLog", "endConnection"}, heartbeatInterval, endConnectionTimeout)
+	terminatingTimeout := 5 * time.Second
+
+	conf := buildMockConnTrackConfig(true, []string{"newConnection", "flowLog", "endConnection"},
+		heartbeatInterval, endConnectionTimeout, terminatingTimeout)
 	ct, err := NewConnectionTrack(opMetrics, *conf, clk)
 	require.NoError(t, err)
 
@@ -196,12 +215,13 @@ func TestEndConn_Bidirectional(t *testing.T) {
 	portA := 9001
 	portB := 9002
 	protocol := 6
+	flowDir := 0
 	hashId := "705baa5149302fa1"
 
-	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, false)
-	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22, false)
-	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33, false)
-	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 444, 44, false)
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, flowDir, 111, 11, false)
+	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, flowDir, 222, 22, false)
+	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, flowDir, 333, 33, false)
+	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, flowDir, 444, 44, false)
 	startTime := clk.Now()
 	table := []struct {
 		name          string
@@ -273,7 +293,10 @@ func TestEndConn_Unidirectional(t *testing.T) {
 	clk := clock.NewMock()
 	heartbeatInterval := 10 * time.Second
 	endConnectionTimeout := 30 * time.Second
-	conf := buildMockConnTrackConfig(false, []string{"newConnection", "flowLog", "endConnection"}, heartbeatInterval, endConnectionTimeout)
+	terminatingTimeout := 5 * time.Second
+
+	conf := buildMockConnTrackConfig(false, []string{"newConnection", "flowLog", "endConnection"},
+		heartbeatInterval, endConnectionTimeout, terminatingTimeout)
 	ct, err := NewConnectionTrack(opMetrics, *conf, clk)
 	require.NoError(t, err)
 
@@ -282,13 +305,14 @@ func TestEndConn_Unidirectional(t *testing.T) {
 	portA := 9001
 	portB := 9002
 	protocol := 6
+	flowDir := 0
 	hashIdAB := "705baa5149302fa1"
 	hashIdBA := "cc40f571f40f3111"
 
-	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, false)
-	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22, false)
-	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33, false)
-	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 444, 44, false)
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, flowDir, 111, 11, false)
+	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, flowDir, 222, 22, false)
+	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, flowDir, 333, 33, false)
+	flBA4 := newMockFlowLog(ipB, portB, ipA, portA, protocol, flowDir, 444, 44, false)
 	startTime := clk.Now()
 	table := []struct {
 		name          string
@@ -375,7 +399,10 @@ func TestHeartbeat_Unidirectional(t *testing.T) {
 	clk := clock.NewMock()
 	heartbeatInterval := 10 * time.Second
 	endConnectionTimeout := 30 * time.Second
-	conf := buildMockConnTrackConfig(false, []string{"newConnection", "flowLog", "heartbeat", "endConnection"}, heartbeatInterval, endConnectionTimeout)
+	terminatingTimeout := 5 * time.Second
+
+	conf := buildMockConnTrackConfig(false, []string{"newConnection", "flowLog", "heartbeat", "endConnection"},
+		heartbeatInterval, endConnectionTimeout, terminatingTimeout)
 	ct, err := NewConnectionTrack(opMetrics, *conf, clk)
 	require.NoError(t, err)
 
@@ -384,12 +411,13 @@ func TestHeartbeat_Unidirectional(t *testing.T) {
 	portA := 9001
 	portB := 9002
 	protocol := 6
+	flowDir := 0
 	hashIdAB := "705baa5149302fa1"
 	hashIdBA := "cc40f571f40f3111"
 
-	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, false)
-	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 222, 22, false)
-	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, 333, 33, false)
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, flowDir, 111, 11, false)
+	flAB2 := newMockFlowLog(ipA, portA, ipB, portB, protocol, flowDir, 222, 22, false)
+	flBA3 := newMockFlowLog(ipB, portB, ipA, portA, protocol, flowDir, 333, 33, false)
 	startTime := clk.Now()
 	table := []struct {
 		name          string
@@ -523,7 +551,10 @@ func TestIsFirst_LongConnection(t *testing.T) {
 	clk := clock.NewMock()
 	heartbeatInterval := 10 * time.Second
 	endConnectionTimeout := 30 * time.Second
-	conf := buildMockConnTrackConfig(false, []string{"heartbeat", "endConnection"}, heartbeatInterval, endConnectionTimeout)
+	terminatingTimeout := 5 * time.Second
+
+	conf := buildMockConnTrackConfig(false, []string{"heartbeat", "endConnection"},
+		heartbeatInterval, endConnectionTimeout, terminatingTimeout)
 	ct, err := NewConnectionTrack(opMetrics, *conf, clk)
 	require.NoError(t, err)
 
@@ -532,8 +563,9 @@ func TestIsFirst_LongConnection(t *testing.T) {
 	portA := 9001
 	portB := 9002
 	protocol := 6
+	flowDir := 0
 	hashIdAB := "705baa5149302fa1"
-	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, false)
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, flowDir, 111, 11, false)
 	startTime := clk.Now()
 	table := []struct {
 		name          string
@@ -611,8 +643,10 @@ func TestIsFirst_ShortConnection(t *testing.T) {
 	clk := clock.NewMock()
 	heartbeatInterval := 10 * time.Second
 	endConnectionTimeout := 5 * time.Second
+	terminatingTimeout := 5 * time.Second
+
 	conf := buildMockConnTrackConfig(false, []string{"heartbeat", "endConnection"},
-		heartbeatInterval, endConnectionTimeout)
+		heartbeatInterval, endConnectionTimeout, terminatingTimeout)
 	ct, err := NewConnectionTrack(opMetrics, *conf, clk)
 	require.NoError(t, err)
 
@@ -621,8 +655,9 @@ func TestIsFirst_ShortConnection(t *testing.T) {
 	portA := 9001
 	portB := 9002
 	protocol := 6
+	flowDir := 0
 	hashIdAB := "705baa5149302fa1"
-	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, 111, 11, false)
+	flAB1 := newMockFlowLog(ipA, portA, ipB, portB, protocol, flowDir, 111, 11, false)
 	startTime := clk.Now()
 	table := []struct {
 		name          string
@@ -674,7 +709,10 @@ func TestPrepareUpdateConnectionRecords(t *testing.T) {
 	clk := clock.NewMock()
 	heartbeatInterval := 10 * time.Second
 	endConnectionTimeout := 30 * time.Second
-	conf := buildMockConnTrackConfig(false, []string{"heartbeat"}, heartbeatInterval, endConnectionTimeout)
+	terminatingTimeout := 5 * time.Second
+
+	conf := buildMockConnTrackConfig(false, []string{"heartbeat"},
+		heartbeatInterval, endConnectionTimeout, terminatingTimeout)
 	interval := 10 * time.Second
 	extract, err := NewConnectionTrack(opMetrics, *conf, clk)
 	require.NoError(t, err)
@@ -733,8 +771,10 @@ func TestScheduling(t *testing.T) {
 	clk := clock.NewMock()
 	defaultHeartbeatInterval := 20 * time.Second
 	defaultEndConnectionTimeout := 15 * time.Second
+	defaultTerminatingTimeout := 5 * time.Second
+
 	conf := buildMockConnTrackConfig(true, []string{"heartbeat", "endConnection"},
-		defaultHeartbeatInterval, defaultEndConnectionTimeout)
+		defaultHeartbeatInterval, defaultEndConnectionTimeout, defaultTerminatingTimeout)
 	// Insert a scheduling group before the default group.
 	// https://github.com/golang/go/wiki/SliceTricks#push-frontunshift
 	conf.Extract.ConnTrack.Scheduling = append(
@@ -743,6 +783,7 @@ func TestScheduling(t *testing.T) {
 				Selector:             map[string]interface{}{"Proto": 1}, // ICMP
 				HeartbeatInterval:    api.Duration{Duration: 30 * time.Second},
 				EndConnectionTimeout: api.Duration{Duration: 20 * time.Second},
+				TerminatingTimeout:   api.Duration{Duration: 10 * time.Second},
 			},
 		},
 		conf.Extract.ConnTrack.Scheduling...)
@@ -755,12 +796,13 @@ func TestScheduling(t *testing.T) {
 	portB := 9002
 	protocolTCP := 6
 	protocolICMP := 1
+	flowDir := 0
 	hashIdTCP := "705baa5149302fa1"
 	hashIdICMP := "3dccf73fe57ba06f"
-	flTCP1 := newMockFlowLog(ipA, portA, ipB, portB, protocolTCP, 111, 11, false)
-	flTCP2 := newMockFlowLog(ipB, portB, ipA, portA, protocolTCP, 222, 22, false)
-	flICMP1 := newMockFlowLog(ipA, portA, ipB, portB, protocolICMP, 333, 33, false)
-	flICMP2 := newMockFlowLog(ipB, portB, ipA, portA, protocolICMP, 444, 44, false)
+	flTCP1 := newMockFlowLog(ipA, portA, ipB, portB, protocolTCP, flowDir, 111, 11, false)
+	flTCP2 := newMockFlowLog(ipB, portB, ipA, portA, protocolTCP, flowDir, 222, 22, false)
+	flICMP1 := newMockFlowLog(ipA, portA, ipB, portB, protocolICMP, flowDir, 333, 33, false)
+	flICMP2 := newMockFlowLog(ipB, portB, ipA, portA, protocolICMP, flowDir, 444, 44, false)
 	startTime := clk.Now()
 	table := []struct {
 		name          string
@@ -863,8 +905,9 @@ func assertStoreConsistency(t *testing.T, extractor extract.Extractor) {
 	groupsLenSlice := make([]int, 0)
 	sumGroupsLen := 0
 	for _, g := range store.groups {
-		sumGroupsLen += g.mom.Len()
-		groupsLenSlice = append(groupsLenSlice, g.mom.Len())
+		sumGroupsLen += g.terminatingMom.Len()
+		sumGroupsLen += g.activeMom.Len()
+		groupsLenSlice = append(groupsLenSlice, g.terminatingMom.Len()+g.activeMom.Len())
 	}
 	require.Equal(t, hashLen, sumGroupsLen, "hashLen(=%v) != sum(%v)", hashLen, groupsLenSlice)
 }
@@ -893,7 +936,10 @@ func TestMaxConnections(t *testing.T) {
 	clk := clock.NewMock()
 	heartbeatInterval := 10 * time.Second
 	endConnectionTimeout := 30 * time.Second
-	conf := buildMockConnTrackConfig(true, []string{"newConnection", "flowLog", "endConnection"}, heartbeatInterval, endConnectionTimeout)
+	terminatingTimeout := 5 * time.Second
+
+	conf := buildMockConnTrackConfig(true, []string{"newConnection", "flowLog", "endConnection"},
+		heartbeatInterval, endConnectionTimeout, terminatingTimeout)
 	conf.Extract.ConnTrack.MaxConnectionsTracked = maxConnections
 	extract, err := NewConnectionTrack(opMetrics, *conf, clk)
 	require.NoError(t, err)
@@ -919,7 +965,10 @@ func TestIsLastFlowLogOfConnection(t *testing.T) {
 	clk := clock.NewMock()
 	heartbeatInterval := 30 * time.Second
 	endConnectionTimeout := 10 * time.Second
-	conf := buildMockConnTrackConfig(true, []string{}, heartbeatInterval, endConnectionTimeout)
+	terminatingTimeout := 5 * time.Second
+
+	conf := buildMockConnTrackConfig(true, []string{},
+		heartbeatInterval, endConnectionTimeout, terminatingTimeout)
 	tcpFlagsFieldName := "TCPFlags"
 	conf.Extract.ConnTrack.TCPFlags = api.ConnTrackTCPFlags{
 		FieldName:           tcpFlagsFieldName,
@@ -935,44 +984,44 @@ func TestIsLastFlowLogOfConnection(t *testing.T) {
 	}{
 		{
 			"Happy path",
-			config.GenericMap{tcpFlagsFieldName: uint32(FIN_ACK_FLAG)},
-			FIN_ACK_FLAG,
+			config.GenericMap{tcpFlagsFieldName: uint32(FIN_FLAG)},
+			FIN_FLAG,
 			true,
 		},
 		{
 			"Multiple flags 1",
-			config.GenericMap{tcpFlagsFieldName: uint32(FIN_ACK_FLAG | SYN_ACK_FLAG)},
-			FIN_ACK_FLAG,
+			config.GenericMap{tcpFlagsFieldName: uint32(FIN_FLAG | SYN_ACK_FLAG)},
+			FIN_FLAG,
 			true,
 		},
 		{
 			"Multiple flags 2",
-			config.GenericMap{tcpFlagsFieldName: uint32(FIN_ACK_FLAG | SYN_ACK_FLAG)},
+			config.GenericMap{tcpFlagsFieldName: uint32(FIN_FLAG | SYN_ACK_FLAG)},
 			SYN_ACK_FLAG,
 			true,
 		},
 		{
 			"Convert from string",
-			config.GenericMap{tcpFlagsFieldName: fmt.Sprint(FIN_ACK_FLAG)},
-			FIN_ACK_FLAG,
+			config.GenericMap{tcpFlagsFieldName: fmt.Sprint(FIN_FLAG)},
+			FIN_FLAG,
 			true,
 		},
 		{
 			"Cannot parse value",
 			config.GenericMap{tcpFlagsFieldName: ""},
-			FIN_ACK_FLAG,
+			FIN_FLAG,
 			false,
 		},
 		{
-			"Other flag than FIN_ACK",
-			config.GenericMap{tcpFlagsFieldName: FIN_FLAG},
-			FIN_ACK_FLAG,
+			"Other flag than FIN",
+			config.GenericMap{tcpFlagsFieldName: FIN_ACK_FLAG},
+			FIN_FLAG,
 			false,
 		},
 		{
 			"Missing TCPFlags field",
 			config.GenericMap{"": ""},
-			FIN_ACK_FLAG,
+			FIN_FLAG,
 			false,
 		},
 	}
@@ -991,8 +1040,10 @@ func TestDetectEndConnection(t *testing.T) {
 	clk := clock.NewMock()
 	defaultUpdateConnectionInterval := 30 * time.Second
 	defaultEndConnectionTimeout := 10 * time.Second
+	defaultTerminatingTimeout := 5 * time.Second
+
 	conf := buildMockConnTrackConfig(true, []string{"newConnection", "endConnection"},
-		defaultUpdateConnectionInterval, defaultEndConnectionTimeout)
+		defaultUpdateConnectionInterval, defaultEndConnectionTimeout, defaultTerminatingTimeout)
 	tcpFlagsFieldName := "TCPFlags"
 	conf.Extract.ConnTrack.TCPFlags = api.ConnTrackTCPFlags{
 		FieldName:           tcpFlagsFieldName,
@@ -1006,10 +1057,14 @@ func TestDetectEndConnection(t *testing.T) {
 	portA := 9001
 	portB := 9002
 	protocolTCP := 6
+	flowDir := 0
 	hashIdTCP := "705baa5149302fa1"
-	flTCP1 := newMockFlowLog(ipA, portA, ipB, portB, protocolTCP, 111, 11, false)
-	flTCP2 := newMockFlowLog(ipB, portB, ipA, portA, protocolTCP, 222, 22, false)
-	flTCP2[tcpFlagsFieldName] = FIN_ACK_FLAG
+	flTCP1 := newMockFlowLog(ipA, portA, ipB, portB, protocolTCP, flowDir, 111, 11, false)
+	flTCP2 := newMockFlowLog(ipB, portB, ipA, portA, protocolTCP, flowDir, 222, 22, false)
+	// duplicates should be ignored
+	flTCP2Duplicated := newMockFlowLog(ipB, portB, ipA, portA, protocolTCP, flowDir, 222, 22, true)
+
+	flTCP2[tcpFlagsFieldName] = FIN_FLAG
 
 	startTime := clk.Now()
 	table := []struct {
@@ -1030,15 +1085,21 @@ func TestDetectEndConnection(t *testing.T) {
 			"5s: end connection",
 			startTime.Add(5 * time.Second),
 			[]config.GenericMap{flTCP2},
+			[]config.GenericMap(nil),
+		},
+		{
+			"6s: end connection duplicated",
+			startTime.Add(6 * time.Second),
+			[]config.GenericMap{flTCP2Duplicated},
+			[]config.GenericMap(nil),
+		},
+		{
+			"20s: end connection without duplicated",
+			startTime.Add(20 * time.Second),
+			[]config.GenericMap{},
 			[]config.GenericMap{
 				newMockRecordEndConnAB(ipA, portA, ipB, portB, protocolTCP, 111, 222, 11, 22, 2).withHash(hashIdTCP).get(),
 			},
-		},
-		{
-			"16s: no end connection",
-			startTime.Add(16 * time.Second),
-			[]config.GenericMap{},
-			nil,
 		},
 	}
 
@@ -1055,6 +1116,7 @@ func TestDetectEndConnection(t *testing.T) {
 	}
 	exposed := test.ReadExposedMetrics(t)
 	require.Contains(t, exposed, `conntrack_tcp_flags{action="detectEndConnection"} 1`)
+	require.Contains(t, exposed, `conntrack_input_records{classification="duplicate"} 1`)
 }
 
 func TestSwapAB(t *testing.T) {
@@ -1062,8 +1124,10 @@ func TestSwapAB(t *testing.T) {
 	clk := clock.NewMock()
 	defaultUpdateConnectionInterval := 30 * time.Second
 	defaultEndConnectionTimeout := 10 * time.Second
+	defaultTerminatingTimeout := 5 * time.Second
+
 	conf := buildMockConnTrackConfig(true, []string{"newConnection", "endConnection"},
-		defaultUpdateConnectionInterval, defaultEndConnectionTimeout)
+		defaultUpdateConnectionInterval, defaultEndConnectionTimeout, defaultTerminatingTimeout)
 	tcpFlagsFieldName := "TCPFlags"
 	conf.Extract.ConnTrack.TCPFlags = api.ConnTrackTCPFlags{
 		FieldName: tcpFlagsFieldName,
@@ -1077,8 +1141,9 @@ func TestSwapAB(t *testing.T) {
 	portA := 9001
 	portB := 9002
 	protocolTCP := 6
+	flowDir := 0
 	hashIdTCP := "705baa5149302fa1"
-	flTCP1 := newMockFlowLog(ipB, portB, ipA, portA, protocolTCP, 111, 11, false)
+	flTCP1 := newMockFlowLog(ipB, portB, ipA, portA, protocolTCP, flowDir, 111, 11, false)
 	flTCP1[tcpFlagsFieldName] = SYN_ACK_FLAG
 
 	startTime := clk.Now()
@@ -1111,4 +1176,92 @@ func TestSwapAB(t *testing.T) {
 	}
 	exposed := test.ReadExposedMetrics(t)
 	require.Contains(t, exposed, `conntrack_tcp_flags{action="swapAB"} 1`)
+}
+
+func TestExpiringConnection(t *testing.T) {
+	test.ResetPromRegistry()
+	clk := clock.NewMock()
+	defaultUpdateConnectionInterval := 30 * time.Second
+	defaultEndConnectionTimeout := 10 * time.Second
+	defaultTerminatingTimeout := 5 * time.Second
+
+	conf := buildMockConnTrackConfig(true, []string{"newConnection", "endConnection"},
+		defaultUpdateConnectionInterval, defaultEndConnectionTimeout, defaultTerminatingTimeout)
+	tcpFlagsFieldName := "TCPFlags"
+	conf.Extract.ConnTrack.TCPFlags = api.ConnTrackTCPFlags{
+		FieldName:           tcpFlagsFieldName,
+		DetectEndConnection: true,
+	}
+	ct, err := NewConnectionTrack(opMetrics, *conf, clk)
+	require.NoError(t, err)
+
+	ipA := "10.0.0.1"
+	ipB := "10.0.0.2"
+	portA := 9001
+	portB := 9002
+	protocolTCP := 6
+	flowDir := 0
+	hashIdTCP := "705baa5149302fa1"
+	flTCP1 := newMockFlowLog(ipA, portA, ipB, portB, protocolTCP, flowDir, 111, 11, false)
+	flTCP2 := newMockFlowLog(ipB, portB, ipA, portA, protocolTCP, flowDir, 222, 22, false)
+	flTCP2[tcpFlagsFieldName] = FIN_FLAG
+	flTCP3 := newMockFlowLog(ipA, portA, ipB, portB, protocolTCP, flowDir, 333, 33, false)
+	flTCP4 := newMockFlowLog(ipA, portA, ipB, portB, protocolTCP, flowDir, 555, 55, false)
+
+	startTime := clk.Now()
+	table := []struct {
+		name          string
+		time          time.Time
+		inputFlowLogs []config.GenericMap
+		expected      []config.GenericMap
+	}{
+		{
+			"start: new connection",
+			startTime.Add(0 * time.Second),
+			[]config.GenericMap{flTCP1},
+			[]config.GenericMap{
+				newMockRecordNewConnAB(ipA, portA, ipB, portB, protocolTCP, 111, 0, 11, 0, 1).withHash(hashIdTCP).markFirst().get(),
+			},
+		},
+		{
+			"5s: FIN flow log to end the connection",
+			startTime.Add(5 * time.Second),
+			[]config.GenericMap{flTCP2},
+			[]config.GenericMap(nil),
+		},
+		{
+			"10s: flow log after FIN is still part of the connection",
+			startTime.Add(10 * time.Second),
+			[]config.GenericMap{flTCP3},
+			[]config.GenericMap(nil),
+		},
+		{
+			"16s: end connection. The after-FIN-flow-log doesn't extend the connection's life",
+			startTime.Add(16 * time.Second),
+			[]config.GenericMap{},
+			[]config.GenericMap{
+				newMockRecordEndConnAB(ipA, portA, ipB, portB, protocolTCP, 444, 222, 44, 22, 3).withHash(hashIdTCP).get(),
+			},
+		},
+		{
+			"17s: another flow log will create a new connection",
+			startTime.Add(17 * time.Second),
+			[]config.GenericMap{flTCP4},
+			[]config.GenericMap{
+				newMockRecordNewConnAB(ipA, portA, ipB, portB, protocolTCP, 555, 0, 55, 0, 1).withHash(hashIdTCP).markFirst().get(),
+			},
+		},
+	}
+
+	var prevTime time.Time
+	for _, tt := range table {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Less(t, prevTime, tt.time)
+			prevTime = tt.time
+			clk.Set(tt.time)
+			actual := ct.Extract(tt.inputFlowLogs)
+			require.Equal(t, tt.expected, actual)
+			assertStoreConsistency(t, ct)
+		})
+	}
 }

--- a/pkg/pipeline/extract/conntrack/hash_test.go
+++ b/pkg/pipeline/extract/conntrack/hash_test.go
@@ -62,6 +62,7 @@ func TestComputeHash_Unidirectional(t *testing.T) {
 	portB := 9002
 	protocolA := 6
 	protocolB := 7
+	flowDir := 0
 	table := []struct {
 		name     string
 		flowLog1 config.GenericMap
@@ -70,32 +71,32 @@ func TestComputeHash_Unidirectional(t *testing.T) {
 	}{
 		{
 			"Same IP, port and protocol",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 222, 11, false),
 			true,
 		},
 		{
 			"Alternating ip+port",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipB, portB, ipA, portA, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipB, portB, ipA, portA, protocolA, flowDir, 222, 11, false),
 			false,
 		},
 		{
 			"Alternating ip",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipB, portA, ipA, portB, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipB, portA, ipA, portB, protocolA, flowDir, 222, 11, false),
 			false,
 		},
 		{
 			"Alternating port",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipA, portB, ipB, portA, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipA, portB, ipB, portA, protocolA, flowDir, 222, 11, false),
 			false,
 		},
 		{
 			"Same IP+port, different protocol",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipA, portA, ipB, portB, protocolB, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolB, flowDir, 222, 11, false),
 			false,
 		},
 	}
@@ -150,6 +151,7 @@ func TestComputeHash_Bidirectional(t *testing.T) {
 	portB := 9002
 	protocolA := 6
 	protocolB := 7
+	flowDir := 0
 	table := []struct {
 		name     string
 		flowLog1 config.GenericMap
@@ -158,32 +160,32 @@ func TestComputeHash_Bidirectional(t *testing.T) {
 	}{
 		{
 			"Same IP, port and protocol",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 222, 11, false),
 			true,
 		},
 		{
 			"Alternating ip+port",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipB, portB, ipA, portA, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipB, portB, ipA, portA, protocolA, flowDir, 222, 11, false),
 			true,
 		},
 		{
 			"Alternating ip",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipB, portA, ipA, portB, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipB, portA, ipA, portB, protocolA, flowDir, 222, 11, false),
 			false,
 		},
 		{
 			"Alternating port",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipA, portB, ipB, portA, protocolA, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipA, portB, ipB, portA, protocolA, flowDir, 222, 11, false),
 			false,
 		},
 		{
 			"Same IP+port, different protocol",
-			newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false),
-			newMockFlowLog(ipA, portA, ipB, portB, protocolB, 222, 11, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false),
+			newMockFlowLog(ipA, portA, ipB, portB, protocolB, flowDir, 222, 11, false),
 			false,
 		},
 	}
@@ -223,8 +225,9 @@ func TestComputeHash_MissingField(t *testing.T) {
 	portA := 1
 	portB := 9002
 	protocolA := 6
+	flowDir := 0
 
-	fl := newMockFlowLog(ipA, portA, ipB, portB, protocolA, 111, 22, false)
+	fl := newMockFlowLog(ipA, portA, ipB, portB, protocolA, flowDir, 111, 22, false)
 
 	h, err := ComputeHash(fl, keyDefinition, testHasher)
 	require.NoError(t, err)

--- a/pkg/pipeline/extract/conntrack/metrics.go
+++ b/pkg/pipeline/extract/conntrack/metrics.go
@@ -25,9 +25,9 @@ import (
 var (
 	connStoreLengthDef = operational.DefineMetric(
 		"conntrack_memory_connections",
-		"The total number of tracked connections in memory.",
+		"The total number of tracked connections in memory per group and phase.",
 		operational.TypeGauge,
-		"group",
+		"group", "phase",
 	)
 
 	inputRecordsDef = operational.DefineMetric(

--- a/pkg/pipeline/extract/conntrack/utils_test.go
+++ b/pkg/pipeline/extract/conntrack/utils_test.go
@@ -22,16 +22,17 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 )
 
-func newMockFlowLog(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, bytes, packets int, duplicate bool) config.GenericMap {
+func newMockFlowLog(srcIP string, srcPort int, dstIP string, dstPort int, protocol int, direction int, bytes, packets int, duplicate bool) config.GenericMap {
 	return config.GenericMap{
-		"SrcAddr":   srcIP,
-		"SrcPort":   srcPort,
-		"DstAddr":   dstIP,
-		"DstPort":   dstPort,
-		"Proto":     protocol,
-		"Bytes":     bytes,
-		"Packets":   packets,
-		"Duplicate": duplicate,
+		"SrcAddr":       srcIP,
+		"SrcPort":       srcPort,
+		"DstAddr":       dstIP,
+		"DstPort":       dstPort,
+		"Proto":         protocol,
+		"FlowDirection": direction,
+		"Bytes":         bytes,
+		"Packets":       packets,
+		"Duplicate":     duplicate,
 	}
 }
 


### PR DESCRIPTION
Backport of https://github.com/netobserv/flowlogs-pipeline/pull/413/commits/0ea48c54365562e6c18b887679a7e68df9c425f1

As these changes impact [NETOBSERV-973](https://issues.redhat.com/browse/NETOBSERV-973), we decided to backport for [release-1.2](https://github.com/netobserv/flowlogs-pipeline/tree/release-1.2)