### PR TITLE
NETOBSERV-915 skip reinterpret direction for conversations

### DIFF
--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -151,7 +151,10 @@ func (n *Network) Transform(inputEntry config.GenericMap) (config.GenericMap, bo
 				}
 			}
 		case api.OpReinterpretDirection:
-			reinterpretDirection(outputEntry, &n.DirectionInfo)
+			// only reinterpret direction on flowlogs
+			if rt, ok := outputEntry["_RecordType"]; !ok || rt == "flowLog" {
+				reinterpretDirection(outputEntry, &n.DirectionInfo)
+			}
 		case api.OpAddIPCategory:
 			if strIP, ok := outputEntry[rule.Input].(string); ok {
 				cat, ok := n.ipCatCache.GetCacheEntry(strIP)


### PR DESCRIPTION
Skip `reinterpretDirection` for conversation events as source and destination can be swapped by TCP flag `SYN_ACK` interpretation.

Related PRs:
- https://github.com/netobserv/network-observability-operator/pull/313
- https://github.com/netobserv/network-observability-console-plugin/pull/317