### PR TITLE
NETOBSERV-1597: skip RecordKeyMissing error

### DIFF
--- a/pkg/pipeline/encode/metrics_common.go
+++ b/pkg/pipeline/encode/metrics_common.go
@@ -228,8 +228,8 @@ func (m *MetricsCommonStruct) extractGenericValue(flow config.GenericMap, info *
 	}
 	val, found := flow[info.ValueKey]
 	if !found {
-		// No value means 0 to keep storage lightweight
-		return 0
+		// No value might mean 0 for counters, to keep storage lightweight - it can safely be ignored
+		return nil
 	}
 	return val
 }

--- a/pkg/pipeline/encode/metrics_common.go
+++ b/pkg/pipeline/encode/metrics_common.go
@@ -228,8 +228,8 @@ func (m *MetricsCommonStruct) extractGenericValue(flow config.GenericMap, info *
 	}
 	val, found := flow[info.ValueKey]
 	if !found {
-		m.errorsCounter.WithLabelValues("RecordKeyMissing", info.Name, info.ValueKey).Inc()
-		return nil
+		// No value means 0 to keep storage lightweight
+		return 0
 	}
 	return val
 }


### PR DESCRIPTION
## Description

Skip all `RecordKeyMissing` and consider these as `0` since we removed empty fields from eBPF agent.

https://github.com/netobserv/netobserv-ebpf-agent/blob/release-1.5/pkg/decode/decode_protobuf.go#L61-L67

If this needs to be configurable for specific cases please let me know. 

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [X] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [X] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
