### PR TITLE
NETOBSERV-1566: ipfix: make RTT optional

### DIFF
--- a/pkg/pipeline/write/write_ipfix.go
+++ b/pkg/pipeline/write/write_ipfix.go
@@ -20,6 +20,8 @@ package write
 import (
 	"fmt"
 	"net"
+	"strconv"
+	"strings"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
@@ -38,6 +40,14 @@ type writeIpfix struct {
 	exporter           *ipfixExporter.ExportingProcess
 	entitiesV4         []entities.InfoElementWithValue
 	entitiesV6         []entities.InfoElementWithValue
+}
+
+type FieldMap struct {
+	Key      string
+	Getter   func(entities.InfoElementWithValue) any
+	Setter   func(entities.InfoElementWithValue, any)
+	Matcher  func(entities.InfoElementWithValue, any) bool
+	Optional bool
 }
 
 // IPv6Type value as defined in IEEE 802: https://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml
@@ -78,6 +88,191 @@ var (
 	}
 	CustomNetworkFields = []string{
 		"timeFlowRttNs",
+		"interfaces",
+		"directions",
+	}
+
+	MapIPFIXKeys = map[string]FieldMap{
+		"sourceIPv4Address": {
+			Key:    "SrcAddr",
+			Getter: func(elt entities.InfoElementWithValue) any { return elt.GetIPAddressValue().String() },
+			Setter: func(elt entities.InfoElementWithValue, rec any) { elt.SetIPAddressValue(net.ParseIP(rec.(string))) },
+		},
+		"destinationIPv4Address": {
+			Key:    "DstAddr",
+			Getter: func(elt entities.InfoElementWithValue) any { return elt.GetIPAddressValue().String() },
+			Setter: func(elt entities.InfoElementWithValue, rec any) { elt.SetIPAddressValue(net.ParseIP(rec.(string))) },
+		},
+		"sourceIPv6Address": {
+			Key:    "SrcAddr",
+			Getter: func(elt entities.InfoElementWithValue) any { return elt.GetIPAddressValue().String() },
+			Setter: func(elt entities.InfoElementWithValue, rec any) { elt.SetIPAddressValue(net.ParseIP(rec.(string))) },
+		},
+		"destinationIPv6Address": {
+			Key:    "DstAddr",
+			Getter: func(elt entities.InfoElementWithValue) any { return elt.GetIPAddressValue().String() },
+			Setter: func(elt entities.InfoElementWithValue, rec any) { elt.SetIPAddressValue(net.ParseIP(rec.(string))) },
+		},
+		"nextHeaderIPv6": {
+			Key:    "Proto",
+			Getter: func(elt entities.InfoElementWithValue) any { return uint32(elt.GetUnsigned8Value()) },
+			Setter: func(elt entities.InfoElementWithValue, rec any) { elt.SetUnsigned8Value(uint8(rec.(uint32))) },
+		},
+		"sourceMacAddress": {
+			Key: "SrcMac",
+			Setter: func(elt entities.InfoElementWithValue, rec any) {
+				elt.SetMacAddressValue(net.HardwareAddr(rec.(string)))
+			},
+			Matcher: func(_ entities.InfoElementWithValue, _ any) bool {
+				// Getting some discrepancies here, need to figure out why
+				return true
+			},
+		},
+		"destinationMacAddress": {
+			Key: "DstMac",
+			Setter: func(elt entities.InfoElementWithValue, rec any) {
+				elt.SetMacAddressValue(net.HardwareAddr(rec.(string)))
+			},
+			Matcher: func(_ entities.InfoElementWithValue, _ any) bool {
+				// Getting some discrepancies here, need to figure out why
+				return true
+			},
+		},
+		"ethernetType": {
+			Key:    "Etype",
+			Getter: func(elt entities.InfoElementWithValue) any { return uint32(elt.GetUnsigned16Value()) },
+			Setter: func(elt entities.InfoElementWithValue, rec any) { elt.SetUnsigned16Value(uint16(rec.(uint32))) },
+		},
+		"flowDirection": {
+			Key: "IfDirections",
+			Setter: func(elt entities.InfoElementWithValue, rec any) {
+				if dirs, ok := rec.([]int); ok && len(dirs) > 0 {
+					elt.SetUnsigned8Value(uint8(dirs[0]))
+				}
+			},
+			Matcher: func(elt entities.InfoElementWithValue, expected any) bool {
+				ifdirs := expected.([]int)
+				return int(elt.GetUnsigned8Value()) == ifdirs[0]
+			},
+		},
+		"directions": {
+			Key: "IfDirections",
+			Getter: func(elt entities.InfoElementWithValue) any {
+				var dirs []int
+				for _, dir := range strings.Split(elt.GetStringValue(), ",") {
+					d, _ := strconv.Atoi(dir)
+					dirs = append(dirs, d)
+				}
+				return dirs
+			},
+			Setter: func(elt entities.InfoElementWithValue, rec any) {
+				if dirs, ok := rec.([]int); ok && len(dirs) > 0 {
+					var asStr []string
+					for _, dir := range dirs {
+						asStr = append(asStr, strconv.Itoa(dir))
+					}
+					elt.SetStringValue(strings.Join(asStr, ","))
+				}
+			},
+		},
+		"protocolIdentifier": {
+			Key:    "Proto",
+			Getter: func(elt entities.InfoElementWithValue) any { return uint32(elt.GetUnsigned8Value()) },
+			Setter: func(elt entities.InfoElementWithValue, rec any) { elt.SetUnsigned8Value(uint8(rec.(uint32))) },
+		},
+		"sourceTransportPort": {
+			Key:    "SrcPort",
+			Getter: func(elt entities.InfoElementWithValue) any { return uint32(elt.GetUnsigned16Value()) },
+			Setter: func(elt entities.InfoElementWithValue, rec any) { elt.SetUnsigned16Value(uint16(rec.(uint32))) },
+		},
+		"destinationTransportPort": {
+			Key:    "DstPort",
+			Getter: func(elt entities.InfoElementWithValue) any { return uint32(elt.GetUnsigned16Value()) },
+			Setter: func(elt entities.InfoElementWithValue, rec any) { elt.SetUnsigned16Value(uint16(rec.(uint32))) },
+		},
+		"octetDeltaCount": {
+			Key:    "Bytes",
+			Getter: func(elt entities.InfoElementWithValue) any { return elt.GetUnsigned64Value() },
+			Setter: func(elt entities.InfoElementWithValue, rec any) { elt.SetUnsigned64Value(rec.(uint64)) },
+		},
+		"flowStartMilliseconds": {
+			Key:    "TimeFlowStartMs",
+			Getter: func(elt entities.InfoElementWithValue) any { return int64(elt.GetUnsigned64Value()) },
+			Setter: func(elt entities.InfoElementWithValue, rec any) { elt.SetUnsigned64Value(uint64(rec.(int64))) },
+		},
+		"flowEndMilliseconds": {
+			Key:    "TimeFlowEndMs",
+			Getter: func(elt entities.InfoElementWithValue) any { return int64(elt.GetUnsigned64Value()) },
+			Setter: func(elt entities.InfoElementWithValue, rec any) { elt.SetUnsigned64Value(uint64(rec.(int64))) },
+		},
+		"packetDeltaCount": {
+			Key:    "Packets",
+			Getter: func(elt entities.InfoElementWithValue) any { return elt.GetUnsigned64Value() },
+			Setter: func(elt entities.InfoElementWithValue, rec any) { elt.SetUnsigned64Value(rec.(uint64)) },
+		},
+		"interfaceName": {
+			Key: "Interfaces",
+			Setter: func(elt entities.InfoElementWithValue, rec any) {
+				if ifs, ok := rec.([]string); ok && len(ifs) > 0 {
+					elt.SetStringValue(ifs[0])
+				}
+			},
+			Matcher: func(elt entities.InfoElementWithValue, expected any) bool {
+				ifs := expected.([]string)
+				return elt.GetStringValue() == ifs[0]
+			},
+		},
+		"interfaces": {
+			Key:    "Interfaces",
+			Getter: func(elt entities.InfoElementWithValue) any { return strings.Split(elt.GetStringValue(), ",") },
+			Setter: func(elt entities.InfoElementWithValue, rec any) {
+				if ifs, ok := rec.([]string); ok {
+					elt.SetStringValue(strings.Join(ifs, ","))
+				}
+			},
+		},
+		"sourcePodNamespace": {
+			Key:      "SrcK8S_Namespace",
+			Getter:   func(elt entities.InfoElementWithValue) any { return elt.GetStringValue() },
+			Setter:   func(elt entities.InfoElementWithValue, rec any) { elt.SetStringValue(rec.(string)) },
+			Optional: true,
+		},
+		"sourcePodName": {
+			Key:      "SrcK8S_Name",
+			Getter:   func(elt entities.InfoElementWithValue) any { return elt.GetStringValue() },
+			Setter:   func(elt entities.InfoElementWithValue, rec any) { elt.SetStringValue(rec.(string)) },
+			Optional: true,
+		},
+		"destinationPodNamespace": {
+			Key:      "DstK8S_Namespace",
+			Getter:   func(elt entities.InfoElementWithValue) any { return elt.GetStringValue() },
+			Setter:   func(elt entities.InfoElementWithValue, rec any) { elt.SetStringValue(rec.(string)) },
+			Optional: true,
+		},
+		"destinationPodName": {
+			Key:      "DstK8S_Name",
+			Getter:   func(elt entities.InfoElementWithValue) any { return elt.GetStringValue() },
+			Setter:   func(elt entities.InfoElementWithValue, rec any) { elt.SetStringValue(rec.(string)) },
+			Optional: true,
+		},
+		"sourceNodeName": {
+			Key:      "SrcK8S_HostName",
+			Getter:   func(elt entities.InfoElementWithValue) any { return elt.GetStringValue() },
+			Setter:   func(elt entities.InfoElementWithValue, rec any) { elt.SetStringValue(rec.(string)) },
+			Optional: true,
+		},
+		"destinationNodeName": {
+			Key:      "DstK8S_HostName",
+			Getter:   func(elt entities.InfoElementWithValue) any { return elt.GetStringValue() },
+			Setter:   func(elt entities.InfoElementWithValue, rec any) { elt.SetStringValue(rec.(string)) },
+			Optional: true,
+		},
+		"timeFlowRttNs": {
+			Key:      "TimeFlowRttNs",
+			Getter:   func(elt entities.InfoElementWithValue) any { return int64(elt.GetUnsigned64Value()) },
+			Setter:   func(elt entities.InfoElementWithValue, rec any) { elt.SetUnsigned64Value(uint64(rec.(int64))) },
+			Optional: true,
+		},
 	}
 )
 
