### PR TITLE
changed error to warning

### DIFF
--- a/pkg/operational/metrics.go
+++ b/pkg/operational/metrics.go
@@ -112,7 +112,7 @@ func (o *Metrics) register(c prometheus.Collector, name string) {
 	err := prometheus.DefaultRegisterer.Register(c)
 	if err != nil {
 		if _, ok := err.(prometheus.AlreadyRegisteredError); ok {
-			logrus.Errorf("metrics registration error [%s]: %v", name, err)
+			logrus.Warningf("metrics registration error [%s]: %v", name, err)
 		} else if o.settings.NoPanic {
 			logrus.Errorf("metrics registration error [%s]: %v", name, err)
 		} else {


### PR DESCRIPTION
If we use multiple encode_prom stages, each instance tries to register its operational metrics. This results in a prometheus.AlreadyRegisteredError, which is not really an error, so we convert it to a warning.