### PR TITLE
NETOBSERV-1352 enhance prom filters for RTT metrics

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -13,10 +13,10 @@ Following is the supported API format for prometheus encode:
                      agg_histogram: counts samples in configurable buckets, pre-aggregated via an Aggregate stage
                  filter: an optional criterion to filter entries by. Deprecated: use filters instead.
                      key: the key to match and filter by
-                     value: the value to match and filter by. Use !nil / nil to match presence / absence
+                     value: the value to match and filter by. Use !nil / nil to match presence / absence. Add multiple matching values using '|' rune such as 'a|b' to match either 'a' or 'b'.
                  filters: a list of criteria to filter entries by
                          key: the key to match and filter by
-                         value: the value to match and filter by. Use !nil / nil to match presence / absence
+                         value: the value to match and filter by. Use !nil / nil to match presence / absence. Add multiple matching values using '|' rune such as 'a|b' to match either 'a' or 'b'.
                  valueKey: entry key from which to resolve metric value
                  labels: labels to be associated with the metric
                  buckets: histogram buckets

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,10 +13,10 @@ Following is the supported API format for prometheus encode:
                      agg_histogram: counts samples in configurable buckets, pre-aggregated via an Aggregate stage
                  filter: an optional criterion to filter entries by. Deprecated: use filters instead.
                      key: the key to match and filter by
-                     value: the value to match and filter by
+                     value: the value to match and filter by. Use !nil / nil to match presence / absence
                  filters: a list of criteria to filter entries by
                          key: the key to match and filter by
-                         value: the value to match and filter by
+                         value: the value to match and filter by. Use !nil / nil to match presence / absence
                  valueKey: entry key from which to resolve metric value
                  labels: labels to be associated with the metric
                  buckets: histogram buckets

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -61,5 +61,5 @@ type PromMetricsItems []PromMetricsItem
 
 type PromMetricsFilter struct {
 	Key   string `yaml:"key" json:"key" doc:"the key to match and filter by"`
-	Value string `yaml:"value" json:"value" doc:"the value to match and filter by"`
+	Value string `yaml:"value" json:"value" doc:"the value to match and filter by. Use !nil / nil to match presence / absence"`
 }

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -61,5 +61,5 @@ type PromMetricsItems []PromMetricsItem
 
 type PromMetricsFilter struct {
 	Key   string `yaml:"key" json:"key" doc:"the key to match and filter by"`
-	Value string `yaml:"value" json:"value" doc:"the value to match and filter by. Use !nil / nil to match presence / absence"`
+	Value string `yaml:"value" json:"value" doc:"the value to match and filter by. Use !nil / nil to match presence / absence. Add multiple matching values using '|' rune such as 'a|b' to match either 'a' or 'b'."`
 }

--- a/pkg/pipeline/encode/encode_prom.go
+++ b/pkg/pipeline/encode/encode_prom.go
@@ -27,6 +27,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
 	putils "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
+	"k8s.io/utils/strings/slices"
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -221,7 +222,7 @@ func (e *EncodeProm) extractGenericValue(flow config.GenericMap, info *api.PromM
 				if !ok {
 					sVal = fmt.Sprint(val)
 				}
-				if sVal != filter.Value {
+				if !slices.Contains(strings.Split(filter.Value, "|"), sVal) {
 					return nil
 				}
 			}

--- a/pkg/pipeline/encode/encode_prom.go
+++ b/pkg/pipeline/encode/encode_prom.go
@@ -205,13 +205,25 @@ func (e *EncodeProm) prepareAggHisto(flow config.GenericMap, info *api.PromMetri
 
 func (e *EncodeProm) extractGenericValue(flow config.GenericMap, info *api.PromMetricsItem) interface{} {
 	for _, filter := range info.GetFilters() {
-		if val, found := flow[filter.Key]; found {
-			sVal, ok := val.(string)
-			if !ok {
-				sVal = fmt.Sprint(val)
-			}
-			if sVal != filter.Value {
+		val, found := flow[filter.Key]
+		switch filter.Value {
+		case "nil":
+			if found {
 				return nil
+			}
+		case "!nil":
+			if !found {
+				return nil
+			}
+		default:
+			if found {
+				sVal, ok := val.(string)
+				if !ok {
+					sVal = fmt.Sprint(val)
+				}
+				if sVal != filter.Value {
+					return nil
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR improve prom metrics filtering introducing:
- [x] `!nil` to match presenceof the field with any value
- [X] `nil` to match absence of the field
- [x] `|` splitter to match at least one value