### PR TITLE
NETOBSERV-1203: Added option to add zones in k8s transform rule

### DIFF
--- a/pkg/api/transform_network.go
+++ b/pkg/api/transform_network.go
@@ -69,12 +69,17 @@ type NetworkTransformRule struct {
 	Parameters      string        `yaml:"parameters,omitempty" json:"parameters,omitempty" doc:"parameters specific to type"`
 	Assignee        string        `yaml:"assignee,omitempty" json:"assignee,omitempty" doc:"value needs to assign to output field"`
 	KubernetesInfra *K8sInfraRule `yaml:"kubernetes_infra,omitempty" json:"kubernetes_infra,omitempty" doc:"Kubernetes infra rule specific configuration"`
+	Kubernetes      *K8sRule      `yaml:"kubernetes,omitempty" json:"kubernetes,omitempty" doc:"Kubernetes rule specific configuration"`
 }
 
 type K8sInfraRule struct {
 	Inputs      []string `yaml:"inputs,omitempty" json:"inputs,omitempty" doc:"entry inputs fields"`
 	Output      string   `yaml:"output,omitempty" json:"output,omitempty" doc:"entry output field"`
 	InfraPrefix string   `yaml:"infra_prefixes,omitempty" json:"infra_prefixes,omitempty" doc:"Namespace prefixes that will be tagged as infra"`
+}
+
+type K8sRule struct {
+	AddZone bool `yaml:"add_zone,omitempty" json:"add_zone,omitempty" doc:"If true the rule will add the zone"`
 }
 
 type NetworkTransformDirectionInfo struct {

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -148,7 +148,7 @@ func fillInK8s(outputEntry config.GenericMap, rule api.NetworkTransformRule) {
 				outputEntry[rule.Output+"_HostName"] = kubeInfo.HostName
 			}
 		}
-		fillInK8sZone(outputEntry, rule, *kubeInfo)
+		fillInK8sZone(outputEntry, rule, *kubeInfo, "_Zone")
 	} else {
 		// NOTE: Some of these fields are taken from opentelemetry specs.
 		// See https://opentelemetry.io/docs/specs/semconv/resource/k8s/
@@ -182,12 +182,13 @@ func fillInK8s(outputEntry config.GenericMap, rule api.NetworkTransformRule) {
 				outputEntry[rule.Output+"k8s.host.name"] = kubeInfo.HostName
 			}
 		}
+		fillInK8sZone(outputEntry, rule, *kubeInfo, "k8s.zone")
 	}
 }
 
 const nodeZoneLabelName = "topology.kubernetes.io/zone"
 
-func fillInK8sZone(outputEntry config.GenericMap, rule api.NetworkTransformRule, kubeInfo kubernetes.Info) {
+func fillInK8sZone(outputEntry config.GenericMap, rule api.NetworkTransformRule, kubeInfo kubernetes.Info, zonePrefix string) {
 	if rule.Kubernetes == nil || !rule.Kubernetes.AddZone {
 		//Nothing to do
 		return
@@ -196,7 +197,7 @@ func fillInK8sZone(outputEntry config.GenericMap, rule api.NetworkTransformRule,
 	case kubernetes.TypeNode:
 		zone, ok := kubeInfo.Labels[nodeZoneLabelName]
 		if ok {
-			outputEntry[rule.Output+"_Zone"] = zone
+			outputEntry[rule.Output+zonePrefix] = zone
 		}
 		return
 	case kubernetes.TypePod:
@@ -208,7 +209,7 @@ func fillInK8sZone(outputEntry config.GenericMap, rule api.NetworkTransformRule,
 		if nodeInfo != nil {
 			zone, ok := nodeInfo.Labels[nodeZoneLabelName]
 			if ok {
-				outputEntry[rule.Output+"_Zone"] = zone
+				outputEntry[rule.Output+zonePrefix] = zone
 			}
 		}
 		return

--- a/pkg/pipeline/transform/transform_network_test.go
+++ b/pkg/pipeline/transform/transform_network_test.go
@@ -242,6 +242,10 @@ func (*fakeKubeData) GetInfo(n string) (*kubernetes.Info, error) {
 	return nil, errors.New("notFound")
 }
 
+func (*fakeKubeData) GetNodeInfo(n string) (*kubernetes.Info, error) {
+	return nil, nil
+}
+
 func Test_Categorize(t *testing.T) {
 	entry := config.GenericMap{
 		"addr1": "10.1.2.3",


### PR DESCRIPTION
## Description

Zones are added to the flows if the rule is configured with the new addZone bool.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
