### PR TITLE
NETOBSERV-1131: need to allow setting multiple filters

### DIFF
--- a/.mk/development.mk
+++ b/.mk/development.mk
@@ -79,7 +79,7 @@ delete-kind-cluster: $(KIND) ## Delete cluster
 
 .PHONY: kind-load-image
 kind-load-image: ## Load image to kind
-ifeq ($(OCI_BIN),$(shell which docker))
+ifeq ($(OCI_BIN),$(shell which docker 2>/dev/null))
 # This is an optimization for docker provider. "kind load docker-image" can load an image directly from docker's
 # local registry. For other providers (i.e. podman), we must use "kind load image-archive" instead.
 	$(KIND) load --name $(KIND_CLUSTER_NAME) docker-image $(IMAGE)-${GOARCH}

--- a/README.md
+++ b/README.md
@@ -49,15 +49,14 @@ Usage:
   flowlogs-pipeline [flags]  
   
 Flags:  
-      --config string            config file (default is $HOME/.flowlogs-pipeline)  
-      --health.address string    Health server address (default "0.0.0.0")  
-      --health.port string       Health server port (default "8080")  
-  -h, --help                     help for flowlogs-pipeline  
-      --log-level string         Log level: debug, info, warning, error (default "error")  
-      --metricsSettings string   json for global metrics settings  
-      --parameters string        json of config file parameters field  
-      --pipeline string          json of config file pipeline field  
-      --profile.port int         Go pprof tool port (default: disabled)
+      --config string             config file (default is $HOME/.flowlogs-pipeline)  
+      --health.port string        Health server port (default "8080")  
+  -h, --help                      help for flowlogs-pipeline  
+      --log-level string          Log level: debug, info, warning, error (default "error")  
+      --metrics-settings string   json for global metrics settings  
+      --parameters string         json of config file parameters field  
+      --pipeline string           json of config file pipeline field  
+      --profile.port int          Go pprof tool port (default: disabled)
 ```
 <!---END-AUTO-flowlogs-pipeline_help--->
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,9 +11,12 @@ Following is the supported API format for prometheus encode:
                      counter: monotonically increasing counter whose value can only increase
                      histogram: counts samples in configurable buckets
                      agg_histogram: counts samples in configurable buckets, pre-aggregated via an Aggregate stage
-                 filter: an optional criterion to filter entries by
+                 filter: an optional criterion to filter entries by. Deprecated: use filters instead.
                      key: the key to match and filter by
                      value: the value to match and filter by
+                 filters: a list of criteria to filter entries by
+                         key: the key to match and filter by
+                         value: the value to match and filter by
                  valueKey: entry key from which to resolve metric value
                  labels: labels to be associated with the metric
                  buckets: histogram buckets

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -41,12 +41,20 @@ func PromEncodeOperationName(operation string) string {
 }
 
 type PromMetricsItem struct {
-	Name     string            `yaml:"name" json:"name" doc:"the metric name"`
-	Type     string            `yaml:"type" json:"type" enum:"PromEncodeOperationEnum" doc:"one of the following:"`
-	Filter   PromMetricsFilter `yaml:"filter" json:"filter" doc:"an optional criterion to filter entries by"`
-	ValueKey string            `yaml:"valueKey" json:"valueKey" doc:"entry key from which to resolve metric value"`
-	Labels   []string          `yaml:"labels" json:"labels" doc:"labels to be associated with the metric"`
-	Buckets  []float64         `yaml:"buckets" json:"buckets" doc:"histogram buckets"`
+	Name     string              `yaml:"name" json:"name" doc:"the metric name"`
+	Type     string              `yaml:"type" json:"type" enum:"PromEncodeOperationEnum" doc:"one of the following:"`
+	Filter   PromMetricsFilter   `yaml:"filter" json:"filter" doc:"an optional criterion to filter entries by. Deprecated: use filters instead."`
+	Filters  []PromMetricsFilter `yaml:"filters" json:"filters" doc:"a list of criteria to filter entries by"`
+	ValueKey string              `yaml:"valueKey" json:"valueKey" doc:"entry key from which to resolve metric value"`
+	Labels   []string            `yaml:"labels" json:"labels" doc:"labels to be associated with the metric"`
+	Buckets  []float64           `yaml:"buckets" json:"buckets" doc:"histogram buckets"`
+}
+
+func (i *PromMetricsItem) GetFilters() []PromMetricsFilter {
+	if len(i.Filters) == 0 && i.Filter.Key != "" {
+		return []PromMetricsFilter{i.Filter}
+	}
+	return i.Filters
 }
 
 type PromMetricsItems []PromMetricsItem

--- a/pkg/confgen/confgen_test.go
+++ b/pkg/confgen/confgen_test.go
@@ -146,7 +146,7 @@ func Test_RunShortConfGen(t *testing.T) {
 		Metrics: api.PromMetricsItems{{
 			Name:     "test_metric",
 			Type:     "gauge",
-			Filter:   api.PromMetricsFilter{Key: "", Value: ""},
+			Filters:  []api.PromMetricsFilter{},
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
 			Buckets:  []float64{},
@@ -225,7 +225,7 @@ func Test_RunConfGenNoAgg(t *testing.T) {
 		Metrics: api.PromMetricsItems{{
 			Name:     "test_metric",
 			Type:     "counter",
-			Filter:   api.PromMetricsFilter{Key: "", Value: ""},
+			Filters:  []api.PromMetricsFilter{},
 			ValueKey: "Bytes",
 			Labels:   []string{"service"},
 			Buckets:  []float64{},
@@ -327,14 +327,14 @@ func Test_RunLongConfGen(t *testing.T) {
 		Metrics: api.PromMetricsItems{{
 			Name:     "test_metric",
 			Type:     "gauge",
-			Filter:   api.PromMetricsFilter{Key: "", Value: ""},
+			Filters:  []api.PromMetricsFilter{},
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
 			Buckets:  []float64{},
 		}, {
 			Name:     "test_histo",
 			Type:     "agg_histogram",
-			Filter:   api.PromMetricsFilter{Key: "", Value: ""},
+			Filters:  []api.PromMetricsFilter{},
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
 			Buckets:  []float64{},
@@ -379,7 +379,7 @@ func Test_GenerateTruncatedConfig(t *testing.T) {
 		Metrics: api.PromMetricsItems{{
 			Name:     "test_metric",
 			Type:     "gauge",
-			Filter:   api.PromMetricsFilter{Key: "", Value: ""},
+			Filters:  []api.PromMetricsFilter{},
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
 		}},
@@ -410,7 +410,7 @@ func Test_GenerateTruncatedNoAgg(t *testing.T) {
 		Metrics: api.PromMetricsItems{{
 			Name:     "test_metric",
 			Type:     "counter",
-			Filter:   api.PromMetricsFilter{},
+			Filters:  []api.PromMetricsFilter{},
 			ValueKey: "Bytes",
 			Labels:   []string{"service"},
 		}},

--- a/pkg/confgen/confgen_test.go
+++ b/pkg/confgen/confgen_test.go
@@ -146,7 +146,7 @@ func Test_RunShortConfGen(t *testing.T) {
 		Metrics: api.PromMetricsItems{{
 			Name:     "test_metric",
 			Type:     "gauge",
-			Filters:  []api.PromMetricsFilter{},
+			Filters:  []api.PromMetricsFilter{{Key: "K", Value: "V"}},
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
 			Buckets:  []float64{},
@@ -225,7 +225,7 @@ func Test_RunConfGenNoAgg(t *testing.T) {
 		Metrics: api.PromMetricsItems{{
 			Name:     "test_metric",
 			Type:     "counter",
-			Filters:  []api.PromMetricsFilter{},
+			Filters:  []api.PromMetricsFilter{{Key: "K", Value: "V"}},
 			ValueKey: "Bytes",
 			Labels:   []string{"service"},
 			Buckets:  []float64{},
@@ -327,14 +327,14 @@ func Test_RunLongConfGen(t *testing.T) {
 		Metrics: api.PromMetricsItems{{
 			Name:     "test_metric",
 			Type:     "gauge",
-			Filters:  []api.PromMetricsFilter{},
+			Filters:  []api.PromMetricsFilter{{Key: "K", Value: "V"}},
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
 			Buckets:  []float64{},
 		}, {
 			Name:     "test_histo",
 			Type:     "agg_histogram",
-			Filters:  []api.PromMetricsFilter{},
+			Filters:  []api.PromMetricsFilter{{Key: "K", Value: "V"}},
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
 			Buckets:  []float64{},
@@ -379,9 +379,9 @@ func Test_GenerateTruncatedConfig(t *testing.T) {
 		Metrics: api.PromMetricsItems{{
 			Name:     "test_metric",
 			Type:     "gauge",
-			Filters:  []api.PromMetricsFilter{},
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
+			Filters:  []api.PromMetricsFilter{{Key: "K", Value: "V"}},
 		}},
 	}, params[1].Encode.Prom)
 
@@ -410,9 +410,9 @@ func Test_GenerateTruncatedNoAgg(t *testing.T) {
 		Metrics: api.PromMetricsItems{{
 			Name:     "test_metric",
 			Type:     "counter",
-			Filters:  []api.PromMetricsFilter{},
 			ValueKey: "Bytes",
 			Labels:   []string{"service"},
+			Filters:  []api.PromMetricsFilter{{Key: "K", Value: "V"}},
 		}},
 	}, params[0].Encode.Prom)
 }

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -166,7 +166,7 @@ func TestKafkaPromPipeline(t *testing.T) {
 
 	b, err = json.Marshal(params[4])
 	require.NoError(t, err)
-	require.JSONEq(t, `{"name":"prom","encode":{"type":"prom","prom":{"expiryTime":"50s", "metrics":[{"name":"connections_per_source_as","type":"counter","filter":{"key":"name","value":"src_as_connection_count"},"valueKey":"recent_count","labels":["by","aggregate"],"buckets":[]}],"prefix":"flp_"}}}`, string(b))
+	require.JSONEq(t, `{"name":"prom","encode":{"type":"prom","prom":{"expiryTime":"50s", "metrics":[{"name":"connections_per_source_as","type":"counter","filter":{"key":"","value":""},"filters":[{"key":"name","value":"src_as_connection_count"}],"valueKey":"recent_count","labels":["by","aggregate"],"buckets":[]}],"prefix":"flp_"}}}`, string(b))
 }
 
 func TestForkPipeline(t *testing.T) {

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -127,10 +127,10 @@ func TestKafkaPromPipeline(t *testing.T) {
 		Metrics: api.PromMetricsItems{{
 			Name: "connections_per_source_as",
 			Type: "counter",
-			Filter: api.PromMetricsFilter{
+			Filters: []api.PromMetricsFilter{{
 				Key:   "name",
 				Value: "src_as_connection_count",
-			},
+			}},
 			ValueKey: "recent_count",
 			Labels:   []string{"by", "aggregate"},
 			Buckets:  []float64{},

--- a/pkg/pipeline/encode/encode_prom.go
+++ b/pkg/pipeline/encode/encode_prom.go
@@ -204,13 +204,13 @@ func (e *EncodeProm) prepareAggHisto(flow config.GenericMap, info *api.PromMetri
 }
 
 func (e *EncodeProm) extractGenericValue(flow config.GenericMap, info *api.PromMetricsItem) interface{} {
-	if info.Filter.Key != "" {
-		if val, found := flow[info.Filter.Key]; found {
+	for _, filter := range info.GetFilters() {
+		if val, found := flow[filter.Key]; found {
 			sVal, ok := val.(string)
 			if !ok {
 				sVal = fmt.Sprint(val)
 			}
-			if sVal != info.Filter.Value {
+			if sVal != filter.Value {
 				return nil
 			}
 		}

--- a/pkg/test/network_defs.go
+++ b/pkg/test/network_defs.go
@@ -90,6 +90,9 @@ encode:
         labels:
           - groupByKeys
           - aggregate
+        filters:
+          - key: K
+            value: V
 visualization:
   type: grafana
   grafana:
@@ -129,6 +132,9 @@ encode:
         labels:
           - groupByKeys
           - aggregate
+        filters:
+          - key: K
+            value: V
 `
 
 const ConfgenNetworkDefNoAgg = `#flp_confgen
@@ -156,6 +162,9 @@ encode:
         valueKey: Bytes
         labels:
           - service
+        filters:
+          - key: K
+            value: V
 visualization:
   type: grafana
   grafana:


### PR DESCRIPTION
Improve the promEncode API to allow setting multiple filters. To avoid breaking change, the existing filter API is kept and marked as deprecated.

Operator PR: https://github.com/netobserv/network-observability-operator/pull/387