### PR TITLE
Update README and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ kubectl get namespace openshift
 2. Deploy FLP with all dependent components (into `default` namespace)
 ```shell
 kubectl config set-context --current --namespace=default
-make ocp-deploy
+IMAGE_ORG=netobserv make ocp-deploy
 ```
 
 3. Use a web-browser to access grafana dashboards ( end-point address exposed by the script) and observe metrics and logs  

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -106,8 +106,8 @@ parameters:
         input: timeReceived
       scheduling:
       - endConnectionTimeout: 10s
-        heartbeatInterval: 30s
         terminatingTimeout: 5s
+        heartbeatInterval: 30s
       tcpFlags:
         fieldName: TCPFlags
         detectEndConnection: true
@@ -152,101 +152,102 @@ parameters:
   extract:
     type: aggregates
     aggregates:
-    - name: bandwidth_network_service
-      groupByKeys:
-      - service
-      - _RecordType
-      operationType: sum
-      operationKey: bytes
-    - name: bandwidth_source_destination_subnet
-      groupByKeys:
-      - dstSubnet24
-      - srcSubnet24
-      - _RecordType
-      operationType: sum
-      operationKey: bytes
-    - name: bandwidth_source_subnet
-      groupByKeys:
-      - srcSubnet
-      - _RecordType
-      operationType: sum
-      operationKey: bytes
-    - name: connection_bytes_hist
-      groupByKeys:
-      - _RecordType
-      operationType: raw_values
-      operationKey: bytes_total
-    - name: connection_bytes_hist_AB
-      groupByKeys:
-      - _RecordType
-      operationType: raw_values
-      operationKey: bytes_AB
-    - name: connection_bytes_hist_BA
-      groupByKeys:
-      - _RecordType
-      operationType: raw_values
-      operationKey: bytes_BA
-    - name: dest_connection_subnet_count
-      groupByKeys:
-      - dstSubnet
-      - _RecordType
-      operationType: count
-      operationKey: isNewFlow
-    - name: src_connection_count
-      groupByKeys:
-      - srcSubnet
-      - _RecordType
-      operationType: count
-    - name: TCPFlags_count
-      groupByKeys:
-      - TCPFlags
-      - _RecordType
-      operationType: count
-    - name: dst_as_connection_count
-      groupByKeys:
-      - dstAS
-      - _RecordType
-      operationType: count
-    - name: src_as_connection_count
-      groupByKeys:
-      - srcAS
-      - _RecordType
-      operationType: count
-    - name: count_source_destination_subnet
-      groupByKeys:
-      - dstSubnet24
-      - srcSubnet24
-      - _RecordType
-      operationType: count
-    - name: bandwidth_destination_subnet
-      groupByKeys:
-      - dstSubnet
-      - _RecordType
-      operationType: sum
-      operationKey: bytes
-    - name: bandwidth_namespace
-      groupByKeys:
-      - srcK8S_Namespace
-      - srcK8S_Type
-      - _RecordType
-      operationType: sum
-      operationKey: bytes
-    - name: flows_bytes_hist
-      groupByKeys:
-      - all_Evaluate
-      - _RecordType
-      operationType: raw_values
-      operationKey: bytes
-    - name: dest_connection_location_count
-      groupByKeys:
-      - dstLocation_CountryName
-      - _RecordType
-      operationType: count
-    - name: dest_service_count
-      groupByKeys:
-      - service
-      - _RecordType
-      operationType: count
+      rules:
+      - name: bandwidth_network_service
+        groupByKeys:
+        - service
+        - _RecordType
+        operationType: sum
+        operationKey: bytes
+      - name: bandwidth_source_destination_subnet
+        groupByKeys:
+        - dstSubnet24
+        - srcSubnet24
+        - _RecordType
+        operationType: sum
+        operationKey: bytes
+      - name: bandwidth_source_subnet
+        groupByKeys:
+        - srcSubnet
+        - _RecordType
+        operationType: sum
+        operationKey: bytes
+      - name: connection_bytes_hist
+        groupByKeys:
+        - _RecordType
+        operationType: raw_values
+        operationKey: bytes_total
+      - name: connection_bytes_hist_AB
+        groupByKeys:
+        - _RecordType
+        operationType: raw_values
+        operationKey: bytes_AB
+      - name: connection_bytes_hist_BA
+        groupByKeys:
+        - _RecordType
+        operationType: raw_values
+        operationKey: bytes_BA
+      - name: dest_connection_subnet_count
+        groupByKeys:
+        - dstSubnet
+        - _RecordType
+        operationType: count
+        operationKey: isNewFlow
+      - name: src_connection_count
+        groupByKeys:
+        - srcSubnet
+        - _RecordType
+        operationType: count
+      - name: TCPFlags_count
+        groupByKeys:
+        - TCPFlags
+        - _RecordType
+        operationType: count
+      - name: dst_as_connection_count
+        groupByKeys:
+        - dstAS
+        - _RecordType
+        operationType: count
+      - name: src_as_connection_count
+        groupByKeys:
+        - srcAS
+        - _RecordType
+        operationType: count
+      - name: count_source_destination_subnet
+        groupByKeys:
+        - dstSubnet24
+        - srcSubnet24
+        - _RecordType
+        operationType: count
+      - name: bandwidth_destination_subnet
+        groupByKeys:
+        - dstSubnet
+        - _RecordType
+        operationType: sum
+        operationKey: bytes
+      - name: bandwidth_namespace
+        groupByKeys:
+        - srcK8S_Namespace
+        - srcK8S_Type
+        - _RecordType
+        operationType: sum
+        operationKey: bytes
+      - name: flows_bytes_hist
+        groupByKeys:
+        - all_Evaluate
+        - _RecordType
+        operationType: raw_values
+        operationKey: bytes
+      - name: dest_connection_location_count
+        groupByKeys:
+        - dstLocation_CountryName
+        - _RecordType
+        operationType: count
+      - name: dest_service_count
+        groupByKeys:
+        - service
+        - _RecordType
+        operationType: count
 - name: encode_prom
   encode:
     type: prom
