### PR TITLE
NETOBSERV-1426: subnet labelling enhancements

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -218,7 +218,7 @@ Following is the supported API format for network transformations:
                     add_kubernetes: add output kubernetes fields from input
                     add_kubernetes_infra: add output kubernetes isInfra field from input
                     reinterpret_direction: reinterpret flow direction at the node level (instead of net interface), to ease the deduplication process
-                    add_ip_category: categorize IPs based on known subnets configuration
+                    add_subnet_label: categorize IPs based on known subnets configuration
                  kubernetes_infra: Kubernetes infra rule configuration
                      inputs: entry inputs fields
                      output: entry output field
@@ -239,7 +239,7 @@ Following is the supported API format for network transformations:
                  add_location: Add location rule configuration
                      input: entry input field
                      output: entry output field
-                 add_ip_category: Add ip category rule configuration
+                 add_subnet_label: Add subnet label rule configuration
                      input: entry input field
                      output: entry output field
                  add_service: Add service rule configuration
@@ -249,9 +249,9 @@ Following is the supported API format for network transformations:
          kubeConfigPath: path to kubeconfig file (optional)
          servicesFile: path to services file (optional, default: /etc/services)
          protocolsFile: path to protocols file (optional, default: /etc/protocols)
-         ipCategories: configure IP categories
-                 cidrs: list of CIDRs to match a category
-                 name: name of the category
+         subnetLabels: configure subnet and IPs custom labels
+                 cidrs: list of CIDRs to match a label
+                 name: name of the label
          directionInfo: information to reinterpret flow direction (optional, to use with reinterpret_direction rule)
              reporterIPField: field providing the reporter (agent) host IP
              srcHostField: source host field

--- a/pkg/api/transform_network.go
+++ b/pkg/api/transform_network.go
@@ -22,7 +22,7 @@ type TransformNetwork struct {
 	KubeConfigPath string                        `yaml:"kubeConfigPath,omitempty" json:"kubeConfigPath,omitempty" doc:"path to kubeconfig file (optional)"`
 	ServicesFile   string                        `yaml:"servicesFile,omitempty" json:"servicesFile,omitempty" doc:"path to services file (optional, default: /etc/services)"`
 	ProtocolsFile  string                        `yaml:"protocolsFile,omitempty" json:"protocolsFile,omitempty" doc:"path to protocols file (optional, default: /etc/protocols)"`
-	IPCategories   []NetworkTransformIPCategory  `yaml:"ipCategories,omitempty" json:"ipCategories,omitempty" doc:"configure IP categories"`
+	SubnetLabels   []NetworkTransformSubnetLabel `yaml:"subnetLabels,omitempty" json:"subnetLabels,omitempty" doc:"configure subnet and IPs custom labels"`
 	DirectionInfo  NetworkTransformDirectionInfo `yaml:"directionInfo,omitempty" json:"directionInfo,omitempty" doc:"information to reinterpret flow direction (optional, to use with reinterpret_direction rule)"`
 }
 
