### PR TITLE
Adding k8s unit tests and some refactoring

### DIFF
--- a/cmd/flowlogs-pipeline/main_test.go
+++ b/cmd/flowlogs-pipeline/main_test.go
@@ -46,9 +46,9 @@ func TestTheMain(t *testing.T) {
 
 func TestPipelineConfigSetup(t *testing.T) {
 	// Kube init mock
-	kdata := new(kubernetes.KubeDataMock)
+	kdata := new(kubernetes.InformersMock)
 	kdata.On("InitFromConfig", "").Return(nil)
-	kubernetes.Data = kdata
+	kubernetes.MockInformers(kdata)
 
 	js := `{
     "PipeLine": "[{\"name\":\"grpc\"},{\"follows\":\"grpc\",\"name\":\"enrich\"},{\"follows\":\"enrich\",\"name\":\"loki\"},{\"follows\":\"enrich\",\"name\":\"prometheus\"}]",

--- a/pkg/pipeline/transform/kubernetes/enrich.go
+++ b/pkg/pipeline/transform/kubernetes/enrich.go
@@ -1,0 +1,160 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+var log = logrus.WithField("component", "transform.Network.Kubernetes")
+
+func InitFromConfig(kubeConfigPath string) error {
+	return informers.initFromConfig(kubeConfigPath)
+}
+
+// For testing
+func MockInformers(m *InformersMock) {
+	informers = m
+}
+
+func Enrich(outputEntry config.GenericMap, rule api.NetworkTransformRule) {
+	kubeInfo, err := informers.getInfo(fmt.Sprintf("%s", outputEntry[rule.Input]))
+	if err != nil {
+		logrus.WithError(err).Tracef("can't find kubernetes info for IP %v", outputEntry[rule.Input])
+		return
+	}
+	if rule.Assignee != "otel" {
+		// NETOBSERV-666: avoid putting empty namespaces or Loki aggregation queries will
+		// differentiate between empty and nil namespaces.
+		if kubeInfo.Namespace != "" {
+			outputEntry[rule.Output+"_Namespace"] = kubeInfo.Namespace
+		}
+		outputEntry[rule.Output+"_Name"] = kubeInfo.Name
+		outputEntry[rule.Output+"_Type"] = kubeInfo.Type
+		outputEntry[rule.Output+"_OwnerName"] = kubeInfo.Owner.Name
+		outputEntry[rule.Output+"_OwnerType"] = kubeInfo.Owner.Type
+		if rule.Parameters != "" {
+			for labelKey, labelValue := range kubeInfo.Labels {
+				outputEntry[rule.Parameters+"_"+labelKey] = labelValue
+			}
+		}
+		if kubeInfo.HostIP != "" {
+			outputEntry[rule.Output+"_HostIP"] = kubeInfo.HostIP
+			if kubeInfo.HostName != "" {
+				outputEntry[rule.Output+"_HostName"] = kubeInfo.HostName
+			}
+		}
+		fillInK8sZone(outputEntry, rule, *kubeInfo, "_Zone")
+	} else {
+		// NOTE: Some of these fields are taken from opentelemetry specs.
+		// See https://opentelemetry.io/docs/specs/semconv/resource/k8s/
+		// Other fields (not specified in the specs) are named similarly
+		if kubeInfo.Namespace != "" {
+			outputEntry[rule.Output+"k8s.namespace.name"] = kubeInfo.Namespace
+		}
+		switch kubeInfo.Type {
+		case TypeNode:
+			outputEntry[rule.Output+"k8s.node.name"] = kubeInfo.Name
+			outputEntry[rule.Output+"k8s.node.uid"] = kubeInfo.UID
+		case TypePod:
+			outputEntry[rule.Output+"k8s.pod.name"] = kubeInfo.Name
+			outputEntry[rule.Output+"k8s.pod.uid"] = kubeInfo.UID
+		case TypeService:
+			outputEntry[rule.Output+"k8s.service.name"] = kubeInfo.Name
+			outputEntry[rule.Output+"k8s.service.uid"] = kubeInfo.UID
+		}
+		outputEntry[rule.Output+"k8s.name"] = kubeInfo.Name
+		outputEntry[rule.Output+"k8s.type"] = kubeInfo.Type
+		outputEntry[rule.Output+"k8s.owner.name"] = kubeInfo.Owner.Name
+		outputEntry[rule.Output+"k8s.owner.type"] = kubeInfo.Owner.Type
+		if rule.Parameters != "" {
+			for labelKey, labelValue := range kubeInfo.Labels {
+				outputEntry[rule.Parameters+"."+labelKey] = labelValue
+			}
+		}
+		if kubeInfo.HostIP != "" {
+			outputEntry[rule.Output+"k8s.host.ip"] = kubeInfo.HostIP
+			if kubeInfo.HostName != "" {
+				outputEntry[rule.Output+"k8s.host.name"] = kubeInfo.HostName
+			}
+		}
+		fillInK8sZone(outputEntry, rule, *kubeInfo, "k8s.zone")
+	}
+}
+
+const nodeZoneLabelName = "topology.kubernetes.io/zone"
+
+func fillInK8sZone(outputEntry config.GenericMap, rule api.NetworkTransformRule, kubeInfo Info, zonePrefix string) {
+	if rule.Kubernetes == nil || !rule.Kubernetes.AddZone {
+		//Nothing to do
+		return
+	}
+	switch kubeInfo.Type {
+	case TypeNode:
+		zone, ok := kubeInfo.Labels[nodeZoneLabelName]
+		if ok {
+			outputEntry[rule.Output+zonePrefix] = zone
+		}
+		return
+	case TypePod:
+		nodeInfo, err := informers.getNodeInfo(kubeInfo.HostName)
+		if err != nil {
+			logrus.WithError(err).Tracef("can't find nodes info for node %v", kubeInfo.HostName)
+			return
+		}
+		if nodeInfo != nil {
+			zone, ok := nodeInfo.Labels[nodeZoneLabelName]
+			if ok {
+				outputEntry[rule.Output+zonePrefix] = zone
+			}
+		}
+		return
+
+	case TypeService:
+		//A service is not assigned to a dedicated zone, skipping
+		return
+	}
+}
+
+func EnrichLayer(outputEntry config.GenericMap, rule api.NetworkTransformRule) {
+	if rule.KubernetesInfra == nil {
+		logrus.Error("transformation rule: Missing Kubernetes Infra configuration ")
+		return
+	}
+	outputEntry[rule.KubernetesInfra.Output] = "infra"
+	for _, input := range rule.KubernetesInfra.Inputs {
+		if objectIsApp(fmt.Sprintf("%s", outputEntry[input]), rule.KubernetesInfra.InfraPrefix) {
+			outputEntry[rule.KubernetesInfra.Output] = "app"
+			return
+		}
+	}
+}
+
+const openshiftNamespacePrefix = "openshift-"
+const openshiftPrefixLen = len(openshiftNamespacePrefix)
+
+func objectIsApp(addr string, additionalInfraPrefix string) bool {
+	obj, err := informers.getInfo(addr)
+	if err != nil {
+		logrus.WithError(err).Tracef("can't find kubernetes info for IP %s", addr)
+		return false
+	}
+	nsLen := len(obj.Namespace)
+	additionalPrefixLen := len(additionalInfraPrefix)
+	if nsLen == 0 {
+		return false
+	}
+	if nsLen >= openshiftPrefixLen && obj.Namespace[:openshiftPrefixLen] == openshiftNamespacePrefix {
+		return false
+	}
+	if nsLen >= additionalPrefixLen && obj.Namespace[:additionalPrefixLen] == additionalInfraPrefix {
+		return false
+	}
+	//Special case with openshift and kubernetes service in default namespace
+	if obj.Namespace == "default" && (obj.Name == "kubernetes" || obj.Name == "openshift") {
+		return false
+	}
+	return true
+}

--- a/pkg/pipeline/transform/kubernetes/enrich_test.go
+++ b/pkg/pipeline/transform/kubernetes/enrich_test.go
@@ -1,0 +1,316 @@
+package kubernetes
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var info = map[string]*Info{
+	"1.2.3.4": nil,
+	"10.0.0.1": {
+		ips: []string{"10.0.0.1"},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "ns-1",
+		},
+		Type:     "Pod",
+		HostName: "host-1",
+		HostIP:   "100.0.0.1",
+	},
+	"10.0.0.2": {
+		ips: []string{"10.0.0.2"},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "pod-2",
+			Namespace: "ns-2",
+		},
+		Type:     "Pod",
+		HostName: "host-2",
+		HostIP:   "100.0.0.2",
+	},
+	"20.0.0.1": {
+		ips: []string{"20.0.0.1"},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "service-1",
+			Namespace: "ns-1",
+		},
+		Type: "Service",
+	},
+}
+
+var nodes = map[string]*Info{
+	"host-1": {
+		ips: []string{"100.0.0.1"},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "host-1",
+			Labels: map[string]string{
+				nodeZoneLabelName: "us-east-1a",
+			},
+		},
+		Type: "Node",
+	},
+	"host-2": {
+		ips: []string{"100.0.0.2"},
+		ObjectMeta: v1.ObjectMeta{
+			Name: "host-2",
+			Labels: map[string]string{
+				nodeZoneLabelName: "us-east-1b",
+			},
+		},
+		Type: "Node",
+	},
+}
+
+var rules = api.NetworkTransformRules{
+	{
+		Type:   api.OpAddKubernetes,
+		Input:  "SrcAddr",
+		Output: "SrcK8s",
+		Kubernetes: &api.K8sRule{
+			AddZone: true,
+		},
+	},
+	{
+		Type:   api.OpAddKubernetes,
+		Input:  "DstAddr",
+		Output: "DstK8s",
+		Kubernetes: &api.K8sRule{
+			AddZone: true,
+		},
+	},
+}
+
+func TestEnrich(t *testing.T) {
+	informers = &fakeInformers{}
+
+	// Pod to unknown
+	entry := config.GenericMap{
+		"SrcAddr": "10.0.0.1",    // pod-1
+		"DstAddr": "42.42.42.42", // unknown
+	}
+	for _, r := range rules {
+		Enrich(entry, r)
+	}
+	assert.Equal(t, config.GenericMap{
+		"DstAddr":          "42.42.42.42",
+		"SrcAddr":          "10.0.0.1",
+		"SrcK8s_HostIP":    "100.0.0.1",
+		"SrcK8s_HostName":  "host-1",
+		"SrcK8s_Name":      "pod-1",
+		"SrcK8s_Namespace": "ns-1",
+		"SrcK8s_OwnerName": "",
+		"SrcK8s_OwnerType": "",
+		"SrcK8s_Type":      "Pod",
+		"SrcK8s_Zone":      "us-east-1a",
+	}, entry)
+
+	// Pod to pod
+	entry = config.GenericMap{
+		"SrcAddr": "10.0.0.1", // pod-1
+		"DstAddr": "10.0.0.2", // pod-2
+	}
+	for _, r := range rules {
+		Enrich(entry, r)
+	}
+	assert.Equal(t, config.GenericMap{
+		"DstAddr":          "10.0.0.2",
+		"DstK8s_HostIP":    "100.0.0.2",
+		"DstK8s_HostName":  "host-2",
+		"DstK8s_Name":      "pod-2",
+		"DstK8s_Namespace": "ns-2",
+		"DstK8s_OwnerName": "",
+		"DstK8s_OwnerType": "",
+		"DstK8s_Type":      "Pod",
+		"DstK8s_Zone":      "us-east-1b",
+		"SrcAddr":          "10.0.0.1",
+		"SrcK8s_HostIP":    "100.0.0.1",
+		"SrcK8s_HostName":  "host-1",
+		"SrcK8s_Name":      "pod-1",
+		"SrcK8s_Namespace": "ns-1",
+		"SrcK8s_OwnerName": "",
+		"SrcK8s_OwnerType": "",
+		"SrcK8s_Type":      "Pod",
+		"SrcK8s_Zone":      "us-east-1a",
+	}, entry)
+
+	// Pod to service
+	entry = config.GenericMap{
+		"SrcAddr": "10.0.0.2", // pod-2
+		"DstAddr": "20.0.0.1", // service-1
+	}
+	for _, r := range rules {
+		Enrich(entry, r)
+	}
+	assert.Equal(t, config.GenericMap{
+		"DstAddr":          "20.0.0.1",
+		"DstK8s_Name":      "service-1",
+		"DstK8s_Namespace": "ns-1",
+		"DstK8s_OwnerName": "",
+		"DstK8s_OwnerType": "",
+		"DstK8s_Type":      "Service",
+		"SrcAddr":          "10.0.0.2",
+		"SrcK8s_HostIP":    "100.0.0.2",
+		"SrcK8s_HostName":  "host-2",
+		"SrcK8s_Name":      "pod-2",
+		"SrcK8s_Namespace": "ns-2",
+		"SrcK8s_OwnerName": "",
+		"SrcK8s_OwnerType": "",
+		"SrcK8s_Type":      "Pod",
+		"SrcK8s_Zone":      "us-east-1b",
+	}, entry)
+}
+
+var otelRules = api.NetworkTransformRules{
+	{
+		Type:     api.OpAddKubernetes,
+		Input:    "source.ip",
+		Output:   "source.",
+		Assignee: "otel",
+		Kubernetes: &api.K8sRule{
+			AddZone: true,
+		},
+	},
+	{
+		Type:     api.OpAddKubernetes,
+		Input:    "destination.ip",
+		Output:   "destination.",
+		Assignee: "otel",
+		Kubernetes: &api.K8sRule{
+			AddZone: true,
+		},
+	},
+}
+
+func TestEnrich_Otel(t *testing.T) {
+	informers = &fakeInformers{}
+
+	// Pod to unknown
+	entry := config.GenericMap{
+		"source.ip":      "10.0.0.1",    // pod-1
+		"destination.ip": "42.42.42.42", // unknown
+	}
+	for _, r := range otelRules {
+		Enrich(entry, r)
+	}
+	assert.Equal(t, config.GenericMap{
+		"destination.ip":            "42.42.42.42",
+		"source.ip":                 "10.0.0.1",
+		"source.k8s.host.ip":        "100.0.0.1",
+		"source.k8s.host.name":      "host-1",
+		"source.k8s.name":           "pod-1",
+		"source.k8s.namespace.name": "ns-1",
+		"source.k8s.pod.name":       "pod-1",
+		"source.k8s.pod.uid":        types.UID(""),
+		"source.k8s.owner.name":     "",
+		"source.k8s.owner.type":     "",
+		"source.k8s.type":           "Pod",
+		"source.k8s.zone":           "us-east-1a",
+	}, entry)
+
+	// Pod to pod
+	entry = config.GenericMap{
+		"source.ip":      "10.0.0.1", // pod-1
+		"destination.ip": "10.0.0.2", // pod-2
+	}
+	for _, r := range otelRules {
+		Enrich(entry, r)
+	}
+	assert.Equal(t, config.GenericMap{
+		"destination.ip":                 "10.0.0.2",
+		"destination.k8s.host.ip":        "100.0.0.2",
+		"destination.k8s.host.name":      "host-2",
+		"destination.k8s.name":           "pod-2",
+		"destination.k8s.namespace.name": "ns-2",
+		"destination.k8s.pod.name":       "pod-2",
+		"destination.k8s.pod.uid":        types.UID(""),
+		"destination.k8s.owner.name":     "",
+		"destination.k8s.owner.type":     "",
+		"destination.k8s.type":           "Pod",
+		"destination.k8s.zone":           "us-east-1b",
+		"source.ip":                      "10.0.0.1",
+		"source.k8s.host.ip":             "100.0.0.1",
+		"source.k8s.host.name":           "host-1",
+		"source.k8s.name":                "pod-1",
+		"source.k8s.namespace.name":      "ns-1",
+		"source.k8s.pod.name":            "pod-1",
+		"source.k8s.pod.uid":             types.UID(""),
+		"source.k8s.owner.name":          "",
+		"source.k8s.owner.type":          "",
+		"source.k8s.type":                "Pod",
+		"source.k8s.zone":                "us-east-1a",
+	}, entry)
+
+	// Pod to service
+	entry = config.GenericMap{
+		"source.ip":      "10.0.0.2", // pod-2
+		"destination.ip": "20.0.0.1", // service-1
+	}
+	for _, r := range otelRules {
+		Enrich(entry, r)
+	}
+	assert.Equal(t, config.GenericMap{
+		"destination.ip":                 "20.0.0.1",
+		"destination.k8s.name":           "service-1",
+		"destination.k8s.namespace.name": "ns-1",
+		"destination.k8s.service.name":   "service-1",
+		"destination.k8s.service.uid":    types.UID(""),
+		"destination.k8s.owner.name":     "",
+		"destination.k8s.owner.type":     "",
+		"destination.k8s.type":           "Service",
+		"source.ip":                      "10.0.0.2",
+		"source.k8s.host.ip":             "100.0.0.2",
+		"source.k8s.host.name":           "host-2",
+		"source.k8s.name":                "pod-2",
+		"source.k8s.namespace.name":      "ns-2",
+		"source.k8s.pod.name":            "pod-2",
+		"source.k8s.pod.uid":             types.UID(""),
+		"source.k8s.owner.name":          "",
+		"source.k8s.owner.type":          "",
+		"source.k8s.type":                "Pod",
+		"source.k8s.zone":                "us-east-1b",
+	}, entry)
+}
+
+func TestEnrich_EmptyNamespace(t *testing.T) {
+	informers = &fakeInformers{}
+	// We need to check that, whether it returns NotFound or just an empty namespace,
+	// there is no map entry for that namespace (an empty-valued map entry is not valid)
+	entry := config.GenericMap{
+		"SrcAddr": "1.2.3.4", // would return an empty namespace
+		"DstAddr": "3.2.1.0", // would return NotFound
+	}
+
+	for _, r := range rules {
+		Enrich(entry, r)
+	}
+
+	assert.NotContains(t, entry, "SrcK8s_Namespace")
+	assert.NotContains(t, entry, "DstK8s_Namespace")
+}
+
+type fakeInformers struct{}
+
+func (d *fakeInformers) initFromConfig(_ string) error {
+	return nil
+}
+
+func (*fakeInformers) getInfo(n string) (*Info, error) {
+	i := info[n]
+	if i != nil {
+		return i, nil
+	}
+	return nil, errors.New("notFound")
+}
+
+func (*fakeInformers) getNodeInfo(n string) (*Info, error) {
+	i := nodes[n]
+	if i != nil {
+		return i, nil
+	}
+	return nil, errors.New("notFound")
+}

--- a/pkg/pipeline/transform/kubernetes/informers-mock.go
+++ b/pkg/pipeline/transform/kubernetes/informers-mock.go
@@ -6,12 +6,12 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-type KubeDataMock struct {
+type InformersMock struct {
 	mock.Mock
-	kubeDataInterface
+	informersInterface
 }
 
-func (o *KubeDataMock) InitFromConfig(kubeConfigPath string) error {
+func (o *InformersMock) InitFromConfig(kubeConfigPath string) error {
 	args := o.Called(kubeConfigPath)
 	return args.Error(0)
 }
@@ -94,7 +94,7 @@ func (m *IndexerMock) FallbackNotFound() {
 	m.On("ByIndex", IndexIP, mock.Anything).Return([]interface{}{}, nil)
 }
 
-func SetupIndexerMocks(kd *KubeData) (pods, nodes, svc, rs *IndexerMock) {
+func SetupIndexerMocks(kd *Informers) (pods, nodes, svc, rs *IndexerMock) {
 	// pods informer
 	pods = &IndexerMock{}
 	pim := InformerMock{}

--- a/pkg/pipeline/transform/kubernetes/informers_test.go
+++ b/pkg/pipeline/transform/kubernetes/informers_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestGetInfo(t *testing.T) {
-	kubeData := KubeData{}
+	kubeData := Informers{}
 	pidx, hidx, sidx, ridx := SetupIndexerMocks(&kubeData)
 	pidx.MockPod("1.2.3.4", "pod1", "podNamespace", "10.0.0.1", nil)
 	pidx.MockPod("1.2.3.5", "pod2", "podNamespace", "10.0.0.1", &Owner{Name: "rs1", Type: "ReplicaSet"})
@@ -38,7 +38,7 @@ func TestGetInfo(t *testing.T) {
 	hidx.FallbackNotFound()
 
 	// Test get orphan pod
-	info, err := kubeData.GetInfo("1.2.3.4")
+	info, err := kubeData.getInfo("1.2.3.4")
 	require.NoError(t, err)
 
 	require.Equal(t, *info, Info{
@@ -53,7 +53,7 @@ func TestGetInfo(t *testing.T) {
 	})
 
 	// Test get pod owned
-	info, err = kubeData.GetInfo("1.2.3.5")
+	info, err = kubeData.getInfo("1.2.3.5")
 	require.NoError(t, err)
 
 	require.Equal(t, *info, Info{
@@ -72,7 +72,7 @@ func TestGetInfo(t *testing.T) {
 	})
 
 	// Test get node
-	info, err = kubeData.GetInfo("10.0.0.1")
+	info, err = kubeData.getInfo("10.0.0.1")
 	require.NoError(t, err)
 
 	require.Equal(t, *info, Info{
@@ -84,7 +84,7 @@ func TestGetInfo(t *testing.T) {
 	})
 
 	// Test get service
-	info, err = kubeData.GetInfo("1.2.3.100")
+	info, err = kubeData.getInfo("1.2.3.100")
 	require.NoError(t, err)
 
 	require.Equal(t, *info, Info{
@@ -97,7 +97,7 @@ func TestGetInfo(t *testing.T) {
 	})
 
 	// Test no match
-	info, err = kubeData.GetInfo("1.2.3.200")
+	info, err = kubeData.getInfo("1.2.3.200")
 	require.NotNil(t, err)
 	require.Nil(t, info)
 }


### PR DESCRIPTION
## Description

No user-facing change / no API change

- Add tests relative to enrichment
- move k8s stuff into k8s package
- Rename "KubeData" as "Informers"

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
