### PR TITLE
NETOBSERV-1466 Update eBPF dependency for FLP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/netobserv/gopipes v0.3.0
 	github.com/netobserv/loki-client-go v0.0.0-20220927092034-f37122a54500
-	github.com/netobserv/netobserv-ebpf-agent v0.3.3
+	github.com/netobserv/netobserv-ebpf-agent v0.3.4-0.20240312085757-e9bf0d0d5a09
 	github.com/netsampler/goflow2 v1.3.7
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -631,8 +631,8 @@ github.com/netobserv/gopipes v0.3.0 h1:IYmPnnAVCdSK7VmHmpFhrVBOEm45qpgbZmJz1sSW+
 github.com/netobserv/gopipes v0.3.0/go.mod h1:N7/Gz05EOF0CQQSKWsv3eof22Cj2PB08Pbttw98YFYU=
 github.com/netobserv/loki-client-go v0.0.0-20220927092034-f37122a54500 h1:RmnoJe/ci5q+QdM7upFdxiU+D8F3L3qTd5wXCwwHefw=
 github.com/netobserv/loki-client-go v0.0.0-20220927092034-f37122a54500/go.mod h1:LHXpc5tjKvsfZn0pwLKrvlgEhZcCaw3Di9mUEZGAI4E=
-github.com/netobserv/netobserv-ebpf-agent v0.3.3 h1:4e/mDVhSTd8JzaqKapaQ78BFLJP/GYpYWQ/LHPArJeI=
-github.com/netobserv/netobserv-ebpf-agent v0.3.3/go.mod h1:R3zRIhu5faj91s9pCU735oULLC+oBDPzA/xVwiUJ9PY=
+github.com/netobserv/netobserv-ebpf-agent v0.3.4-0.20240312085757-e9bf0d0d5a09 h1:9Y7nPXhMc8PToNX4aQltGNcpSDBehWoTHlg/LWToils=
+github.com/netobserv/netobserv-ebpf-agent v0.3.4-0.20240312085757-e9bf0d0d5a09/go.mod h1:W26Mf03LriOdylI/3T0yKgmU3bR4gy/ihzRd0SzJb3w=
 github.com/netsampler/goflow2 v1.3.7 h1:XZaTy8kkMnGXpJ9hS3KbO1McyrFTpVNhVFEx9rNhMmc=
 github.com/netsampler/goflow2 v1.3.7/go.mod h1:4UZsVGVAs//iMCptUHn3WNScztJeUhZH7kDW2+/vDdQ=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -228,7 +228,7 @@ parameters:
 	assert.NotZero(t, capturedRecord["TimeReceived"])
 	delete(capturedRecord, "TimeReceived")
 	assert.EqualValues(t, map[string]interface{}{
-		"FlowDirection":          float64(1),
+		"IfDirections":           []interface{}{float64(1)},
 		"Bytes":                  float64(456),
 		"SrcAddr":                "1.2.3.4",
 		"DstAddr":                "5.6.7.8",
@@ -237,13 +237,12 @@ parameters:
 		"SrcMac":                 "01:02:03:04:05:06",
 		"SrcPort":                float64(23000),
 		"DstPort":                float64(443),
-		"Duplicate":              false,
 		"Etype":                  float64(2048),
 		"Packets":                float64(123),
 		"Proto":                  float64(17),
 		"TimeFlowStartMs":        float64(startTime.UnixMilli()),
 		"TimeFlowEndMs":          float64(endTime.UnixMilli()),
-		"Interface":              "eth0",
+		"Interfaces":             []interface{}{"eth0"},
 		"AgentIP":                "10.11.12.13",
 		"PktDropBytes":           float64(100),
 		"PktDropPackets":         float64(10),

--- a/pkg/pipeline/write/testnorace/write_ipfix_test.go
+++ b/pkg/pipeline/write/testnorace/write_ipfix_test.go
@@ -147,7 +147,7 @@ func matchElement(t *testing.T, element entities.InfoElementWithValue, flow conf
 	case "ethernetType":
 		assert.Equal(t, flow["Etype"], uint32(element.GetUnsigned16Value()))
 	case "flowDirection":
-		assert.Equal(t, flow["FlowDirection"], int(element.GetUnsigned8Value()))
+		assert.Equal(t, flow["IfDirections"], []int{int(element.GetUnsigned8Value())})
 	case "protocolIdentifier":
 		assert.Equal(t, flow["Proto"], uint32(element.GetUnsigned8Value()))
 	case "sourceTransportPort":
@@ -163,7 +163,7 @@ func matchElement(t *testing.T, element entities.InfoElementWithValue, flow conf
 	case "packetDeltaCount":
 		assert.Equal(t, flow["Packets"], element.GetUnsigned64Value())
 	case "interfaceName":
-		assert.Equal(t, flow["Interface"], element.GetStringValue())
+		assert.Equal(t, flow["Interfaces"], []string{element.GetStringValue()})
 	case "sourcePodNamespace":
 		assert.Equal(t, flow["SrcK8S_Namespace"], element.GetStringValue())
 	case "sourcePodName":

--- a/pkg/pipeline/write/write_ipfix.go
+++ b/pkg/pipeline/write/write_ipfix.go
@@ -246,8 +246,9 @@ func setStandardIEValue(record config.GenericMap, ieValPtr *entities.InfoElement
 			return fmt.Errorf("unable to find ethernet type (Etype) in record")
 		}
 	case "flowDirection":
-		if record["FlowDirection"] != nil {
-			ieVal.SetUnsigned8Value(uint8(record["FlowDirection"].(int)))
+		dirs := record["IfDirections"].([]int)
+		if len(dirs) > 0 {
+			ieVal.SetUnsigned8Value(uint8(dirs[0]))
 		} else {
 			return fmt.Errorf("unable to find flow direction (flowDirection) in record")
 		}
@@ -336,8 +337,9 @@ func setStandardIEValue(record config.GenericMap, ieValPtr *entities.InfoElement
 			return fmt.Errorf("unable to find packets in record")
 		}
 	case "interfaceName":
-		if record["Interface"] != nil {
-			ieVal.SetStringValue(record["Interface"].(string))
+		interfaces := record["Interfaces"].([]string)
+		if len(interfaces) > 0 {
+			ieVal.SetStringValue(interfaces[0])
 		} else {
 			return fmt.Errorf("unable to find interface in record")
 		}

--- a/vendor/github.com/netobserv/netobserv-ebpf-agent/pkg/decode/decode_protobuf.go
+++ b/vendor/github.com/netobserv/netobserv-ebpf-agent/pkg/decode/decode_protobuf.go
@@ -46,16 +46,17 @@ func PBFlowToMap(flow *pbflow.Record) config.GenericMap {
 		return config.GenericMap{}
 	}
 	out := config.GenericMap{
-		"FlowDirection":   int(flow.Direction.Number()),
 		"SrcMac":          macToStr(flow.DataLink.GetSrcMac()),
 		"DstMac":          macToStr(flow.DataLink.GetDstMac()),
 		"Etype":           flow.EthProtocol,
-		"Duplicate":       flow.Duplicate,
 		"TimeFlowStartMs": flow.TimeFlowStart.AsTime().UnixMilli(),
 		"TimeFlowEndMs":   flow.TimeFlowEnd.AsTime().UnixMilli(),
 		"TimeReceived":    time.Now().Unix(),
-		"Interface":       flow.Interface,
 		"AgentIP":         ipToStr(flow.AgentIp),
+	}
+
+	if flow.Duplicate {
+		out["Duplicate"] = true
 	}
 
 	if flow.Bytes != 0 {
@@ -65,17 +66,20 @@ func PBFlowToMap(flow *pbflow.Record) config.GenericMap {
 	if flow.Packets != 0 {
 		out["Packets"] = flow.Packets
 	}
-	var interfaces []interface{}
-	var flowDirections []interface{}
 
+	var interfaces []string
+	var directions []int
 	if len(flow.GetDupList()) != 0 {
 		for _, entry := range flow.GetDupList() {
 			interfaces = append(interfaces, entry.Interface)
-			flowDirections = append(flowDirections, entry.Direction)
+			directions = append(directions, int(entry.Direction))
 		}
-		out["Interfaces"] = interfaces
-		out["FlowDirections"] = flowDirections
+	} else {
+		interfaces = append(interfaces, flow.Interface)
+		directions = append(directions, int(flow.Direction))
 	}
+	out["Interfaces"] = interfaces
+	out["IfDirections"] = directions
 
 	ethType := ethernet.EtherType(flow.EthProtocol)
 	if ethType == ethernet.EtherTypeIPv4 || ethType == ethernet.EtherTypeIPv6 {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -250,7 +250,7 @@ github.com/netobserv/loki-client-go/pkg/labelutil
 github.com/netobserv/loki-client-go/pkg/logproto
 github.com/netobserv/loki-client-go/pkg/metric
 github.com/netobserv/loki-client-go/pkg/urlutil
-# github.com/netobserv/netobserv-ebpf-agent v0.3.3
+# github.com/netobserv/netobserv-ebpf-agent v0.3.4-0.20240312085757-e9bf0d0d5a09
 ## explicit; go 1.20
 github.com/netobserv/netobserv-ebpf-agent/pkg/decode
 github.com/netobserv/netobserv-ebpf-agent/pkg/grpc


### PR DESCRIPTION
## Description

See eBPF update https://github.com/netobserv/netobserv-ebpf-agent/pull/275 and followup to remove Duplicate field https://github.com/netobserv/netobserv-ebpf-agent/pull/276

## Dependencies

Update go mod once eBPF PR is merged

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
