### PR TITLE
NETOBSERV-1308: fix minor vulnerabilities with location db

### DIFF
--- a/pkg/pipeline/transform/location/location_test.go
+++ b/pkg/pipeline/transform/location/location_test.go
@@ -46,7 +46,7 @@ func Test_InitLocationDB(t *testing.T) {
 	_dbURL = "test_fake"
 	err = InitLocationDB()
 	require.Contains(t, err.Error(), "http.Get")
-	_dbURL = DbUrl
+	_dbURL = dbUrl
 	_osio.Stat = os.Stat
 	_osio.Create = os.Create
 
@@ -60,11 +60,11 @@ func Test_InitLocationDB(t *testing.T) {
 	err = InitLocationDB()
 	require.Contains(t, err.Error(), "io.Copy")
 	testServer.Close()
-	_dbURL = DbUrl
+	_dbURL = dbUrl
 	_osio.Stat = os.Stat
 	_osio.Create = os.Create
 
-	// fail in out.Close
+	// fail again in io.Copy
 	_osio.Stat = func(name string) (os.FileInfo, error) { return nil, os.ErrNotExist }
 	_osio.Create = func(name string) (*os.File, error) { return nil, nil }
 	testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -72,9 +72,9 @@ func Test_InitLocationDB(t *testing.T) {
 	}))
 	_dbURL = testServer.URL
 	err = InitLocationDB()
-	require.Contains(t, err.Error(), "out.Close")
+	require.Contains(t, err.Error(), "io.Copy")
 	testServer.Close()
-	_dbURL = DbUrl
+	_dbURL = dbUrl
 	_osio.Stat = os.Stat
 	_osio.Create = os.Create
 
@@ -88,14 +88,14 @@ func Test_InitLocationDB(t *testing.T) {
 	err = InitLocationDB()
 	require.Contains(t, err.Error(), "failed unzip")
 	testServer.Close()
-	_dbURL = DbUrl
+	_dbURL = dbUrl
 	_osio.Stat = os.Stat
 
 	// fail in OpenDB
 	_osio.Stat = func(name string) (os.FileInfo, error) { return nil, os.ErrNotExist }
 	buf := new(bytes.Buffer)
 	zipWriter := zip.NewWriter(buf)
-	_, _ = zipWriter.Create(DBFilename)
+	_, _ = zipWriter.Create(dbFilename)
 	zipWriter.Close()
 	testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		_, _ = res.Write(buf.Bytes())
@@ -105,12 +105,12 @@ func Test_InitLocationDB(t *testing.T) {
 	err = InitLocationDB()
 	require.Error(t, err)
 	testServer.Close()
-	_dbURL = DbUrl
+	_dbURL = dbUrl
 	_osio.Stat = os.Stat
 	// success
 	// NOTE:: Downloading the DB is a long operation, about 30 seconds, and this delays the tests
 	// TODO: Consider remove this test
-	os.RemoveAll(DBFileLocation)
+	os.RemoveAll(dbFileLocation)
 	initLocationDBErr := InitLocationDB()
 	require.Nil(t, initLocationDBErr)
 }


### PR DESCRIPTION
- Do not use Insecure TLS
- Add client timeout
- Unexport a few variables

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
