### PR TITLE
NETOBSERV-1231: Improve promencode API: scaling & filters

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -13,13 +13,24 @@ Following is the supported API format for prometheus encode:
                      agg_histogram: counts samples in configurable buckets, pre-aggregated via an Aggregate stage
                  filter: an optional criterion to filter entries by. Deprecated: use filters instead.
                      key: the key to match and filter by
-                     value: the value to match and filter by. Use !nil / nil to match presence / absence. Add multiple matching values using '|' rune such as 'a|b' to match either 'a' or 'b'.
+                     value: the value to match and filter by
+                     type: (enum) the type of filter match: exact (default), presence, absence or regex
+                         exact: match exactly the provided fitler value
+                         presence: filter key must be present (filter value is ignored)
+                         absence: filter key must be absent (filter value is ignored)
+                         regex: match filter value as a regular expression
                  filters: a list of criteria to filter entries by
                          key: the key to match and filter by
-                         value: the value to match and filter by. Use !nil / nil to match presence / absence. Add multiple matching values using '|' rune such as 'a|b' to match either 'a' or 'b'.
+                         value: the value to match and filter by
+                         type: (enum) the type of filter match: exact (default), presence, absence or regex
+                             exact: match exactly the provided fitler value
+                             presence: filter key must be present (filter value is ignored)
+                             absence: filter key must be absent (filter value is ignored)
+                             regex: match filter value as a regular expression
                  valueKey: entry key from which to resolve metric value
                  labels: labels to be associated with the metric
                  buckets: histogram buckets