@@ -257,6 +258,7 @@ parameters:
         filter:
           key: name
           value: bandwidth_network_service
+        filters: []
         valueKey: recent_op_value
         labels:
         - groupByKeys
@@ -267,6 +269,7 @@ parameters:
         filter:
           key: name
           value: bandwidth_source_destination_subnet
+        filters: []
         valueKey: recent_op_value
         labels:
         - groupByKeys
@@ -277,6 +280,7 @@ parameters:
         filter:
           key: name
           value: bandwidth_source_subnet
+        filters: []
         valueKey: bytes
         labels:
         - srcSubnet
@@ -286,6 +290,7 @@ parameters:
         filter:
           key: name
           value: connection_bytes_hist
+        filters: []
         valueKey: recent_raw_values
         labels:
         - groupByKeys
@@ -301,6 +306,7 @@ parameters:
         filter:
           key: name
           value: connection_bytes_hist_AB
+        filters: []
         valueKey: recent_raw_values
         labels:
         - groupByKeys
@@ -316,6 +322,7 @@ parameters:
         filter:
           key: name
           value: connection_bytes_hist_BA
+        filters: []
         valueKey: recent_raw_values
         labels:
         - groupByKeys
@@ -331,6 +338,7 @@ parameters:
         filter:
           key: name
           value: dest_connection_subnet_count
+        filters: []
         valueKey: recent_count
         labels:
         - _RecordType
@@ -341,6 +349,7 @@ parameters:
         filter:
           key: name
           value: src_connection_count
+        filters: []
         valueKey: recent_count
         labels:
         - srcSubnet
@@ -351,6 +360,7 @@ parameters:
         filter:
           key: name
           value: TCPFlags_count
+        filters: []
         valueKey: recent_count
         labels:
         - groupByKeys
@@ -361,6 +371,7 @@ parameters:
         filter:
           key: name
           value: dst_as_connection_count
+        filters: []
         valueKey: recent_count
         labels:
         - dstAS
@@ -371,6 +382,7 @@ parameters:
         filter:
           key: name
           value: src_as_connection_count
+        filters: []
         valueKey: recent_count
         labels:
         - srcAS
@@ -381,6 +393,7 @@ parameters:
         filter:
           key: name
           value: count_source_destination_subnet
+        filters: []
         valueKey: recent_count
         labels:
         - dstSubnet24
@@ -392,6 +405,7 @@ parameters:
         filter:
           key: name
           value: bandwidth_destination_subnet
