### PR TITLE
WIP NETOBSERV-1471 add tcp write stage

### DIFF
--- a/contrib/kubernetes/flowlogs-pipeline.conf.yaml
+++ b/contrib/kubernetes/flowlogs-pipeline.conf.yaml
@@ -1,7 +1,8 @@
 # This file was generated automatically by flowlogs-pipeline confgenerator
 log-level: error
 metricsSettings:
-  port: 9102
+  promconnectioninfo:
+    port: 9102
   prefix: flp_op_
 pipeline:
 - name: ingest_collector
@@ -252,41 +253,49 @@ parameters:
   encode:
     type: prom
     prom:
+      promconnectioninfo: null
       metrics:
       - name: bandwidth_per_network_service
         type: counter
         filters:
         - key: name
           value: bandwidth_network_service
+          type: ""
         valueKey: recent_op_value
         labels:
         - groupByKeys
         - aggregate
         buckets: []
+        valueScale: 0
       - name: bandwidth_per_source_destination_subnet
         type: counter
         filters:
         - key: name
           value: bandwidth_source_destination_subnet
+          type: ""
         valueKey: recent_op_value
         labels:
         - groupByKeys
         - aggregate
         buckets: []
+        valueScale: 0
       - name: bandwidth_per_source_subnet
         type: gauge
         filters:
         - key: name
           value: bandwidth_source_subnet
+          type: ""
         valueKey: bytes
         labels:
         - srcSubnet
         buckets: []
+        valueScale: 0
       - name: connection_size_histogram
         type: agg_histogram
         filters:
         - key: name
           value: connection_bytes_hist
+          type: ""
         valueKey: recent_raw_values
         labels:
         - groupByKeys
@@ -297,11 +306,13 @@ parameters:
         - 10240
         - 102400
         - 1.048576e+06
+        valueScale: 0
       - name: connection_size_histogram_ab
         type: agg_histogram
         filters:
         - key: name
           value: connection_bytes_hist_AB
+          type: ""
         valueKey: recent_raw_values
         labels:
         - groupByKeys
@@ -312,11 +323,13 @@ parameters:
         - 10240
         - 102400
         - 1.048576e+06
+        valueScale: 0
       - name: connection_size_histogram_ba
         type: agg_histogram
         filters:
         - key: name
           value: connection_bytes_hist_BA
+          type: ""
         valueKey: recent_raw_values
         labels:
         - groupByKeys
@@ -327,92 +340,110 @@ parameters:
         - 10240
         - 102400
         - 1.048576e+06
+        valueScale: 0
       - name: connections_per_destination_subnet
         type: counter
         filters:
         - key: name
           value: dest_connection_subnet_count
+          type: ""
         valueKey: recent_count
         labels:
         - _RecordType
         - dstSubnet
         buckets: []
+        valueScale: 0
       - name: connections_per_source_subnet
         type: counter
         filters:
         - key: name
           value: src_connection_count
+          type: ""
         valueKey: recent_count
         labels:
         - srcSubnet
         - _RecordType
         buckets: []
+        valueScale: 0
       - name: connections_per_tcp_flags
         type: counter
         filters:
         - key: name
           value: TCPFlags_count
+          type: ""
         valueKey: recent_count
         labels:
         - groupByKeys
         - aggregate
         buckets: []
+        valueScale: 0
       - name: connections_per_destination_as
         type: counter
         filters:
         - key: name
           value: dst_as_connection_count
+          type: ""
         valueKey: recent_count
         labels:
         - dstAS
         - _RecordType
         buckets: []
+        valueScale: 0
       - name: connections_per_source_as
         type: counter
         filters:
         - key: name
           value: src_as_connection_count
+          type: ""
         valueKey: recent_count
         labels:
         - srcAS
         - _RecordType
         buckets: []
+        valueScale: 0
       - name: count_per_source_destination_subnet
         type: counter
         filters:
         - key: name
           value: count_source_destination_subnet
