### PR TITLE
use unknown for interface we can't detect instead of "" 

### DIFF
--- a/vendor/github.com/netobserv/netobserv-ebpf-agent/pkg/utils/utils.go
+++ b/vendor/github.com/netobserv/netobserv-ebpf-agent/pkg/utils/utils.go
@@ -95,7 +95,7 @@ func utsnameStr[T int8 | uint8](in []T) string {
 func GetInterfaceName(ifIndex uint32) string {
 	iface, err := net.InterfaceByIndex(int(ifIndex))
 	if err != nil {
-		return ""
+		return "unknown"
 	}
 	return iface.Name
 }


### PR DESCRIPTION
## Description

need to be consistent when can't find interface name and always use unknown string


## Dependencies
https://github.com/netobserv/netobserv-ebpf-agent/pull/250

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