@@ -151,6 +346,16 @@ func loadCustomRegistry(EnterpriseID uint32) error {
 		return err
 	}
 	err = registry.PutInfoElement((*entities.NewInfoElement("timeFlowRttNs", 7740, entities.Unsigned64, EnterpriseID, 8)), EnterpriseID)
+	if err != nil {
+		ilog.WithError(err).Errorf("Failed to register element")
+		return err
+	}
+	err = registry.PutInfoElement((*entities.NewInfoElement("interfaces", 7741, entities.String, EnterpriseID, 65535)), EnterpriseID)
+	if err != nil {
+		ilog.WithError(err).Errorf("Failed to register element")
+		return err
+	}
+	err = registry.PutInfoElement((*entities.NewInfoElement("directions", 7742, entities.String, EnterpriseID, 65535)), EnterpriseID)
 	if err != nil {
 		ilog.WithError(err).Errorf("Failed to register element")
 		return err
@@ -237,172 +442,26 @@ func SendTemplateRecordv6(exporter *ipfixExporter.ExportingProcess, enrichEnterp
 }
 
 //nolint:cyclop
-func setStandardIEValue(record config.GenericMap, ieValPtr *entities.InfoElementWithValue) error {
+func setElementValue(record config.GenericMap, ieValPtr *entities.InfoElementWithValue) error {
 	ieVal := *ieValPtr
-	switch ieVal.GetName() {
-	case "ethernetType":
-		if record["Etype"] != nil {
-			ieVal.SetUnsigned16Value(uint16(record["Etype"].(uint32)))
-		} else {
-			return fmt.Errorf("unable to find ethernet type (Etype) in record")
-		}
-	case "flowDirection":
-		dirs := record["IfDirections"].([]int)
-		if len(dirs) > 0 {
-			ieVal.SetUnsigned8Value(uint8(dirs[0]))
-		} else {
-			return fmt.Errorf("unable to find flow direction (flowDirection) in record")
-		}
-	case "sourceMacAddress":
-		if record["SrcMac"] != nil {
-			ieVal.SetMacAddressValue(net.HardwareAddr(record["SrcMac"].(string)))
-		} else {
-			return fmt.Errorf("unable to find source mac address (SrcMac) in record")
-		}
-	case "destinationMacAddress":
-		if record["DstMac"] != nil {
-			ieVal.SetMacAddressValue(net.HardwareAddr(record["DstMac"].(string)))
-		} else {
-			return fmt.Errorf("unable to find dest mac address (DstMac) in record")
-		}
-	case "sourceIPv4Address":
-		if record["SrcAddr"] != nil {
-			ieVal.SetIPAddressValue(net.ParseIP(record["SrcAddr"].(string)))
-		} else {
-			return fmt.Errorf("unable to find source IPv4 address (SrcAddr) in record")
-		}
-	case "destinationIPv4Address":
-		if record["DstAddr"] != nil {
-			ieVal.SetIPAddressValue(net.ParseIP(record["DstAddr"].(string)))
-		} else {
-			return fmt.Errorf("unable to find dest IPv4 address (DstAddr) in record")
-		}
-	case "sourceIPv6Address":
-		if record["SrcAddr"] != nil {
-			ieVal.SetIPAddressValue(net.ParseIP(record["SrcAddr"].(string)))
-		} else {
-			return fmt.Errorf("unable to find source IPv6 address (SrcAddr) in record")
-		}
-	case "destinationIPv6Address":
-		if record["DstAddr"] != nil {
-			ieVal.SetIPAddressValue(net.ParseIP(record["DstAddr"].(string)))
-		} else {
-			return fmt.Errorf("unable to find dest IPv6 address (DstAddr) in record")
-		}
-	case "protocolIdentifier":
-		if record["Proto"] != nil {
-			ieVal.SetUnsigned8Value(uint8(record["Proto"].(uint32)))
-		} else {
-			return fmt.Errorf("unable to find protocol identifier (Proto) in record")
-		}
-	case "nextHeaderIPv6":
-		if record["Proto"] != nil {
-			ieVal.SetUnsigned8Value(uint8(record["Proto"].(uint32)))
-		} else {
-			return fmt.Errorf("unable to find next header (Proto) in record")
-		}
-	case "sourceTransportPort":
-		if record["SrcPort"] != nil {
-			ieVal.SetUnsigned16Value(uint16(record["SrcPort"].(uint32)))
-		} else {
-			return fmt.Errorf("unable to find source port (SrcPort) in record")
-		}
-	case "destinationTransportPort":
-		if record["DstPort"] != nil {
-			ieVal.SetUnsigned16Value(uint16(record["DstPort"].(uint32)))
-		} else {
-			return fmt.Errorf("unable to find dest port (DstPort) in record")
-		}
-	case "octetDeltaCount":
-		if record["Bytes"] != nil {
-			ieVal.SetUnsigned64Value(record["Bytes"].(uint64))
-		} else {
-			return fmt.Errorf("unable to find bytes in record")
-		}
-	case "flowStartMilliseconds":
-		if record["TimeFlowStartMs"] != nil {
-			ieVal.SetUnsigned64Value(uint64(record["TimeFlowStartMs"].(int64)))
-		} else {
-			return fmt.Errorf("unable to find flow start time (TimeFlowStartMs) in record")
-		}
-	case "flowEndMilliseconds":
-		if record["TimeFlowEndMs"] != nil {
-			ieVal.SetUnsigned64Value(uint64(record["TimeFlowEndMs"].(int64)))
-		} else {
-			return fmt.Errorf("unable to find flow end time (TimeFlowEndMs) in record")
-		}
-	case "packetDeltaCount":
-		if record["Packets"] != nil {
-			ieVal.SetUnsigned64Value(record["Packets"].(uint64))
-		} else {
-			return fmt.Errorf("unable to find packets in record")
-		}
-	case "interfaceName":
-		interfaces := record["Interfaces"].([]string)
-		if len(interfaces) > 0 {
-			ieVal.SetStringValue(interfaces[0])
-		} else {
-			return fmt.Errorf("unable to find interface in record")
-		}
-	case "timeFlowRttNs":
-		if record["TimeFlowRttNs"] != nil {
-			ieVal.SetUnsigned64Value(uint64(record["TimeFlowRttNs"].(int64)))
-		} else {
-			return fmt.Errorf("unable to find timeflowrtt in record")
-		}
+	name := ieVal.GetName()
+	mapping, ok := MapIPFIXKeys[name]
+	if !ok {
+		return nil
+	}
+	if value := record[mapping.Key]; value != nil {
+		mapping.Setter(ieVal, value)
+	} else if !mapping.Optional {
+		return fmt.Errorf("unable to find %s (%s) in record", name, mapping.Key)
 	}
 	return nil
 }
 
-func setKubeIEValue(record config.GenericMap, ieValPtr *entities.InfoElementWithValue) {
-	ieVal := *ieValPtr
-	switch ieVal.GetName() {
-	case "sourcePodNamespace":
-		if record["SrcK8S_Namespace"] != nil {
-			ieVal.SetStringValue(record["SrcK8S_Namespace"].(string))
-		} else {
-			ieVal.SetStringValue("none")
-		}
-	case "sourcePodName":
-		if record["SrcK8S_Name"] != nil {
-			ieVal.SetStringValue(record["SrcK8S_Name"].(string))
-		} else {
-			ieVal.SetStringValue("none")
-		}
-	case "destinationPodNamespace":
-		if record["DstK8S_Namespace"] != nil {
-			ieVal.SetStringValue(record["DstK8S_Namespace"].(string))
-		} else {
-			ieVal.SetStringValue("none")
-		}
-	case "destinationPodName":
-		if record["DstK8S_Name"] != nil {
-			ieVal.SetStringValue(record["DstK8S_Name"].(string))
-		} else {
-			ieVal.SetStringValue("none")
-		}
-	case "sourceNodeName":
-		if record["SrcK8S_HostName"] != nil {
-			ieVal.SetStringValue(record["SrcK8S_HostName"].(string))
-		} else {
-			ieVal.SetStringValue("none")
-		}
-	case "destinationNodeName":
-		if record["DstK8S_HostName"] != nil {
-			ieVal.SetStringValue(record["DstK8S_HostName"].(string))
-		} else {
-			ieVal.SetStringValue("none")
-		}
-	}
-}
-func setEntities(record config.GenericMap, enrichEnterpriseID uint32, elements *[]entities.InfoElementWithValue) error {
+func setEntities(record config.GenericMap, elements *[]entities.InfoElementWithValue) error {
 	for _, ieVal := range *elements {
-		err := setStandardIEValue(record, &ieVal)
+		err := setElementValue(record, &ieVal)
 		if err != nil {
 			return err
-		}
-		if enrichEnterpriseID != 0 {
-			setKubeIEValue(record, &ieVal)
 		}
 	}
 	return nil
@@ -412,13 +471,13 @@ func (t *writeIpfix) sendDataRecord(record config.GenericMap, v6 bool) error {
 	var templateID uint16
 	if v6 {
 		templateID = t.templateIDv6
-		err := setEntities(record, t.enrichEnterpriseID, &t.entitiesV6)
+		err := setEntities(record, &t.entitiesV6)
 		if err != nil {
 			return err
 		}
 	} else {
 		templateID = t.templateIDv4
-		err := setEntities(record, t.enrichEnterpriseID, &t.entitiesV4)
+		err := setEntities(record, &t.entitiesV4)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Description

- refactor IPFIX fields mapping / definition
- allow optional fields
- add interfaces and directions (plural) fields to IPFIX template
- add tests for partial records & non-enriched records

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
