### PR TITLE
Fix crash when metrics settings are unset

### DIFF
--- a/pkg/confgen/flowlogs2metrics_config.go
+++ b/pkg/confgen/flowlogs2metrics_config.go
@@ -68,7 +68,7 @@ func (cg *ConfGen) GenerateFlowlogs2PipelineConfig() *config.ConfigFileStruct {
 		Pipeline:   pipeline.GetStages(),
 		Parameters: pipeline.GetStageParams(),
 		MetricsSettings: config.MetricsSettings{
-			PromConnectionInfo: &api.PromConnectionInfo{Port: 9102},
+			PromConnectionInfo: api.PromConnectionInfo{Port: 9102},
 			Prefix:             "flp_op_",
 		},
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,7 +55,7 @@ type Profile struct {
 // Also, currently FLP doesn't support defining more than one PromEncode stage. If this feature is added later, these global settings
 // will help configuring common setting for all PromEncode stages - PromEncode settings would then act as overrides.
 type MetricsSettings struct {
-	*api.PromConnectionInfo
+	api.PromConnectionInfo
 	Prefix            string `yaml:"prefix,omitempty" json:"prefix,omitempty" doc:"prefix for names of the operational metrics"`
 	NoPanic           bool   `yaml:"noPanic,omitempty" json:"noPanic,omitempty"`
 	SuppressGoMetrics bool   `yaml:"suppressGoMetrics,omitempty" json:"suppressGoMetrics,omitempty" doc:"filter out Go and process metrics"`
@@ -154,7 +154,7 @@ func ParseConfig(opts Options) (ConfigFileStruct, error) {
 		}
 		logrus.Debugf("metrics settings = %v ", out.MetricsSettings)
 	} else {
-		logrus.Errorf("metrics settings missing")
+		logrus.Infof("using default metrics settings")
 	}
 
 	return out, nil


### PR DESCRIPTION
It's panic'ing with:
panic: runtime error: invalid memory address or nil pointer dereference

Due to ConnectionInfo being a pointer

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