@@ -48,7 +48,7 @@ const (
 	NetworkAddKubernetes        TransformNetworkOperationEnum = "add_kubernetes"        // add output kubernetes fields from input
 	NetworkAddKubernetesInfra   TransformNetworkOperationEnum = "add_kubernetes_infra"  // add output kubernetes isInfra field from input
 	NetworkReinterpretDirection TransformNetworkOperationEnum = "reinterpret_direction" // reinterpret flow direction at the node level (instead of net interface), to ease the deduplication process
-	NetworkAddIPCategory        TransformNetworkOperationEnum = "add_ip_category"       // categorize IPs based on known subnets configuration
+	NetworkAddSubnetLabel       TransformNetworkOperationEnum = "add_subnet_label"      // categorize IPs based on known subnets configuration
 )
 
 type NetworkTransformRule struct {
@@ -57,7 +57,7 @@ type NetworkTransformRule struct {
 	Kubernetes      *K8sRule                      `yaml:"kubernetes,omitempty" json:"kubernetes,omitempty" doc:"Kubernetes rule configuration"`
 	AddSubnet       *NetworkAddSubnetRule         `yaml:"add_subnet,omitempty" json:"add_subnet,omitempty" doc:"Add subnet rule configuration"`
 	AddLocation     *NetworkGenericRule           `yaml:"add_location,omitempty" json:"add_location,omitempty" doc:"Add location rule configuration"`
-	AddIPCategory   *NetworkGenericRule           `yaml:"add_ip_category,omitempty" json:"add_ip_category,omitempty" doc:"Add ip category rule configuration"`
+	AddSubnetLabel  *NetworkAddSubnetLabelRule    `yaml:"add_subnet_label,omitempty" json:"add_subnet_label,omitempty" doc:"Add subnet label rule configuration"`
 	AddService      *NetworkAddServiceRule        `yaml:"add_service,omitempty" json:"add_service,omitempty" doc:"Add service rule configuration"`
 }
 
@@ -92,6 +92,11 @@ type NetworkAddSubnetRule struct {
 	SubnetMask string `yaml:"subnet_mask,omitempty" json:"subnet_mask,omitempty" doc:"subnet mask field"`
 }
 
+type NetworkAddSubnetLabelRule struct {
+	Input  string `yaml:"input,omitempty" json:"input,omitempty" doc:"entry input field"`
+	Output string `yaml:"output,omitempty" json:"output,omitempty" doc:"entry output field"`
+}
+
 type NetworkAddServiceRule struct {
 	Input    string `yaml:"input,omitempty" json:"input,omitempty" doc:"entry input field"`
 	Output   string `yaml:"output,omitempty" json:"output,omitempty" doc:"entry output field"`
@@ -108,7 +113,7 @@ type NetworkTransformDirectionInfo struct {
 
 type NetworkTransformRules []NetworkTransformRule
 
-type NetworkTransformIPCategory struct {
-	CIDRs []string `yaml:"cidrs,omitempty" json:"cidrs,omitempty" doc:"list of CIDRs to match a category"`
-	Name  string   `yaml:"name,omitempty" json:"name,omitempty" doc:"name of the category"`
+type NetworkTransformSubnetLabel struct {
+	CIDRs []string `yaml:"cidrs,omitempty" json:"cidrs,omitempty" doc:"list of CIDRs to match a label"`
+	Name  string   `yaml:"name,omitempty" json:"name,omitempty" doc:"name of the label"`
 }

--- a/pkg/pipeline/transform/transform_network_test.go
+++ b/pkg/pipeline/transform/transform_network_test.go
@@ -227,12 +227,12 @@ func Test_Categorize(t *testing.T) {
 		Transform: &config.Transform{
 			Network: &api.TransformNetwork{
 				Rules: []api.NetworkTransformRule{
-					{Type: api.NetworkAddIPCategory, AddIPCategory: &api.NetworkGenericRule{Input: "addr1", Output: "cat1"}},
-					{Type: api.NetworkAddIPCategory, AddIPCategory: &api.NetworkGenericRule{Input: "addr2", Output: "cat2"}},
-					{Type: api.NetworkAddIPCategory, AddIPCategory: &api.NetworkGenericRule{Input: "addr3", Output: "cat3"}},
-					{Type: api.NetworkAddIPCategory, AddIPCategory: &api.NetworkGenericRule{Input: "addr4", Output: "cat4"}},
+					{Type: api.NetworkAddSubnetLabel, AddSubnetLabel: &api.NetworkAddSubnetLabelRule{Input: "addr1", Output: "cat1"}},
+					{Type: api.NetworkAddSubnetLabel, AddSubnetLabel: &api.NetworkAddSubnetLabelRule{Input: "addr2", Output: "cat2"}},
+					{Type: api.NetworkAddSubnetLabel, AddSubnetLabel: &api.NetworkAddSubnetLabelRule{Input: "addr3", Output: "cat3"}},
+					{Type: api.NetworkAddSubnetLabel, AddSubnetLabel: &api.NetworkAddSubnetLabelRule{Input: "addr4", Output: "cat4"}},
 				},
-				IPCategories: []api.NetworkTransformIPCategory{{
+				SubnetLabels: []api.NetworkTransformSubnetLabel{{
 					Name:  "Pods overlay",
 					CIDRs: []string{"10.0.0.0/8"},
 				}, {
@@ -257,7 +257,6 @@ func Test_Categorize(t *testing.T) {
 		"addr2": "100.1.2.3",
 		"cat2":  "MySite.com",
 		"addr3": "100.2.3.4",
-		"cat3":  "",
 		"addr4": "101.1.0.0",
 		"cat4":  "MySite.com",
 	}, output)


### PR DESCRIPTION
## Description

- rename IPCategories -> SubnetLabels
- allow to skip applying labels when a given field is present (in order
  to save space / processing by avoiding redundant information)
- Adapt to refactored API (cf #580)

### Breaking change migration guide

E.g., if you have some "add_ip_category" rule defined such as:

```yaml
        transform:
          type: "network"
          network:
            rules:
            - input: "the_address"
              output: "subnet"
              type: add_ip_category
            ipCategories:
            - cidrs:
              - 101.1.0.0/32
              - 100.1.0.0/16
              name: "MySite.com"
```

This must be rewritten as:

```yaml
        transform:
          type: "network"
          network:
            rules:
            - type: add_subnet_label
              add_subnet_label:
                input: "the_address"
                output: "subnet"
            subnetLabels:
            - cidrs:
              - 101.1.0.0/32
              - 100.1.0.0/16
              name: "MySite.com"
```

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
#580 (merged)

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
