### PR TITLE
Add ingest_stdin

### DIFF
--- a/cmd/flowlogs-pipeline/main.go
+++ b/cmd/flowlogs-pipeline/main.go
@@ -204,7 +204,7 @@ func run() {
 	// Create new flows pipeline
 	mainPipeline, err = pipeline.NewPipeline(&cfg)
 	if err != nil {
-		log.Fatalf("failed to initialize pipeline %s", err)
+		log.Fatalf("failed to initialize pipeline: %s", err)
 		os.Exit(1)
 	}
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -111,6 +111,16 @@ Following is the supported API format for the Network Observability eBPF ingest:
          port: the port number to listen on
          bufferLength: the length of the ingest channel buffer, in groups of flows, containing each group hundreds of flows (default: 100)
 </pre>
+## Ingest Standard Input
+Following is the supported API format for the standard input ingest:
+
+<pre>
+ stdin:
+         decoder: decoder to use
+             type: (enum) one of the following:
+                 json: JSON decoder
+                 protobuf: Protobuf decoder
+</pre>
 ## Transform Generic API
 Following is the supported API format for generic transformations:
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -23,6 +23,7 @@ const (
 	FileChunksType               = "file_chunks"
 	SyntheticType                = "synthetic"
 	CollectorType                = "collector"
+	StdinType                    = "stdin"
 	GRPCType                     = "grpc"
 	FakeType                     = "fake"
 	KafkaType                    = "kafka"
@@ -60,6 +61,7 @@ type API struct {
 	IngestCollector    IngestCollector  `yaml:"collector" doc:"## Ingest collector API\nFollowing is the supported API format for the NetFlow / IPFIX collector:\n"`
 	IngestKafka        IngestKafka      `yaml:"kafka" doc:"## Ingest Kafka API\nFollowing is the supported API format for the kafka ingest:\n"`
 	IngestGRPCProto    IngestGRPCProto  `yaml:"grpc" doc:"## Ingest GRPC from Network Observability eBPF Agent\nFollowing is the supported API format for the Network Observability eBPF ingest:\n"`
+	IngestStdin        IngestStdin      `yaml:"stdin" doc:"## Ingest Standard Input\nFollowing is the supported API format for the standard input ingest:\n"`
 	TransformGeneric   TransformGeneric `yaml:"generic" doc:"## Transform Generic API\nFollowing is the supported API format for generic transformations:\n"`
 	TransformFilter    TransformFilter  `yaml:"filter" doc:"## Transform Filter API\nFollowing is the supported API format for filter transformations:\n"`
 	TransformNetwork   TransformNetwork `yaml:"network" doc:"## Transform Network API\nFollowing is the supported API format for network transformations:\n"`

--- a/pkg/api/ingest_stdin.go
+++ b/pkg/api/ingest_stdin.go
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2023 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package api
+
+type IngestStdin struct {
+	Decoder Decoder `yaml:"decoder,omitempty" json:"decoder,omitempty" doc:"decoder to use"`
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,6 +91,7 @@ type Ingest struct {
 	Kafka     *api.IngestKafka     `yaml:"kafka,omitempty" json:"kafka,omitempty"`
 	GRPC      *api.IngestGRPCProto `yaml:"grpc,omitempty" json:"grpc,omitempty"`
 	Synthetic *api.IngestSynthetic `yaml:"synthetic,omitempty" json:"synthetic,omitempty"`
+	Stdin     *api.IngestStdin     `yaml:"stdin,omitempty" json:"stdin,omitempty"`
 }
 
 type File struct {

--- a/pkg/pipeline/ingest/ingest_stdin.go
+++ b/pkg/pipeline/ingest/ingest_stdin.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2023 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package ingest
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/decode"
+	pUtils "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	"github.com/sirupsen/logrus"
+)
+
+var slog = logrus.WithField("component", "ingest.Stdin")
+
+type ingestStdin struct {
+	in       chan string
+	eof      chan struct{}
+	exitChan <-chan struct{}
+	metrics  *metrics
+	decoder  decode.Decoder
+}
+
+// Ingest ingests entries from stdin
+func (s *ingestStdin) Ingest(out chan<- config.GenericMap) {
+	slog.Debugf("entering ingestStdin.Ingest")
+	s.metrics.createOutQueueLen(out)
+
+	go s.getStdinInput()
+
+	// process log lines received by stdin
+	s.processLogLines(out)
+}
+
+func (s *ingestStdin) getStdinInput() {
+	scanner := bufio.NewScanner(os.Stdin)
+	// Loop to read lines from stdin until an error or EOF is encountered
+	for scanner.Scan() {
+		s.in <- scanner.Text()
+	}
+
+	// Check for errors
+	if err := scanner.Err(); err != nil {
+		slog.WithError(err).Errorf("Error reading standard input")
+	}
+	close(s.eof)
+}
+
+func (s *ingestStdin) processLogLines(out chan<- config.GenericMap) {
+	for {
+		select {
+		case <-s.exitChan:
+			slog.Debugf("exiting ingestStdin because of signal")
+			return
+		case <-s.eof:
+			slog.Debugf("exiting ingestStdin because of EOF")
+			return
+		case line := <-s.in:
+			s.processRecord(out, line)
+		}
+	}
+}
+
+func (s *ingestStdin) processRecord(out chan<- config.GenericMap, line string) {
+	slog.Debugf("Decoding %s", line)
+	decoded, err := s.decoder.Decode([]byte(line))
+	if err != nil {
+		slog.WithError(err).Warnf("ignoring line %v", line)
+		s.metrics.error("Ignoring line")
+		return
+	}
+	s.metrics.flowsProcessed.Inc()
+	out <- decoded
+}
+
+// NewIngestStdin create a new ingester
+func NewIngestStdin(opMetrics *operational.Metrics, params config.StageParam) (Ingester, error) {
+	slog.Debugf("Entering NewIngestStdin")
+	if params.Ingest == nil || params.Ingest.Stdin == nil || params.Ingest.Stdin.Decoder.Type == "" {
+		return nil, fmt.Errorf("stdin decoder not specified")
+	}
+	decoderType := params.Ingest.Stdin.Decoder.Type
+	if decoderType != api.DecoderName("JSON") {
+		return nil, fmt.Errorf("stdin supports only json decoder. Given decoder type: %v", decoderType)
+	}
+
+	in := make(chan string, channelSize)
+	eof := make(chan struct{})
+	metrics := newMetrics(opMetrics, params.Name, params.Ingest.Type, func() int { return len(in) })
+	decoder, err := decode.GetDecoder(params.Ingest.Stdin.Decoder)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ingestStdin{
+		exitChan: pUtils.ExitChannel(),
+		in:       in,
+		eof:      eof,
+		metrics:  metrics,
+		decoder:  decoder,
+	}, nil
+}

--- a/pkg/pipeline/pipeline_builder.go
+++ b/pkg/pipeline/pipeline_builder.go
@@ -334,6 +334,8 @@ func getIngester(opMetrics *operational.Metrics, params config.StageParam) (inge
 		ingester, err = ingest.NewIngestSynthetic(opMetrics, params)
 	case api.CollectorType:
 		ingester, err = ingest.NewIngestCollector(opMetrics, params)
+	case api.StdinType:
+		ingester, err = ingest.NewIngestStdin(opMetrics, params)
 	case api.KafkaType:
 		ingester, err = ingest.NewIngestKafka(opMetrics, params)
 	case api.GRPCType:


### PR DESCRIPTION
This PR adds a standard input ingester.
Currently it supports only json formats and assumes each line corresponds to a flowlog.
Closes #486.

Simple configuration to test it:
```
cat << EOF > ./conf.yaml
log-level: trace
metricsSettings:
  prefix: flp_operational_
pipeline:
  - name: ingest_stdin
  - name: write_stdout
    follows: ingest_stdin
parameters:
  - name: ingest_stdin
    ingest:
      type: stdin
      stdin:
        decoder:
          type: json
  - name: write_stdout
    write:
      type: stdout
      stdout:
        format: fields
EOF
```

Run FLP:
```
./flowlogs-pipeline --config conf.yaml
```
and type:
```
{"SrcIP":"0.0.0.0"}
```


This also allows Unix pipeline:
```
echo -e '{"SrcIP":"0.0.0.0"}\n{"DstIP":"1.2.3.4"}'  | ./flowlogs-pipeline --config conf.yaml
```