+        filters: []
         valueKey: recent_op_value
         labels:
         - groupByKeys
@@ -402,6 +416,7 @@ parameters:
         filter:
           key: name
           value: bandwidth_namespace
+        filters: []
         valueKey: recent_op_value
         labels:
         - groupByKeys
@@ -412,6 +427,7 @@ parameters:
         filter:
           key: name
           value: flows_bytes_hist
+        filters: []
         valueKey: recent_raw_values
         labels:
         - groupByKeys
@@ -427,6 +443,7 @@ parameters:
         filter:
           key: name
           value: dest_connection_location_count
+        filters: []
         valueKey: recent_count
         labels:
         - dstLocation_CountryName
@@ -437,6 +454,7 @@ parameters:
         filter:
           key: name
           value: dest_service_count
+        filters: []
         valueKey: recent_count
         labels:
         - service

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -255,9 +255,6 @@ parameters:
       metrics:
       - name: bandwidth_per_network_service
         type: counter
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: bandwidth_network_service
@@ -268,9 +265,6 @@ parameters:
         buckets: []
       - name: bandwidth_per_source_destination_subnet
         type: counter
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: bandwidth_source_destination_subnet
@@ -281,9 +275,6 @@ parameters:
         buckets: []
       - name: bandwidth_per_source_subnet
         type: gauge
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: bandwidth_source_subnet
@@ -293,9 +284,6 @@ parameters:
         buckets: []
       - name: connection_size_histogram
         type: agg_histogram
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: connection_bytes_hist
@@ -311,9 +299,6 @@ parameters:
         - 1.048576e+06
       - name: connection_size_histogram_ab
         type: agg_histogram
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: connection_bytes_hist_AB
@@ -329,9 +314,6 @@ parameters:
         - 1.048576e+06
       - name: connection_size_histogram_ba
         type: agg_histogram
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: connection_bytes_hist_BA
@@ -347,9 +329,6 @@ parameters:
         - 1.048576e+06
       - name: connections_per_destination_subnet
         type: counter
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: dest_connection_subnet_count
@@ -360,9 +339,6 @@ parameters:
         buckets: []
       - name: connections_per_source_subnet
         type: counter
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: src_connection_count
@@ -373,9 +349,6 @@ parameters:
         buckets: []
       - name: connections_per_tcp_flags
         type: counter
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: TCPFlags_count
@@ -386,9 +359,6 @@ parameters:
         buckets: []
       - name: connections_per_destination_as
         type: counter
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: dst_as_connection_count
@@ -399,9 +369,6 @@ parameters:
         buckets: []
       - name: connections_per_source_as
         type: counter
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: src_as_connection_count
@@ -412,9 +379,6 @@ parameters:
         buckets: []
       - name: count_per_source_destination_subnet
         type: counter
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: count_source_destination_subnet
@@ -426,9 +390,6 @@ parameters:
         buckets: []
       - name: egress_per_destination_subnet
         type: counter
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: bandwidth_destination_subnet
@@ -439,9 +400,6 @@ parameters:
         buckets: []
       - name: egress_per_namespace
         type: counter
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: bandwidth_namespace
@@ -452,9 +410,6 @@ parameters:
         buckets: []
       - name: flows_length_histogram
         type: agg_histogram
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: flows_bytes_hist
@@ -470,9 +425,6 @@ parameters:
         - 1.048576e+06
       - name: connections_per_destination_location
         type: counter
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: dest_connection_location_count
@@ -483,9 +435,6 @@ parameters:
         buckets: []
       - name: service_count
         type: counter
-        filter:
-          key: ""
-          value: ""
         filters:
         - key: name
           value: dest_service_count

--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -2,7 +2,7 @@
 log-level: error
 metricsSettings:
   port: 9102
-  prefix: flp_op
+  prefix: flp_op_
 pipeline:
 - name: ingest_collector
 - name: transform_generic
@@ -256,9 +256,11 @@ parameters:
       - name: bandwidth_per_network_service
         type: counter
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: bandwidth_network_service
-        filters: []
         valueKey: recent_op_value
         labels:
         - groupByKeys
@@ -267,9 +269,11 @@ parameters:
       - name: bandwidth_per_source_destination_subnet
         type: counter
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: bandwidth_source_destination_subnet
-        filters: []
         valueKey: recent_op_value
         labels:
         - groupByKeys
