### PR TITLE
NETOBSERV-1427: Added config watcher and supporting metrics reloading

### DIFF
--- a/cmd/flowlogs-pipeline/main.go
+++ b/cmd/flowlogs-pipeline/main.go
@@ -147,6 +147,7 @@ func initFlags() {
 	rootCmd.PersistentFlags().IntVar(&opts.Profile.Port, "profile.port", 0, "Go pprof tool port (default: disabled)")
 	rootCmd.PersistentFlags().StringVar(&opts.PipeLine, "pipeline", "", "json of config file pipeline field")
 	rootCmd.PersistentFlags().StringVar(&opts.Parameters, "parameters", "", "json of config file parameters field")
+	rootCmd.PersistentFlags().StringVar(&opts.DynamicParameters, "dynamicParameters", "", "json of configmap location for dynamic parameters")
 	rootCmd.PersistentFlags().StringVar(&opts.MetricsSettings, "metricsSettings", "", "json for global metrics settings")
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,22 +27,35 @@ import (
 )
 
 type Options struct {
-	PipeLine        string
-	Parameters      string
-	MetricsSettings string
-	Health          Health
-	Profile         Profile
+	PipeLine          string
+	Parameters        string
+	DynamicParameters string
+	MetricsSettings   string
+	Health            Health
+	Profile           Profile
 }
 
 // (nolint => needs refactoring)
 //
 //nolint:revive
 type ConfigFileStruct struct {
-	LogLevel        string          `yaml:"log-level,omitempty" json:"log-level,omitempty"`
-	MetricsSettings MetricsSettings `yaml:"metricsSettings,omitempty" json:"metricsSettings,omitempty"`
-	Pipeline        []Stage         `yaml:"pipeline,omitempty" json:"pipeline,omitempty"`
-	Parameters      []StageParam    `yaml:"parameters,omitempty" json:"parameters,omitempty"`
-	PerfSettings    PerfSettings    `yaml:"perfSettings,omitempty" json:"perfSettings,omitempty"`
+	LogLevel          string            `yaml:"log-level,omitempty" json:"log-level,omitempty"`
+	MetricsSettings   MetricsSettings   `yaml:"metricsSettings,omitempty" json:"metricsSettings,omitempty"`
+	Pipeline          []Stage           `yaml:"pipeline,omitempty" json:"pipeline,omitempty"`
+	Parameters        []StageParam      `yaml:"parameters,omitempty" json:"parameters,omitempty"`
+	PerfSettings      PerfSettings      `yaml:"perfSettings,omitempty" json:"perfSettings,omitempty"`
+	DynamicParameters DynamicParameters `yaml:"dynamicParameters,omitempty" json:"dynamicParameters,omitempty"`
+}
+
+type DynamicParameters struct {
+	Namespace      string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
+	Name           string `yaml:"name,omitempty" json:"name,omitempty"`
+	FileName       string `yaml:"fileName,omitempty" json:"fileName,omitempty"`
+	KubeConfigPath string `yaml:"kubeConfigPath,omitempty" json:"kubeConfigPath,omitempty" doc:"path to kubeconfig file (optional)"`
+}
+
+type HotReloadStruct struct {
+	Parameters []StageParam `yaml:"parameters,omitempty" json:"parameters,omitempty"`
 }
 
 type Health struct {
@@ -153,6 +166,15 @@ func ParseConfig(opts *Options) (ConfigFileStruct, error) {
 		return out, err
 	}
 	logrus.Debugf("params = %v ", out.Parameters)
+
+	if opts.DynamicParameters != "" {
+		err = JSONUnmarshalStrict([]byte(opts.DynamicParameters), &out.DynamicParameters)
+		if err != nil {
+			logrus.Errorf("error when parsing dynamic pipeline parameters: %v", err)
+			return out, err
+		}
+		logrus.Debugf("dynamicParams = %v ", out.DynamicParameters)
+	}
 
 	if opts.MetricsSettings != "" {
 		err = JSONUnmarshalStrict([]byte(opts.MetricsSettings), &out.MetricsSettings)

--- a/pkg/config/pipeline_builder.go
+++ b/pkg/config/pipeline_builder.go
@@ -192,6 +192,33 @@ func (b *PipelineBuilderStage) GetStageParams() []StageParam {
 	return b.pipeline.config
 }
 
+func isStaticParam(param StageParam) bool {
+	if param.Encode != nil && param.Encode.Type == api.PromType {
+		return false
+	}
+	return true
+}
+
+func (b *PipelineBuilderStage) GetStaticStageParams() []StageParam {
+	res := []StageParam{}
+	for _, param := range b.pipeline.config {
+		if isStaticParam(param) {
+			res = append(res, param)
+		}
+	}
+	return res
+}
+
+func (b *PipelineBuilderStage) GetDynamicStageParams() []StageParam {
+	res := []StageParam{}
+	for _, param := range b.pipeline.config {
+		if !isStaticParam(param) {
+			res = append(res, param)
+		}
+	}
+	return res
+}
+
 // IntoConfigFileStruct injects the current pipeline and params in the provided ConfigFileStruct object.
 func (b *PipelineBuilderStage) IntoConfigFileStruct(cfs *ConfigFileStruct) *ConfigFileStruct {
 	cfs.Pipeline = b.GetStages()

--- a/pkg/pipeline/encode/encode.go
+++ b/pkg/pipeline/encode/encode.go
@@ -28,11 +28,16 @@ type encodeNone struct {
 
 type Encoder interface {
 	Encode(in config.GenericMap)
+	Update(config.StageParam)
 }
 
 // Encode encodes a flow before being stored
 func (t *encodeNone) Encode(in config.GenericMap) {
 	t.prevRecord = in
+}
+
+func (t *encodeNone) Update(_ config.StageParam) {
+	log.Warn("Encode None, update not supported")
 }
 
 // NewEncodeNone create a new encode

--- a/pkg/pipeline/encode/encode_kafka.go
+++ b/pkg/pipeline/encode/encode_kafka.go
@@ -66,6 +66,10 @@ func (r *encodeKafka) Encode(entry config.GenericMap) {
 	}
 }
 
+func (r *encodeKafka) Update(_ config.StageParam) {
+	log.Warn("Encode Kafka, update not supported")
+}
+
 // NewEncodeKafka create a new writer to kafka
 func NewEncodeKafka(opMetrics *operational.Metrics, params config.StageParam) (Encoder, error) {
 	log.Debugf("entering NewEncodeKafka")

--- a/pkg/pipeline/encode/encode_prom_test.go
+++ b/pkg/pipeline/encode/encode_prom_test.go
@@ -99,13 +99,13 @@ func Test_NewEncodeProm(t *testing.T) {
 	require.Equal(t, 1, len(encodeProm.metricCommon.aggHistos))
 	require.Equal(t, time.Second, encodeProm.metricCommon.expiryTime)
 
-	require.Equal(t, encodeProm.metricCommon.gauges[0].info.Name, "Bytes")
+	require.Equal(t, encodeProm.metricCommon.gauges["test_Bytes"].info.Name, "Bytes")
 	expectedList := []string{"srcAddr", "dstAddr", "srcPort"}
-	require.Equal(t, encodeProm.metricCommon.gauges[0].info.Labels, expectedList)
+	require.Equal(t, encodeProm.metricCommon.gauges["test_Bytes"].info.Labels, expectedList)
 
-	require.Equal(t, encodeProm.metricCommon.counters[0].info.Name, "Packets")
+	require.Equal(t, encodeProm.metricCommon.counters["test_Packets"].info.Name, "Packets")
 	expectedList = []string{"srcAddr", "dstAddr", "dstPort"}
-	require.Equal(t, encodeProm.metricCommon.counters[0].info.Labels, expectedList)
+	require.Equal(t, encodeProm.metricCommon.counters["test_Packets"].info.Labels, expectedList)
 	entry := test.GetExtractMockEntry()
 	encodeProm.Encode(entry)
 

--- a/pkg/pipeline/encode/encode_s3.go
+++ b/pkg/pipeline/encode/encode_s3.go
@@ -109,6 +109,10 @@ func (s *encodeS3) GenerateStoreHeader(flows []config.GenericMap, startTime time
 	return object
 }
 
+func (s *encodeS3) Update(_ config.StageParam) {
+	log.Warn("Encode S3 Writer, update not supported")
+}
+
 func (s *encodeS3) createObjectTimeoutLoop() {
 	log.Debugf("entering createObjectTimeoutLoop")
 	ticker := time.NewTicker(s.s3Params.WriteTimeout.Duration)
@@ -214,4 +218,8 @@ func (e *encodeS3Writer) putObject(bucket string, objectName string, object map[
 	uploadInfo, err := e.s3Client.PutObject(context.Background(), bucket, objectName, b, int64(b.Len()), minio.PutObjectOptions{ContentType: "application/octet-stream"})
 	log.Debugf("uploadInfo = %v", uploadInfo)
 	return err
+}
+
+func (e *encodeS3Writer) Update(_ config.StageParam) {
+	log.Warn("Encode S3 Writer, update not supported")
 }

--- a/pkg/pipeline/encode/metrics_common.go
+++ b/pkg/pipeline/encode/metrics_common.go
@@ -37,10 +37,10 @@ type mInfoStruct struct {
 }
 
 type MetricsCommonStruct struct {
-	gauges           []mInfoStruct
-	counters         []mInfoStruct
-	histos           []mInfoStruct
-	aggHistos        []mInfoStruct
+	gauges           map[string]mInfoStruct
+	counters         map[string]mInfoStruct
+	histos           map[string]mInfoStruct
+	aggHistos        map[string]mInfoStruct
 	mCache           *putils.TimedCache
 	mChacheLenMetric prometheus.Gauge
 	metricsProcessed prometheus.Counter
@@ -85,24 +85,24 @@ var (
 	)
 )
 
-func (m *MetricsCommonStruct) AddCounter(g interface{}, info *MetricInfo) {
+func (m *MetricsCommonStruct) AddCounter(name string, g interface{}, info *MetricInfo) {
 	mStruct := mInfoStruct{genericMetric: g, info: info}
-	m.counters = append(m.counters, mStruct)
+	m.counters[name] = mStruct
 }
 
-func (m *MetricsCommonStruct) AddGauge(g interface{}, info *MetricInfo) {
+func (m *MetricsCommonStruct) AddGauge(name string, g interface{}, info *MetricInfo) {
 	mStruct := mInfoStruct{genericMetric: g, info: info}
-	m.gauges = append(m.gauges, mStruct)
+	m.gauges[name] = mStruct
 }
 
-func (m *MetricsCommonStruct) AddHist(g interface{}, info *MetricInfo) {
+func (m *MetricsCommonStruct) AddHist(name string, g interface{}, info *MetricInfo) {
 	mStruct := mInfoStruct{genericMetric: g, info: info}
-	m.histos = append(m.histos, mStruct)
+	m.histos[name] = mStruct
 }
 
-func (m *MetricsCommonStruct) AddAggHist(g interface{}, info *MetricInfo) {
+func (m *MetricsCommonStruct) AddAggHist(name string, g interface{}, info *MetricInfo) {
 	mStruct := mInfoStruct{genericMetric: g, info: info}
-	m.aggHistos = append(m.aggHistos, mStruct)
+	m.aggHistos[name] = mStruct
 }
 
 func (m *MetricsCommonStruct) MetricCommonEncode(mci MetricsCommonInterface, metricRecord config.GenericMap) {
@@ -273,6 +273,10 @@ func NewMetricsCommonStruct(opMetrics *operational.Metrics, maxCacheEntries int,
 		errorsCounter:    opMetrics.NewCounterVec(&encodePromErrors),
 		expiryTime:       expiryTime.Duration,
 		exitChan:         putils.ExitChannel(),
+		gauges:           map[string]mInfoStruct{},
+		counters:         map[string]mInfoStruct{},
+		histos:           map[string]mInfoStruct{},
+		aggHistos:        map[string]mInfoStruct{},
 	}
 	go m.cleanupExpiredEntriesLoop(callback)
 	return m

--- a/pkg/pipeline/encode/opentelemetry/encode_otlplogs.go
+++ b/pkg/pipeline/encode/opentelemetry/encode_otlplogs.go
@@ -42,6 +42,10 @@ func (e *EncodeOtlpLogs) Encode(entry config.GenericMap) {
 	e.LogWrite(entry)
 }
 
+func (e *EncodeOtlpLogs) Update(_ config.StageParam) {
+	log.Warn("EncodeOtlpLogs, update not supported")
+}
+
 func NewEncodeOtlpLogs(_ *operational.Metrics, params config.StageParam) (encode.Encoder, error) {
 	log.Tracef("entering NewEncodeOtlpLogs \n")
 	cfg := api.EncodeOtlpLogs{}

--- a/pkg/pipeline/encode/opentelemetry/encode_otlpmetrics.go
+++ b/pkg/pipeline/encode/opentelemetry/encode_otlpmetrics.go
@@ -45,6 +45,10 @@ type EncodeOtlpMetrics struct {
 	metricCommon *encode.MetricsCommonStruct
 }
 
+func (e *EncodeOtlpMetrics) Update(_ config.StageParam) {
+	log.Warn("EncodeOtlpMetrics, update not supported")
+}
+
 // Encode encodes a metric to be exported
 func (e *EncodeOtlpMetrics) Encode(metricRecord config.GenericMap) {
 	log.Tracef("entering EncodeOtlpMetrics. entry = %v", metricRecord)
@@ -140,7 +144,7 @@ func NewEncodeOtlpMetrics(opMetrics *operational.Metrics, params config.StagePar
 				log.Errorf("error during counter creation: %v", err)
 				return nil, err
 			}
-			metricCommon.AddCounter(counter, mInfo)
+			metricCommon.AddCounter(fullMetricName, counter, mInfo)
 		case api.MetricGauge:
 			// at implementation time, only asynchronous gauges are supported by otel in golang
 			obs := Float64Gauge{observations: make(map[string]Float64GaugeEntry)}
@@ -152,7 +156,7 @@ func NewEncodeOtlpMetrics(opMetrics *operational.Metrics, params config.StagePar
 				log.Errorf("error during gauge creation: %v", err)
 				return nil, err
 			}
-			metricCommon.AddGauge(gauge, mInfo)
+			metricCommon.AddGauge(fullMetricName, gauge, mInfo)
 		case api.MetricHistogram:
 			var histo metric.Float64Histogram
 			if len(mCfg.Buckets) == 0 {
@@ -167,7 +171,7 @@ func NewEncodeOtlpMetrics(opMetrics *operational.Metrics, params config.StagePar
 				log.Errorf("error during histogram creation: %v", err)
 				return nil, err
 			}
-			metricCommon.AddHist(histo, mInfo)
+			metricCommon.AddHist(fullMetricName, histo, mInfo)
 		case api.MetricAggHistogram:
 			fallthrough
 		default:

--- a/pkg/pipeline/encode/opentelemetry/encode_otlptrace.go
+++ b/pkg/pipeline/encode/opentelemetry/encode_otlptrace.go
@@ -91,6 +91,10 @@ OUTER:
 	}
 }
 
+func (e *EncodeOtlpTrace) Update(_ config.StageParam) {
+	log.Warn("EncodeOtlpTrace, update not supported")
+}
+
 func NewEncodeOtlpTraces(_ *operational.Metrics, params config.StageParam) (encode.Encoder, error) {
 	log.Tracef("entering NewEncodeOtlpTraces \n")
 	cfg := api.EncodeOtlpTraces{}

--- a/pkg/pipeline/pipeline_watcher.go
+++ b/pkg/pipeline/pipeline_watcher.go
@@ -1,0 +1,114 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+)
+
+type pipelineConfigWatcher struct {
+	clientSet        kubernetes.Clientset
+	cmName           string
+	cmNamespace      string
+	configFile       string
+	pipelineEntryMap map[string]*pipelineEntry
+}
+
+func newPipelineConfigWatcher(cfg *config.ConfigFileStruct, pipelineEntryMap map[string]*pipelineEntry) (*pipelineConfigWatcher, error) {
+	if cfg.DynamicParameters.Name == "" ||
+		cfg.DynamicParameters.Namespace == "" ||
+		cfg.DynamicParameters.FileName == "" {
+		return nil, nil
+	}
+
+	config, err := utils.LoadK8sConfig(cfg.DynamicParameters.KubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	pipelineCW := pipelineConfigWatcher{
+		clientSet:        *clientset,
+		pipelineEntryMap: pipelineEntryMap,
+		cmName:           cfg.DynamicParameters.Name,
+		cmNamespace:      cfg.DynamicParameters.Namespace,
+		configFile:       cfg.DynamicParameters.FileName,
+	}
+
+	return &pipelineCW, nil
+
+}
+
+func (pcw *pipelineConfigWatcher) Run() {
+	for {
+		watcher, err := pcw.clientSet.CoreV1().ConfigMaps(pcw.cmNamespace).Watch(context.TODO(),
+			metav1.SingleObject(metav1.ObjectMeta{Name: pcw.cmName, Namespace: pcw.cmNamespace}))
+		if err != nil {
+			log.Errorf("Unable to create watcher: %s", err)
+			return
+		}
+		pcw.handleEvent(watcher.ResultChan())
+	}
+}
+
+func (pcw *pipelineConfigWatcher) handleEvent(eventChannel <-chan watch.Event) {
+	for {
+		event, open := <-eventChannel
+		if open {
+			switch event.Type {
+			case watch.Added:
+				fallthrough
+			case watch.Modified:
+				// Update our endpoint
+				if updatedMap, ok := event.Object.(*corev1.ConfigMap); ok {
+					pcw.updateFromConfigmap(updatedMap)
+				}
+			case watch.Deleted:
+				fallthrough
+			case watch.Bookmark:
+			case watch.Error:
+			default:
+				// Do nothing
+			}
+		} else {
+			// If eventChannel is closed, it means the server has closed the connection
+			return
+		}
+	}
+}
+
+func (pcw *pipelineConfigWatcher) updateFromConfigmap(cm *corev1.ConfigMap) {
+	if rawConfig, ok := cm.Data[pcw.configFile]; ok {
+		config := config.HotReloadStruct{}
+		err := json.Unmarshal([]byte(rawConfig), &config)
+		if err != nil {
+			log.Errorf("Cannot parse config: %v", err)
+			return
+		}
+		for _, param := range config.Parameters {
+			if pentry, ok := pcw.pipelineEntryMap[param.Name]; ok {
+				pcw.updateEntry(pentry, param)
+			}
+		}
+	}
+}
+
+func (pcw *pipelineConfigWatcher) updateEntry(pEntry *pipelineEntry, param config.StageParam) {
+	switch pEntry.stageType {
+	case StageEncode:
+		pEntry.Encoder.Update(param)
+	default:
+		log.Warningf("Hot reloading not supported for: %s", pEntry.stageType)
+	}
+}

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -1,0 +1,41 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	kubeConfigEnvVariable = "KUBECONFIG"
+)
+
+func LoadK8sConfig(kubeConfigPath string) (*rest.Config, error) {
+	// if no config path is provided, load it from the env variable
+	if kubeConfigPath == "" {
+		kubeConfigPath = os.Getenv(kubeConfigEnvVariable)
+	}
+	// otherwise, load it from the $HOME/.kube/config file
+	if kubeConfigPath == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("can't get user home dir: %w", err)
+		}
+		kubeConfigPath = path.Join(homeDir, ".kube", "config")
+	}
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err == nil {
+		return config, nil
+	}
+	// fallback: use in-cluster config
+	config, err = rest.InClusterConfig()
+	if err != nil {
+		return nil, fmt.Errorf("can't access kubenetes. Tried using config from: "+
+			"config parameter, %s env, homedir and InClusterConfig. Got: %w",
+			kubeConfigEnvVariable, err)
+	}
+	return config, nil
+}


### PR DESCRIPTION
## Description

Added new type to watch a configmap and notify prometheus encoder

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [X] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