+          type: ""
         valueKey: recent_count
         labels:
         - dstSubnet24
         - srcSubnet24
         - _RecordType
         buckets: []
+        valueScale: 0
       - name: egress_per_destination_subnet
         type: counter
         filters:
         - key: name
           value: bandwidth_destination_subnet
+          type: ""
         valueKey: recent_op_value
         labels:
         - groupByKeys
         - aggregate
         buckets: []
+        valueScale: 0
       - name: egress_per_namespace
         type: counter
         filters:
         - key: name
           value: bandwidth_namespace
+          type: ""
         valueKey: recent_op_value
         labels:
         - groupByKeys
         - aggregate
         buckets: []
+        valueScale: 0
       - name: flows_length_histogram
         type: agg_histogram
         filters:
         - key: name
           value: flows_bytes_hist
+          type: ""
         valueKey: recent_raw_values
         labels:
         - groupByKeys
@@ -423,26 +454,31 @@ parameters:
         - 10240
         - 102400
         - 1.048576e+06
+        valueScale: 0
       - name: connections_per_destination_location
         type: counter
         filters:
         - key: name
           value: dest_connection_location_count
+          type: ""
         valueKey: recent_count
         labels:
         - dstLocation_CountryName
         - _RecordType
         buckets: []
+        valueScale: 0
       - name: service_count
         type: counter
         filters:
         - key: name
           value: dest_service_count
+          type: ""
         valueKey: recent_count
         labels:
         - service
         - _RecordType
         buckets: []