@@ -278,9 +282,11 @@ parameters:
       - name: bandwidth_per_source_subnet
         type: gauge
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: bandwidth_source_subnet
-        filters: []
         valueKey: bytes
         labels:
         - srcSubnet
@@ -288,9 +294,11 @@ parameters:
       - name: connection_size_histogram
         type: agg_histogram
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: connection_bytes_hist
-        filters: []
         valueKey: recent_raw_values
         labels:
         - groupByKeys
@@ -304,9 +312,11 @@ parameters:
       - name: connection_size_histogram_ab
         type: agg_histogram
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: connection_bytes_hist_AB
-        filters: []
         valueKey: recent_raw_values
         labels:
         - groupByKeys
@@ -320,9 +330,11 @@ parameters:
       - name: connection_size_histogram_ba
         type: agg_histogram
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: connection_bytes_hist_BA
-        filters: []
         valueKey: recent_raw_values
         labels:
         - groupByKeys
@@ -336,9 +348,11 @@ parameters:
       - name: connections_per_destination_subnet
         type: counter
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: dest_connection_subnet_count
-        filters: []
         valueKey: recent_count
         labels:
         - _RecordType
@@ -347,9 +361,11 @@ parameters:
       - name: connections_per_source_subnet
         type: counter
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: src_connection_count
-        filters: []
         valueKey: recent_count
         labels:
         - srcSubnet
@@ -358,9 +374,11 @@ parameters:
       - name: connections_per_tcp_flags
         type: counter
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: TCPFlags_count
-        filters: []
         valueKey: recent_count
         labels:
         - groupByKeys
@@ -369,9 +387,11 @@ parameters:
       - name: connections_per_destination_as
         type: counter
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: dst_as_connection_count
-        filters: []
         valueKey: recent_count
         labels:
         - dstAS
@@ -380,9 +400,11 @@ parameters:
       - name: connections_per_source_as
         type: counter
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: src_as_connection_count
-        filters: []
         valueKey: recent_count
         labels:
         - srcAS
@@ -391,9 +413,11 @@ parameters:
       - name: count_per_source_destination_subnet
         type: counter
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: count_source_destination_subnet
-        filters: []
         valueKey: recent_count
         labels:
         - dstSubnet24
@@ -403,9 +427,11 @@ parameters:
       - name: egress_per_destination_subnet
         type: counter
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: bandwidth_destination_subnet
-        filters: []
         valueKey: recent_op_value
         labels:
         - groupByKeys
@@ -414,9 +440,11 @@ parameters:
       - name: egress_per_namespace
         type: counter
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: bandwidth_namespace
-        filters: []
         valueKey: recent_op_value
         labels:
         - groupByKeys
@@ -425,9 +453,11 @@ parameters:
       - name: flows_length_histogram
         type: agg_histogram
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: flows_bytes_hist
-        filters: []
         valueKey: recent_raw_values
         labels:
         - groupByKeys
@@ -441,9 +471,11 @@ parameters:
       - name: connections_per_destination_location
         type: counter
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: dest_connection_location_count
-        filters: []
         valueKey: recent_count
         labels:
         - dstLocation_CountryName
@@ -452,9 +484,11 @@ parameters:
       - name: service_count
         type: counter
         filter:
-          key: name
+          key: ""
+          value: ""
+        filters:
+        - key: name
           value: dest_service_count
-        filters: []
         valueKey: recent_count
         labels:
         - service

--- a/network_definitions/bandwidth_per_network_service.yaml
+++ b/network_definitions/bandwidth_per_network_service.yaml
@@ -32,7 +32,7 @@ encode:
     metrics:
       - name: bandwidth_per_network_service
         type: counter
-        filter: {key: name, value: bandwidth_network_service}
+        filters: [{key: name, value: bandwidth_network_service}]
         valueKey: recent_op_value
         labels:
           - groupByKeys

--- a/network_definitions/bandwidth_per_src_dest_subnet.yaml
+++ b/network_definitions/bandwidth_per_src_dest_subnet.yaml
@@ -37,7 +37,7 @@ encode:
     metrics:
       - name: bandwidth_per_source_destination_subnet
         type: counter
