### PR TITLE
NETOBSERV-1451: Bump ubi 9.3 / go 1.21

### DIFF
--- a/.github/workflows/pull_request_e2e.yml
+++ b/.github/workflows/pull_request_e2e.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.20']
+        go: ['1.21']
         
     steps:
     - name: install make

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.20']
+        go: ['1.21']
     steps:
       - name: install make
         run: sudo apt-get install make

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.20']
+        go: ['1.21']
     steps:
       - name: checkout
         uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ OCI_BUILD_OPTS ?=
 OCI_BIN_PATH = $(shell which docker 2>/dev/null || which podman)
 OCI_BIN ?= $(shell basename ${OCI_BIN_PATH})
 
-MIN_GO_VERSION := 1.19.0
+MIN_GO_VERSION := 1.20.0
 FLP_BIN_FILE=flowlogs-pipeline
 CG_BIN_FILE=confgenerator
 NETFLOW_GENERATOR=nflow-generator

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,7 +1,7 @@
 # We do not use --platform feature to auto fill this ARG because of incompatibility between podman and docker
 ARG TARGETPLATFORM=linux/amd64
 ARG BUILDPLATFORM=linux/amd64
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.20 as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.21 as builder
 
 ARG TARGETPLATFORM
 ARG TARGETARCH=amd64
@@ -22,7 +22,7 @@ RUN git status --porcelain
 RUN GOARCH=$TARGETARCH make build_code
 
 # final stage
-FROM  --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:9.2
+FROM  --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 
 COPY --from=builder /app/flowlogs-pipeline /app/
 COPY --from=builder /app/confgenerator /app/

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netobserv/flowlogs-pipeline
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
