### PR TITLE
Fix yaml unmarshaling of inlined config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,11 +55,11 @@ type Profile struct {
 // Also, currently FLP doesn't support defining more than one PromEncode stage. If this feature is added later, these global settings
 // will help configuring common setting for all PromEncode stages - PromEncode settings would then act as overrides.
 type MetricsSettings struct {
-	api.PromConnectionInfo
-	DisableGlobalServer bool   `yaml:"disableGlobalServer,omitempty" json:"disableGlobalServer,omitempty" doc:"disabling the global metrics server makes operational metrics unavailable. If prometheus-encoding stages are defined, they need to contain their own metrics server parameters."`
-	Prefix              string `yaml:"prefix,omitempty" json:"prefix,omitempty" doc:"prefix for names of the operational metrics"`
-	NoPanic             bool   `yaml:"noPanic,omitempty" json:"noPanic,omitempty"`
-	SuppressGoMetrics   bool   `yaml:"suppressGoMetrics,omitempty" json:"suppressGoMetrics,omitempty" doc:"filter out Go and process metrics"`
+	api.PromConnectionInfo `yaml:",inline"`
+	DisableGlobalServer    bool   `yaml:"disableGlobalServer,omitempty" json:"disableGlobalServer,omitempty" doc:"disabling the global metrics server makes operational metrics unavailable. If prometheus-encoding stages are defined, they need to contain their own metrics server parameters."`
+	Prefix                 string `yaml:"prefix,omitempty" json:"prefix,omitempty" doc:"prefix for names of the operational metrics"`
+	NoPanic                bool   `yaml:"noPanic,omitempty" json:"noPanic,omitempty"`
+	SuppressGoMetrics      bool   `yaml:"suppressGoMetrics,omitempty" json:"suppressGoMetrics,omitempty" doc:"filter out Go and process metrics"`
 }
 
 // PerfSettings allows setting some internal configuration parameters

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,9 +18,11 @@
 package config
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 func TestJsonUnmarshalStrict(t *testing.T) {
@@ -38,4 +40,18 @@ func TestJsonUnmarshalStrict(t *testing.T) {
 	msg = `{"F":1, "B":"bbb", "NewField":0}`
 	err = JsonUnmarshalStrict([]byte(msg), &actualMsg)
 	require.Error(t, err)
+}
+
+func TestUnmarshalInline(t *testing.T) {
+	cfg := `{"metricsSettings":{"port":9102,"prefix":"netobserv_"}}`
+	var cfs ConfigFileStruct
+	err := yaml.Unmarshal([]byte(cfg), &cfs)
+	require.NoError(t, err)
+	require.Equal(t, "netobserv_", cfs.MetricsSettings.Prefix)
+	require.Equal(t, 9102, cfs.MetricsSettings.PromConnectionInfo.Port)
+
+	err = json.Unmarshal([]byte(cfg), &cfs)
+	require.NoError(t, err)
+	require.Equal(t, "netobserv_", cfs.MetricsSettings.Prefix)
+	require.Equal(t, 9102, cfs.MetricsSettings.PromConnectionInfo.Port)
 }


### PR DESCRIPTION
The `PromConnectionInfo` data wasn't unmarshaled when using yaml (it worked with json)
This is needed for agent's direct-flp feature