-        filter: {key: name, value: bandwidth_source_destination_subnet}
+        filters: [{key: name, value: bandwidth_source_destination_subnet}]
         valueKey: recent_op_value
         labels:
           - groupByKeys

--- a/network_definitions/bandwidth_per_src_subnet.yaml
+++ b/network_definitions/bandwidth_per_src_subnet.yaml
@@ -32,7 +32,7 @@ encode:
     metrics:
       - name: bandwidth_per_source_subnet
         type: gauge
-        filter: {key: name, value: bandwidth_source_subnet}
+        filters: [{key: name, value: bandwidth_source_subnet}]
         valueKey: bytes
         labels:
           - srcSubnet

--- a/network_definitions/connection_length_histogram.yaml
+++ b/network_definitions/connection_length_histogram.yaml
@@ -35,7 +35,7 @@ encode:
     metrics:
       - name: connection_size_histogram
         type: histogram
-        filter: { key: name, value: connection_bytes_hist }
+        filters: [{ key: name, value: connection_bytes_hist }]
         valueKey: recent_raw_values
         labels:
           - groupByKeys
@@ -48,7 +48,7 @@ encode:
           - 1048576 #   1MiB
       - name: connection_size_histogram_ab
         type: histogram
-        filter: { key: name, value: connection_bytes_hist_AB }
+        filters: [{ key: name, value: connection_bytes_hist_AB }]
         valueKey: recent_raw_values
         labels:
           - groupByKeys
@@ -61,7 +61,7 @@ encode:
           - 1048576 #   1MiB
       - name: connection_size_histogram_ba
         type: histogram
-        filter: { key: name, value: connection_bytes_hist_BA }
+        filters: [{ key: name, value: connection_bytes_hist_BA }]
         valueKey: recent_raw_values
         labels:
           - groupByKeys

--- a/network_definitions/connection_rate_per_dest_subnet.yaml
+++ b/network_definitions/connection_rate_per_dest_subnet.yaml
@@ -30,7 +30,7 @@ encode:
     metrics:
       - name: connections_per_destination_subnet
         type: counter
-        filter: {key: name, value: dest_connection_subnet_count}
+        filters: [{key: name, value: dest_connection_subnet_count}]
         valueKey: recent_count
         labels:
           - _RecordType

--- a/network_definitions/connection_rate_per_src_subnet.yaml
+++ b/network_definitions/connection_rate_per_src_subnet.yaml
@@ -29,7 +29,7 @@ encode:
     metrics:
       - name: connections_per_source_subnet
         type: counter
-        filter: {key: name, value: src_connection_count}
+        filters: [{key: name, value: src_connection_count}]
         valueKey: recent_count
         labels:
           - srcSubnet

--- a/network_definitions/connection_rate_per_tcp_flags.yaml
+++ b/network_definitions/connection_rate_per_tcp_flags.yaml
@@ -23,7 +23,7 @@ encode:
     metrics:
       - name: connections_per_tcp_flags
         type: counter
-        filter: { key: name, value: TCPFlags_count }
+        filters: [{ key: name, value: TCPFlags_count }]
         valueKey: recent_count
         labels:
           - groupByKeys

--- a/network_definitions/connections_per_dst_as.yaml
+++ b/network_definitions/connections_per_dst_as.yaml
@@ -24,7 +24,7 @@ encode:
     metrics:
       - name: connections_per_destination_as
         type: counter
-        filter: { key: name, value: dst_as_connection_count }
+        filters: [{ key: name, value: dst_as_connection_count }]
         valueKey: recent_count
         labels:
           - dstAS

--- a/network_definitions/connections_per_src_as.yaml
+++ b/network_definitions/connections_per_src_as.yaml
@@ -24,7 +24,7 @@ encode:
     metrics:
       - name: connections_per_source_as
         type: counter
-        filter: { key: name, value: src_as_connection_count }
+        filters: [{ key: name, value: src_as_connection_count }]
         valueKey: recent_count
         labels:
           - srcAS

--- a/network_definitions/count_per_src_dest_subnet.yaml
+++ b/network_definitions/count_per_src_dest_subnet.yaml
@@ -36,7 +36,7 @@ encode:
     metrics:
       - name: count_per_source_destination_subnet
         type: counter