+                 valueScale: scale factor of the value (MetricVal := FlowVal / Scale)
          prefix: prefix added to each metric name
          expiryTime: time duration of no-flow to wait before deleting prometheus data item
          maxMetrics: maximum number of metrics to report (default: unlimited)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -46,6 +46,10 @@ const (
 	AddServiceRuleType           = "add_service"
 	AddKubernetesRuleType        = "add_kubernetes"
 	ReinterpretDirectionRuleType = "reinterpret_direction"
+	PromFilterExact              = "exact"
+	PromFilterPresence           = "presence"
+	PromFilterAbsence            = "absence"
+	PromFilterRegex              = "regex"
 
 	TagYaml = "yaml"
 	TagDoc  = "doc"

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -41,13 +41,14 @@ func PromEncodeOperationName(operation string) string {
 }
 
 type PromMetricsItem struct {
-	Name     string              `yaml:"name" json:"name" doc:"the metric name"`
-	Type     string              `yaml:"type" json:"type" enum:"PromEncodeOperationEnum" doc:"one of the following:"`
-	Filter   PromMetricsFilter   `yaml:"filter,omitempty" json:"filter,omitempty" doc:"an optional criterion to filter entries by. Deprecated: use filters instead."`
-	Filters  []PromMetricsFilter `yaml:"filters" json:"filters" doc:"a list of criteria to filter entries by"`
-	ValueKey string              `yaml:"valueKey" json:"valueKey" doc:"entry key from which to resolve metric value"`
-	Labels   []string            `yaml:"labels" json:"labels" doc:"labels to be associated with the metric"`
-	Buckets  []float64           `yaml:"buckets" json:"buckets" doc:"histogram buckets"`
+	Name       string              `yaml:"name" json:"name" doc:"the metric name"`
+	Type       string              `yaml:"type" json:"type" enum:"PromEncodeOperationEnum" doc:"one of the following:"`
+	Filter     PromMetricsFilter   `yaml:"filter,omitempty" json:"filter,omitempty" doc:"an optional criterion to filter entries by. Deprecated: use filters instead."`
+	Filters    []PromMetricsFilter `yaml:"filters" json:"filters" doc:"a list of criteria to filter entries by"`
+	ValueKey   string              `yaml:"valueKey" json:"valueKey" doc:"entry key from which to resolve metric value"`
+	Labels     []string            `yaml:"labels" json:"labels" doc:"labels to be associated with the metric"`
+	Buckets    []float64           `yaml:"buckets" json:"buckets" doc:"histogram buckets"`
+	ValueScale float64             `yaml:"valueScale" json:"valueScale" doc:"scale factor of the value (MetricVal := FlowVal / Scale)"`
 }
 
 func (i *PromMetricsItem) GetFilters() []PromMetricsFilter {
@@ -61,5 +62,17 @@ type PromMetricsItems []PromMetricsItem
 
 type PromMetricsFilter struct {
 	Key   string `yaml:"key" json:"key" doc:"the key to match and filter by"`
-	Value string `yaml:"value" json:"value" doc:"the value to match and filter by. Use !nil / nil to match presence / absence. Add multiple matching values using '|' rune such as 'a|b' to match either 'a' or 'b'."`
+	Value string `yaml:"value" json:"value" doc:"the value to match and filter by"`
+	Type  string `yaml:"type" json:"type" enum:"PromEncodeFilterTypeEnum" doc:"the type of filter match: exact (default), presence, absence or regex"`
+}
+
+type PromEncodeFilterTypeEnum struct {
+	Exact    string `yaml:"exact" json:"exact" doc:"match exactly the provided fitler value"`
+	Presence string `yaml:"presence" json:"presence" doc:"filter key must be present (filter value is ignored)"`
+	Absence  string `yaml:"absence" json:"absence" doc:"filter key must be absent (filter value is ignored)"`
+	Regex    string `yaml:"regex" json:"regex" doc:"match filter value as a regular expression"`
+}
+
+func PromEncodeFilterTypeName(t string) string {
+	return GetEnumName(PromEncodeFilterTypeEnum{}, t)
 }

--- a/pkg/api/enum.go
+++ b/pkg/api/enum.go
@@ -24,6 +24,7 @@ import (
 
 type enums struct {
 	PromEncodeOperationEnum       PromEncodeOperationEnum
+	PromEncodeFilterTypeEnum      PromEncodeFilterTypeEnum
 	TransformNetworkOperationEnum TransformNetworkOperationEnum
 	TransformFilterOperationEnum  TransformFilterOperationEnum
 	TransformGenericOperationEnum TransformGenericOperationEnum

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -166,7 +166,7 @@ func TestKafkaPromPipeline(t *testing.T) {
 
 	b, err = json.Marshal(params[4])
 	require.NoError(t, err)
-	require.JSONEq(t, `{"name":"prom","encode":{"type":"prom","prom":{"expiryTime":"50s", "metrics":[{"name":"connections_per_source_as","type":"counter","filter":{"key":"","value":""},"filters":[{"key":"name","value":"src_as_connection_count"}],"valueKey":"recent_count","labels":["by","aggregate"],"buckets":[]}],"prefix":"flp_"}}}`, string(b))
+	require.JSONEq(t, `{"name":"prom","encode":{"type":"prom","prom":{"expiryTime":"50s", "metrics":[{"name":"connections_per_source_as","type":"counter","filter":{"key":"","type":"","value":""},"filters":[{"key":"name","type":"","value":"src_as_connection_count"}],"valueKey":"recent_count","valueScale":0,"labels":["by","aggregate"],"buckets":[]}],"prefix":"flp_"}}}`, string(b))
 }
 
 func TestForkPipeline(t *testing.T) {

--- a/pkg/pipeline/encode/encode_prom_metric.go
+++ b/pkg/pipeline/encode/encode_prom_metric.go
@@ -1,0 +1,82 @@
+package encode
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+)
+
+type predicate func(flow config.GenericMap) bool
+
+type metricInfo struct {
+	api.PromMetricsItem
+	filterPredicates []predicate
+}
+
+func presence(filter api.PromMetricsFilter) predicate {
+	return func(flow config.GenericMap) bool {
+		_, found := flow[filter.Key]
+		return found
+	}
+}
+
+func absence(filter api.PromMetricsFilter) predicate {
+	return func(flow config.GenericMap) bool {
+		_, found := flow[filter.Key]
+		return !found
+	}
+}
+
+func exact(filter api.PromMetricsFilter) predicate {
+	return func(flow config.GenericMap) bool {
+		if val, found := flow[filter.Key]; found {
+			sVal, ok := val.(string)
+			if !ok {
+				sVal = fmt.Sprint(val)
+			}
+			return sVal == filter.Value
+		}
+		return false
+	}
+}
+
+func regex(filter api.PromMetricsFilter) predicate {
+	r, _ := regexp.Compile(filter.Value)
+	return func(flow config.GenericMap) bool {
+		if val, found := flow[filter.Key]; found {
+			sVal, ok := val.(string)
+			if !ok {
+				sVal = fmt.Sprint(val)
+			}
+			return r.MatchString(sVal)
+		}
+		return false
+	}
+}
+
+func filterToPredicate(filter api.PromMetricsFilter) predicate {
+	switch filter.Type {
+	case api.PromFilterExact:
+		return exact(filter)
+	case api.PromFilterPresence:
+		return presence(filter)
+	case api.PromFilterAbsence:
+		return absence(filter)
+	case api.PromFilterRegex:
+		return regex(filter)
+	}
+	// Default = exact
+	return exact(filter)
+}
+
+func CreateMetricInfo(def api.PromMetricsItem) *metricInfo {
+	mi := metricInfo{
+		PromMetricsItem: def,
+	}
+	for _, f := range def.GetFilters() {
+		mi.filterPredicates = append(mi.filterPredicates, filterToPredicate(f))
+	}
+	return &mi
+}

--- a/pkg/pipeline/encode/encode_prom_test.go
+++ b/pkg/pipeline/encode/encode_prom_test.go
@@ -523,7 +523,7 @@ func buildFlow() config.GenericMap {
 	}
 }
 
-func hundredFlows() []config.GenericMap {
+func thousandsFlows() []config.GenericMap {
 	flows := make([]config.GenericMap, 1000)
 	for i := 0; i < 1000; i++ {
 		flows[i] = buildFlow()
@@ -573,7 +573,7 @@ func BenchmarkPromEncode(b *testing.B) {
 	require.NoError(b, err)
 
 	for i := 0; i < b.N; i++ {
-		for _, metric := range hundredFlows() {
+		for _, metric := range thousandsFlows() {
 			prom.Encode(metric)
 		}
 	}

--- a/pkg/pipeline/encode/encode_prom_test.go
+++ b/pkg/pipeline/encode/encode_prom_test.go
@@ -306,7 +306,7 @@ func Test_FilterNotNil(t *testing.T) {
 				Name:     "latencies",
 				Type:     "histogram",
 				ValueKey: "latency",
-				Filters:  []api.PromMetricsFilter{{Key: "latency", Value: "!nil"}},
+				Filters:  []api.PromMetricsFilter{{Key: "latency", Type: "presence"}},
 			},
 		},
 	}
@@ -361,7 +361,7 @@ func Test_FilterDirection(t *testing.T) {
 				Name:     "ingress_or_inner_packets_total",
 				Type:     "counter",
 				ValueKey: "packets",
-				Filters:  []api.PromMetricsFilter{{Key: "dir", Value: "0|2"}},
+				Filters:  []api.PromMetricsFilter{{Key: "dir", Value: "0|2", Type: "regex"}},
 			},
 		},
 	}
@@ -378,6 +378,45 @@ func Test_FilterDirection(t *testing.T) {
 	require.Contains(t, exposed, `test_ingress_packets_total 10`)
 	require.Contains(t, exposed, `test_egress_packets_total 100`)
 	require.Contains(t, exposed, `test_ingress_or_inner_packets_total 1010`)
+}
+
+func Test_ValueScale(t *testing.T) {
+	metrics := []config.GenericMap{{"rtt": 15_000_000} /*15ms*/, {"rtt": 110_000_000} /*110ms*/}
+	params := api.PromEncode{
+		Prefix:     "test_",
+		ExpiryTime: api.Duration{Duration: time.Duration(60 * time.Second)},
+		Metrics: []api.PromMetricsItem{
+			{
+				Name:       "rtt_seconds",
+				Type:       "histogram",
+				ValueKey:   "rtt",
+				ValueScale: 1_000_000_000,
+			},
+		},
+	}
+
+	encodeProm, err := initProm(&params)
+	require.NoError(t, err)
+	for _, metric := range metrics {
+		encodeProm.Encode(metric)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	exposed := test.ReadExposedMetrics(t)
+
+	// One is less than 25ms, Two are less than 250ms
+	require.Contains(t, exposed, `test_rtt_seconds_bucket{le="0.005"} 0`)
+	require.Contains(t, exposed, `test_rtt_seconds_bucket{le="0.01"} 0`)
+	require.Contains(t, exposed, `test_rtt_seconds_bucket{le="0.025"} 1`)
+	require.Contains(t, exposed, `test_rtt_seconds_bucket{le="0.05"} 1`)
+	require.Contains(t, exposed, `test_rtt_seconds_bucket{le="0.1"} 1`)
+	require.Contains(t, exposed, `test_rtt_seconds_bucket{le="0.25"} 2`)
+	require.Contains(t, exposed, `test_rtt_seconds_bucket{le="0.5"} 2`)
+	require.Contains(t, exposed, `test_rtt_seconds_bucket{le="1"} 2`)
+	require.Contains(t, exposed, `test_rtt_seconds_bucket{le="2.5"} 2`)
+	require.Contains(t, exposed, `test_rtt_seconds_bucket{le="5"} 2`)
+	require.Contains(t, exposed, `test_rtt_seconds_bucket{le="10"} 2`)
+	require.Contains(t, exposed, `test_rtt_seconds_bucket{le="+Inf"} 2`)
 }
 
 func Test_MetricTTL(t *testing.T) {
@@ -485,8 +524,8 @@ func buildFlow() config.GenericMap {
 }
 
 func hundredFlows() []config.GenericMap {
-	flows := make([]config.GenericMap, 100)
-	for i := 0; i < 100; i++ {
+	flows := make([]config.GenericMap, 1000)
+	for i := 0; i < 1000; i++ {
 		flows[i] = buildFlow()
 	}
 	return flows
@@ -503,11 +542,24 @@ func BenchmarkPromEncode(b *testing.B) {
 			Type:     "counter",
 			ValueKey: "bytes",
 			Labels:   []string{"srcIP", "dstIP"},
+			Filters: []api.PromMetricsFilter{
+				{
+					Key:   "srcIP",
+					Value: "10.0.0.10|10.0.0.11|10.0.0.12",
+					Type:  "regex",
+				},
+			},
 		}, {
 			Name:     "packets_total",
 			Type:     "counter",
 			ValueKey: "packets",
 			Labels:   []string{"srcIP", "dstIP"},
+			Filters: []api.PromMetricsFilter{
+				{
+					Key:   "srcIP",
+					Value: "10.0.0.10",
+				},
+			},
 		}, {
 			Name:     "latency_seconds",
 			Type:     "histogram",


### PR DESCRIPTION
- New ValueScale config to allow scale conversion, e.g. RTT ns to seconds
- To avoid having reserved characters or words in filters, use a dedicated API instead: new setting Filter.Type (exact,presence,absence or regex)
- Pre-compute regex by setting up a "predicate" function per filter

**Breaking-change** : metrics currently defining filters such as "FlowDirection: 0|2" must be adapted with the new Filter Type API

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