+        valueScale: 0
       prefix: flp_
 - name: write_loki
   write:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -31,6 +31,7 @@ const (
 	OtlpLogsType                 = "otlplogs"
 	OtlpMetricsType              = "otlpmetrics"
 	OtlpTracesType               = "otlptraces"
+	TCPType                      = "tcp"
 	StdoutType                   = "stdout"
 	LokiType                     = "loki"
 	IpfixType                    = "ipfix"
@@ -74,6 +75,7 @@ type API struct {
 	TransformFilter    TransformFilter   `yaml:"filter" doc:"## Transform Filter API\nFollowing is the supported API format for filter transformations:\n"`
 	TransformNetwork   TransformNetwork  `yaml:"network" doc:"## Transform Network API\nFollowing is the supported API format for network transformations:\n"`
 	WriteLoki          WriteLoki         `yaml:"loki" doc:"## Write Loki API\nFollowing is the supported API format for writing to loki:\n"`
+	WriteTCP           WriteTCP          `yaml:"tcp" doc:"## Write TCP\nFollowing is the supported API format for writing to tcp:\n"`
 	WriteStdout        WriteStdout       `yaml:"stdout" doc:"## Write Standard Output\nFollowing is the supported API format for writing to standard output:\n"`
 	ExtractAggregate   Aggregates        `yaml:"aggregates" doc:"## Aggregate metrics API\nFollowing is the supported API format for specifying metrics aggregations:\n"`
 	ConnectionTracking ConnTrack         `yaml:"conntrack" doc:"## Connection tracking API\nFollowing is the supported API format for specifying connection tracking:\n"`

--- a/pkg/api/write_tcp.go
+++ b/pkg/api/write_tcp.go
@@ -1,0 +1,5 @@
+package api
+
+type WriteTCP struct {
+	Port string `yaml:"port,omitempty" json:"port,omitempty" doc:"TCP port number"`
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -126,6 +126,7 @@ type Encode struct {
 
 type Write struct {
 	Type   string           `yaml:"type" json:"type"`
+	TCP    *api.WriteTCP    `yaml:"tcp,omitempty" json:"tcp,omitempty"`
 	Loki   *api.WriteLoki   `yaml:"loki,omitempty" json:"loki,omitempty"`
 	Stdout *api.WriteStdout `yaml:"stdout,omitempty" json:"stdout,omitempty"`
 	Ipfix  *api.WriteIpfix  `yaml:"ipfix,omitempty" json:"ipfix,omitempty"`

--- a/pkg/config/pipeline_builder.go
+++ b/pkg/config/pipeline_builder.go
@@ -151,6 +151,11 @@ func (b *PipelineBuilderStage) EncodeS3(name string, s3 api.EncodeS3) PipelineBu
 	return b.next(name, NewEncodeS3Params(name, s3))
 }
 
+// WriteTCP chains the current stage with a WriteTCP stage and returns that new stage
+func (b *PipelineBuilderStage) WriteTCP(name string, tcp api.WriteTCP) PipelineBuilderStage {
+	return b.next(name, NewWriteTCPParams(name, tcp))
+}
+
 // WriteStdout chains the current stage with a WriteStdout stage and returns that new stage
 func (b *PipelineBuilderStage) WriteStdout(name string, stdout api.WriteStdout) PipelineBuilderStage {
 	return b.next(name, NewWriteStdoutParams(name, stdout))

--- a/pkg/config/stage_params.go
+++ b/pkg/config/stage_params.go
@@ -69,6 +69,10 @@ func NewEncodeS3Params(name string, s3 api.EncodeS3) StageParam {
 	return StageParam{Name: name, Encode: &Encode{Type: api.S3Type, S3: &s3}}
 }
 
+func NewWriteTCPParams(name string, tcp api.WriteTCP) StageParam {
+	return StageParam{Name: name, Write: &Write{Type: api.TCPType, TCP: &tcp}}
+}
+
 func NewWriteStdoutParams(name string, stdout api.WriteStdout) StageParam {
 	return StageParam{Name: name, Write: &Write{Type: api.StdoutType, Stdout: &stdout}}
 }

--- a/pkg/pipeline/pipeline_builder.go
+++ b/pkg/pipeline/pipeline_builder.go
@@ -368,6 +368,8 @@ func getWriter(opMetrics *operational.Metrics, params config.StageParam) (write.
 	var writer write.Writer
 	var err error
 	switch params.Write.Type {
+	case api.TCPType:
+		writer, err = write.NewWriteTCP(params)
 	case api.StdoutType:
 		writer, err = write.NewWriteStdout(params)
 	case api.NoneType:

--- a/pkg/pipeline/write/write_tcp.go
+++ b/pkg/pipeline/write/write_tcp.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2021 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package write
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/sirupsen/logrus"
+)
+
+type writeTCP struct {
+	address string
+	conn    net.Conn
+}
+
+// Write writes a flow to tcp connection
+func (t *writeTCP) Write(v config.GenericMap) {
+	logrus.Tracef("entering writeTCP Write")
+	b, _ := json.Marshal(v)
+	// append new line between each record to split on client side
+	b = append(b, []byte("\n")...)
+	_, err := t.conn.Write(b)
+	if err != nil {
+		log.WithError(err).Warn("can't write tcp")
+	}
+}
+
+// NewWriteTCP create a new write
+func NewWriteTCP(params config.StageParam) (Writer, error) {
+	logrus.Debugf("entering NewWriteTCP")
+	writeTCP := &writeTCP{}
+	if params.Write != nil && params.Write.TCP != nil && params.Write.TCP.Port != "" {
+		writeTCP.address = ":" + params.Write.TCP.Port
+	} else {
+		return nil, fmt.Errorf("Write.TCP.Port must be specified")
+	}
+
+	logrus.Debugf("NewWriteTCP Listen %s", writeTCP.address)
+	l, err := net.Listen("tcp", writeTCP.address)
+	if err != nil {
+		return nil, err
+	}
+	defer l.Close()
+	clientConn, err := l.Accept()
+	if err != nil {
+		return nil, err
+	}
+	writeTCP.conn = clientConn
+
+	return writeTCP, nil
+}


### PR DESCRIPTION
## Description

This PR adds TCP write stage to FLP.
We need to decide if we move to [gRPC](https://github.com/netobserv/flowlogs-pipeline/pull/621) instead before merging.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