-        filter: { key: name, value: count_source_destination_subnet }
+        filters: [{ key: name, value: count_source_destination_subnet }]
         valueKey: recent_count
         labels:
           - dstSubnet24

--- a/network_definitions/egress_bandwidth_per_dest_subnet.yaml
+++ b/network_definitions/egress_bandwidth_per_dest_subnet.yaml
@@ -32,7 +32,7 @@ encode:
     metrics:
       - name: egress_per_destination_subnet
         type: counter
-        filter: { key: name, value: bandwidth_destination_subnet }
+        filters: [{ key: name, value: bandwidth_destination_subnet }]
         valueKey: recent_op_value
         labels:
           - groupByKeys

--- a/network_definitions/egress_bandwidth_per_namespace.yaml
+++ b/network_definitions/egress_bandwidth_per_namespace.yaml
@@ -32,7 +32,7 @@ encode:
     metrics:
       - name: egress_per_namespace
         type: counter
-        filter: { key: name, value: bandwidth_namespace }
+        filters: [{ key: name, value: bandwidth_namespace }]
         valueKey: recent_op_value
         labels:
           - groupByKeys

--- a/network_definitions/flows_length_histogram.yaml
+++ b/network_definitions/flows_length_histogram.yaml
@@ -32,7 +32,7 @@ encode:
     metrics:
       - name: flows_length_histogram
         type: histogram
-        filter: { key: name, value: flows_bytes_hist }
+        filters: [{ key: name, value: flows_bytes_hist }]
         valueKey: recent_raw_values
         labels:
           - groupByKeys

--- a/network_definitions/geo-location_rate_per_dest.yaml
+++ b/network_definitions/geo-location_rate_per_dest.yaml
@@ -30,7 +30,7 @@ encode:
     metrics:
       - name: connections_per_destination_location
         type: counter
-        filter: { key: name, value: dest_connection_location_count }
+        filters: [{ key: name, value: dest_connection_location_count }]
         valueKey: recent_count
         labels:
           - dstLocation_CountryName

--- a/network_definitions/network_services_count.yaml
+++ b/network_definitions/network_services_count.yaml
@@ -31,7 +31,7 @@ encode:
     metrics:
       - name: service_count
         type: counter
-        filter: { key: name, value: dest_service_count }
+        filters: [{ key: name, value: dest_service_count }]
         valueKey: recent_count
         labels:
           - service

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -43,7 +43,7 @@ func PromEncodeOperationName(operation string) string {
 type PromMetricsItem struct {
 	Name     string              `yaml:"name" json:"name" doc:"the metric name"`
 	Type     string              `yaml:"type" json:"type" enum:"PromEncodeOperationEnum" doc:"one of the following:"`
-	Filter   PromMetricsFilter   `yaml:"filter" json:"filter" doc:"an optional criterion to filter entries by. Deprecated: use filters instead."`
+	Filter   PromMetricsFilter   `yaml:"filter,omitempty" json:"filter,omitempty" doc:"an optional criterion to filter entries by. Deprecated: use filters instead."`
 	Filters  []PromMetricsFilter `yaml:"filters" json:"filters" doc:"a list of criteria to filter entries by"`
 	ValueKey string              `yaml:"valueKey" json:"valueKey" doc:"entry key from which to resolve metric value"`
 	Labels   []string            `yaml:"labels" json:"labels" doc:"labels to be associated with the metric"`

--- a/pkg/confgen/flowlogs2metrics_config.go
+++ b/pkg/confgen/flowlogs2metrics_config.go
@@ -69,7 +69,7 @@ func (cg *ConfGen) GenerateFlowlogs2PipelineConfig() *config.ConfigFileStruct {
 		Parameters: pipeline.GetStageParams(),
 		MetricsSettings: config.MetricsSettings{
 			Port:   9102,
-			Prefix: "flp_op",
+			Prefix: "flp_op_",
 		},
 	}
 }


### PR DESCRIPTION
Following the feedback of @aslom in #473:

1. The README was updated to run `make ocp-deploy` with `IMAGE_ORG=netobserv`
2. The configuration of FLP was updated. #418 introduced a new API field in `extract_aggregate` which required this update.
3. On the way, updated the operational metric prefix to `flp_op_` (added underscore) to avoid metric names like `flp_opmetrics_processed`