### PR TITLE
NETOBSERV-1222: create PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Description
+
+<!-- Fill-in description here -->
+
+## Dependencies
+
+<!-- List here any related PRs with links, that need to be pulled also for testing -->
+n/a
+
+## Checklist
+
+If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.
+
+* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
+* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
+* [ ] Does this PR require product documentation?
+  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
+* [ ] Does this PR require a product release notes entry?
+  * [ ] If so, fill in "Release Note Text" in the JIRA.
+* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
+  * [ ] If so, make sure it is described in the JIRA ticket.
+* QE requirements (check 1 from the list):
+  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
+  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
+  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).


### PR DESCRIPTION
FYI @KalmanMeth @ronensc , not sure if you were aware of this planned change: we're adding this PR template to help guiding contributors through the processes, across all repos used in operator context. 