### PR TITLE
NETOBSERV-1466 add 'different' filter to prom metrics

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -51,6 +51,7 @@ const (
 	AddKubernetesInfraRuleType   = "add_kubernetes_infra"
 	ReinterpretDirectionRuleType = "reinterpret_direction"
 	PromFilterExact              = "exact"
+	PromFilterDifferent          = "different"
 	PromFilterPresence           = "presence"
 	PromFilterAbsence            = "absence"
 	PromFilterRegex              = "regex"

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -70,14 +70,15 @@ type MetricsItems []MetricsItem
 type MetricsFilter struct {
 	Key   string `yaml:"key" json:"key" doc:"the key to match and filter by"`
 	Value string `yaml:"value" json:"value" doc:"the value to match and filter by"`
-	Type  string `yaml:"type" json:"type" enum:"MetricEncodeFilterTypeEnum" doc:"the type of filter match: exact (default), presence, absence or regex"`
+	Type  string `yaml:"type" json:"type" enum:"MetricEncodeFilterTypeEnum" doc:"the type of filter match: exact (default), different, presence, absence or regex"`
 }
 
 type MetricEncodeFilterTypeEnum struct {
-	Exact    string `yaml:"exact" json:"exact" doc:"match exactly the provided fitler value"`
-	Presence string `yaml:"presence" json:"presence" doc:"filter key must be present (filter value is ignored)"`
-	Absence  string `yaml:"absence" json:"absence" doc:"filter key must be absent (filter value is ignored)"`
-	Regex    string `yaml:"regex" json:"regex" doc:"match filter value as a regular expression"`
+	Exact     string `yaml:"exact" json:"exact" doc:"match exactly the provided fitler value"`
+	Different string `yaml:"different" json:"different" doc:"not match the provided fitler value"`
+	Presence  string `yaml:"presence" json:"presence" doc:"filter key must be present (filter value is ignored)"`
+	Absence   string `yaml:"absence" json:"absence" doc:"filter key must be absent (filter value is ignored)"`
+	Regex     string `yaml:"regex" json:"regex" doc:"match filter value as a regular expression"`
 }
 
 func MetricEncodeFilterTypeName(t string) string {


### PR DESCRIPTION
## Description

Add a new filter to prometheus metrics to allow removing `Duplicate` fields when using deduper merge mode.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
