### PR TITLE
NETOBSERV-1248: shared k8s cache

### DIFF
--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -37,7 +37,7 @@ jobs:
       - name: get short sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build and push manifest with images
-        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make images
+        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} IMAGE_CACHE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}-cache:${{ env.short_sha }} make images
       - uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /flowlogs-pipeline
 /confgenerator
+/k8s-cache
 /bin/
 cover.out

--- a/README.md
+++ b/README.md
@@ -924,7 +924,7 @@ General
   
 Develop  
   lint                  Lint the code  
-  build                 Build flowlogs-pipeline executable and update the docs  
+  build                 Build flowlogs-pipeline executables and update the docs  
   docs                  Update flowlogs-pipeline documentation  
   clean                 Clean  
   tests-unit            Unit tests  

--- a/cmd/k8s-cache/main.go
+++ b/cmd/k8s-cache/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	buildVersion = "unknown"
+	buildDate    = "unknown"
+	app          = "flp-cache"
+	configPath   = flag.String("config", "", "path to a config file")
+	versionFlag  = flag.Bool("v", false, "print version")
+	log          = logrus.WithField("module", "main")
+)
+
+type Config struct {
+	KubeConfigPath string          `yaml:"kubeConfigPath"`
+	KafkaConfig    api.EncodeKafka `yaml:"kafkaConfig"`
+	PProfPort      int32           `yaml:"pprofPort"` // TODO: manage pprof
+	LogLevel       string          `yaml:"logLevel"`
+}
+
+func main() {
+	flag.Parse()
+
+	appVersion := fmt.Sprintf("%s [build version: %s, build date: %s]", app, buildVersion, buildDate)
+	if *versionFlag {
+		fmt.Println(appVersion)
+		os.Exit(0)
+	}
+
+	cfg, err := readConfig(*configPath)
+	if err != nil {
+		log.WithError(err).Fatal("error reading config file")
+	}
+
+	lvl, err := logrus.ParseLevel(cfg.LogLevel)
+	if err != nil {
+		log.Errorf("Log level %s not recognized, using info", cfg.LogLevel)
+		lvl = logrus.InfoLevel
+	}
+	logrus.SetLevel(lvl)
+	log.Infof("Starting %s at log level %s", appVersion, lvl)
+	log.Infof("Configuration: %#v", cfg)
+
+	err = kubernetes.InitInformerDatasource(cfg.KubeConfigPath, &cfg.KafkaConfig)
+	if err != nil {
+		log.WithError(err).Fatal("error initializing Kubernetes & informers")
+	}
+
+	stopCh := utils.SetupElegantExit()
+	<-stopCh
+}
+
+func readConfig(path string) (*Config, error) {
+	var cfg Config
+	if len(path) == 0 {
+		return &cfg, nil
+	}
+	yamlFile, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	err = yaml.Unmarshal(yamlFile, &cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cfg, err
+}

--- a/contrib/docker/cache.Dockerfile
+++ b/contrib/docker/cache.Dockerfile
@@ -1,0 +1,29 @@
+# We do not use --platform feature to auto fill this ARG because of incompatibility between podman and docker
+ARG TARGETPLATFORM=linux/amd64
+ARG BUILDPLATFORM=linux/amd64
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22 as builder
+
+ARG TARGETPLATFORM
+ARG TARGETARCH=amd64
+WORKDIR /app
+
+# Copy source code
+COPY go.mod .
+COPY go.sum .
+COPY Makefile .
+COPY .mk/ .mk/
+COPY .bingo/ .bingo/
+COPY vendor/ vendor/
+COPY .git/ .git/
+COPY cmd/ cmd/
+COPY pkg/ pkg/
+
+RUN git status --porcelain
+RUN GOARCH=$TARGETARCH make build_k8s_cache
+
+# final stage
+FROM  --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:9.4
+
+COPY --from=builder /app/k8s-cache /app/
+
+ENTRYPOINT ["/app/k8s-cache"]

--- a/docs/api.md
+++ b/docs/api.md
@@ -247,6 +247,32 @@ Following is the supported API format for network transformations:
                      output: entry output field
                      protocol: entry protocol field
          kubeConfigPath: path to kubeconfig file (optional)
+         kafkaCacheConfig: Kafka config for informers cache (optional)
+             brokers: list of kafka broker addresses
+             topic: kafka topic to listen on
+             groupid: separate groupid for each consumer on specified topic
+             groupBalancers: list of balancing strategies (range, roundRobin, rackAffinity)
+             startOffset: FirstOffset (least recent - default) or LastOffset (most recent) offset available for a partition
+             batchReadTimeout: how often (in milliseconds) to process input
+             decoder: decoder to use (E.g. json or protobuf)
+                 type: (enum) one of the following:
+                    json: JSON decoder
+                    protobuf: Protobuf decoder
+             batchMaxLen: the number of accumulated flows before being forwarded for processing
+             pullQueueCapacity: the capacity of the queue use to store pulled flows
+             pullMaxBytes: the maximum number of bytes being pulled from kafka
+             commitInterval: the interval (in milliseconds) at which offsets are committed to the broker.  If 0, commits will be handled synchronously.
+             tls: TLS client configuration (optional)
+                 insecureSkipVerify: skip client verifying the server's certificate chain and host name
+                 caCertPath: path to the CA certificate
+                 userCertPath: path to the user certificate
+                 userKeyPath: path to the user private key
+             sasl: SASL configuration (optional)
+                 type: SASL type
+                    plain: Plain SASL
+                    scramSHA512: SCRAM/SHA512 SASL
+                 clientIDPath: path to the client ID / SASL username
+                 clientSecretPath: path to the client secret / SASL password
          servicesFile: path to services file (optional, default: /etc/services)
          protocolsFile: path to protocols file (optional, default: /etc/protocols)
          subnetLabels: configure subnet and IPs custom labels

--- a/pkg/api/transform_network.go
+++ b/pkg/api/transform_network.go
@@ -18,12 +18,13 @@
 package api
 
 type TransformNetwork struct {
-	Rules          NetworkTransformRules         `yaml:"rules" json:"rules" doc:"list of transform rules, each includes:"`
-	KubeConfigPath string                        `yaml:"kubeConfigPath,omitempty" json:"kubeConfigPath,omitempty" doc:"path to kubeconfig file (optional)"`
-	ServicesFile   string                        `yaml:"servicesFile,omitempty" json:"servicesFile,omitempty" doc:"path to services file (optional, default: /etc/services)"`
-	ProtocolsFile  string                        `yaml:"protocolsFile,omitempty" json:"protocolsFile,omitempty" doc:"path to protocols file (optional, default: /etc/protocols)"`
-	SubnetLabels   []NetworkTransformSubnetLabel `yaml:"subnetLabels,omitempty" json:"subnetLabels,omitempty" doc:"configure subnet and IPs custom labels"`
-	DirectionInfo  NetworkTransformDirectionInfo `yaml:"directionInfo,omitempty" json:"directionInfo,omitempty" doc:"information to reinterpret flow direction (optional, to use with reinterpret_direction rule)"`
+	Rules            NetworkTransformRules         `yaml:"rules" json:"rules" doc:"list of transform rules, each includes:"`
+	KubeConfigPath   string                        `yaml:"kubeConfigPath,omitempty" json:"kubeConfigPath,omitempty" doc:"path to kubeconfig file (optional)"`
+	KafkaCacheConfig *IngestKafka                  `yaml:"kafkaCacheConfig,omitempty" json:"kafkaCacheConfig,omitempty" doc:"Kafka config for informers cache (optional)"`
+	ServicesFile     string                        `yaml:"servicesFile,omitempty" json:"servicesFile,omitempty" doc:"path to services file (optional, default: /etc/services)"`
+	ProtocolsFile    string                        `yaml:"protocolsFile,omitempty" json:"protocolsFile,omitempty" doc:"path to protocols file (optional, default: /etc/protocols)"`
+	SubnetLabels     []NetworkTransformSubnetLabel `yaml:"subnetLabels,omitempty" json:"subnetLabels,omitempty" doc:"configure subnet and IPs custom labels"`
+	DirectionInfo    NetworkTransformDirectionInfo `yaml:"directionInfo,omitempty" json:"directionInfo,omitempty" doc:"information to reinterpret flow direction (optional, to use with reinterpret_direction rule)"`
 }
 
 func (tn *TransformNetwork) GetServiceFiles() (string, string) {

--- a/pkg/kafka/reader.go
+++ b/pkg/kafka/reader.go
@@ -1,0 +1,117 @@
+package kafka
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	kafkago "github.com/segmentio/kafka-go"
+	"github.com/sirupsen/logrus"
+)
+
+var klog = logrus.WithField("component", "kafka-reader")
+
+const defaultBatchReadTimeout = int64(1000)
+const defaultKafkaBatchMaxLength = 500
+const defaultKafkaCommitInterval = 500
+
+func NewReader(config *api.IngestKafka) (*kafkago.Reader, int, error) {
+	startOffsetString := config.StartOffset
+	var startOffset int64
+	switch startOffsetString {
+	case "FirstOffset", "":
+		startOffset = kafkago.FirstOffset
+	case "LastOffset":
+		startOffset = kafkago.LastOffset
+	default:
+		startOffset = kafkago.FirstOffset
+		klog.Errorf("illegal value for StartOffset: %s; using default\n", startOffsetString)
+	}
+	klog.Debugf("startOffset = %v", startOffset)
+	groupBalancers := make([]kafkago.GroupBalancer, 0)
+	for _, gb := range config.GroupBalancers {
+		switch gb {
+		case "range":
+			groupBalancers = append(groupBalancers, &kafkago.RangeGroupBalancer{})
+		case "roundRobin":
+			groupBalancers = append(groupBalancers, &kafkago.RoundRobinGroupBalancer{})
+		case "rackAffinity":
+			groupBalancers = append(groupBalancers, &kafkago.RackAffinityGroupBalancer{})
+		default:
+			klog.Warningf("groupbalancers parameter missing")
+			groupBalancers = append(groupBalancers, &kafkago.RoundRobinGroupBalancer{})
+		}
+	}
+
+	batchReadTimeout := defaultBatchReadTimeout
+	if config.BatchReadTimeout != 0 {
+		batchReadTimeout = config.BatchReadTimeout
+	}
+	klog.Debugf("batchReadTimeout = %d", batchReadTimeout)
+
+	commitInterval := int64(defaultKafkaCommitInterval)
+	if config.CommitInterval != 0 {
+		commitInterval = config.CommitInterval
+	}
+	klog.Debugf("commitInterval = %d", config.CommitInterval)
+
+	dialer := &kafkago.Dialer{
+		Timeout:   kafkago.DefaultDialer.Timeout,
+		DualStack: kafkago.DefaultDialer.DualStack,
+	}
+	if config.TLS != nil {
+		klog.Infof("Using TLS configuration: %v", config.TLS)
+		tlsConfig, err := config.TLS.Build()
+		if err != nil {
+			return nil, 0, err
+		}
+		dialer.TLS = tlsConfig
+	}
+
+	if config.SASL != nil {
+		m, err := utils.SetupSASLMechanism(config.SASL)
+		if err != nil {
+			return nil, 0, err
+		}
+		dialer.SASLMechanism = m
+	}
+
+	readerConfig := kafkago.ReaderConfig{
+		Brokers:        config.Brokers,
+		Topic:          config.Topic,
+		GroupID:        config.GroupID,
+		GroupBalancers: groupBalancers,
+		StartOffset:    startOffset,
+		CommitInterval: time.Duration(commitInterval) * time.Millisecond,
+		Dialer:         dialer,
+	}
+
+	if readerConfig.GroupID == "" {
+		// Use hostname
+		readerConfig.GroupID = os.Getenv("HOSTNAME")
+	}
+
+	if config.PullQueueCapacity > 0 {
+		readerConfig.QueueCapacity = config.PullQueueCapacity
+	}
+
+	if config.PullMaxBytes > 0 {
+		readerConfig.MaxBytes = config.PullMaxBytes
+	}
+
+	bml := defaultKafkaBatchMaxLength
+	if config.BatchMaxLen != 0 {
+		bml = config.BatchMaxLen
+	}
+
+	klog.Debugf("reader config: %#v", readerConfig)
+
+	kafkaReader := kafkago.NewReader(readerConfig)
+	if kafkaReader == nil {
+		return nil, 0, errors.New("NewIngestKafka: failed to create kafka-go reader")
+	}
+
+	return kafkaReader, bml, nil
+}

--- a/pkg/kafka/writer.go
+++ b/pkg/kafka/writer.go
@@ -1,0 +1,77 @@
+package kafka
+
+import (
+	"time"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	kafkago "github.com/segmentio/kafka-go"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	defaultReadTimeoutSeconds  = int64(10)
+	defaultWriteTimeoutSeconds = int64(10)
+)
+
+func NewWriter(config *api.EncodeKafka) (*kafkago.Writer, error) {
+	var balancer kafkago.Balancer
+	switch config.Balancer {
+	case api.KafkaRoundRobin:
+		balancer = &kafkago.RoundRobin{}
+	case api.KafkaLeastBytes:
+		balancer = &kafkago.LeastBytes{}
+	case api.KafkaHash:
+		balancer = &kafkago.Hash{}
+	case api.KafkaCrc32:
+		balancer = &kafkago.CRC32Balancer{}
+	case api.KafkaMurmur2:
+		balancer = &kafkago.Murmur2Balancer{}
+	default:
+		balancer = nil
+	}
+
+	readTimeoutSecs := defaultReadTimeoutSeconds
+	if config.ReadTimeout != 0 {
+		readTimeoutSecs = config.ReadTimeout
+	}
+
+	writeTimeoutSecs := defaultWriteTimeoutSeconds
+	if config.WriteTimeout != 0 {
+		writeTimeoutSecs = config.WriteTimeout
+	}
+
+	transport := kafkago.Transport{}
+	if config.TLS != nil {
+		log.Infof("Using TLS configuration: %v", config.TLS)
+		tlsConfig, err := config.TLS.Build()
+		if err != nil {
+			return nil, err
+		}
+		transport.TLS = tlsConfig
+	}
+
+	if config.SASL != nil {
+		m, err := utils.SetupSASLMechanism(config.SASL)
+		if err != nil {
+			return nil, err
+		}
+		transport.SASL = m
+	}
+
+	kafkaWriter := kafkago.Writer{
+		Addr:         kafkago.TCP(config.Address),
+		Topic:        config.Topic,
+		Balancer:     balancer,
+		ReadTimeout:  time.Duration(readTimeoutSecs) * time.Second,
+		WriteTimeout: time.Duration(writeTimeoutSecs) * time.Second,
+		BatchSize:    config.BatchSize,
+		BatchBytes:   config.BatchBytes,
+		// Temporary fix may be we should implement a batching systems
+		// https://github.com/segmentio/kafka-go/issues/326#issuecomment-519375403
+		BatchTimeout: time.Nanosecond,
+		Transport:    &transport,
+	}
+
+	return &kafkaWriter, nil
+}

--- a/pkg/pipeline/encode/encode_kafka.go
+++ b/pkg/pipeline/encode/encode_kafka.go
@@ -19,21 +19,15 @@ package encode
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/kafka"
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
-	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	kafkago "github.com/segmentio/kafka-go"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
-)
-
-const (
-	defaultReadTimeoutSeconds  = int64(10)
-	defaultWriteTimeoutSeconds = int64(10)
 )
 
 type kafkaWriteMessage interface {
@@ -78,68 +72,14 @@ func NewEncodeKafka(opMetrics *operational.Metrics, params config.StageParam) (E
 		config = *params.Encode.Kafka
 	}
 
-	var balancer kafkago.Balancer
-	switch config.Balancer {
-	case api.KafkaRoundRobin:
-		balancer = &kafkago.RoundRobin{}
-	case api.KafkaLeastBytes:
-		balancer = &kafkago.LeastBytes{}
-	case api.KafkaHash:
-		balancer = &kafkago.Hash{}
-	case api.KafkaCrc32:
-		balancer = &kafkago.CRC32Balancer{}
-	case api.KafkaMurmur2:
-		balancer = &kafkago.Murmur2Balancer{}
-	default:
-		balancer = nil
-	}
-
-	readTimeoutSecs := defaultReadTimeoutSeconds
-	if config.ReadTimeout != 0 {
-		readTimeoutSecs = config.ReadTimeout
-	}
-
-	writeTimeoutSecs := defaultWriteTimeoutSeconds
-	if config.WriteTimeout != 0 {
-		writeTimeoutSecs = config.WriteTimeout
-	}
-
-	transport := kafkago.Transport{}
-	if config.TLS != nil {
-		log.Infof("Using TLS configuration: %v", config.TLS)
-		tlsConfig, err := config.TLS.Build()
-		if err != nil {
-			return nil, err
-		}
-		transport.TLS = tlsConfig
-	}
-
-	if config.SASL != nil {
-		m, err := utils.SetupSASLMechanism(config.SASL)
-		if err != nil {
-			return nil, err
-		}
-		transport.SASL = m
-	}
-
-	// connect to the kafka server
-	kafkaWriter := kafkago.Writer{
-		Addr:         kafkago.TCP(config.Address),
-		Topic:        config.Topic,
-		Balancer:     balancer,
-		ReadTimeout:  time.Duration(readTimeoutSecs) * time.Second,
-		WriteTimeout: time.Duration(writeTimeoutSecs) * time.Second,
-		BatchSize:    config.BatchSize,
-		BatchBytes:   config.BatchBytes,
-		// Temporary fix may be we should implement a batching systems
-		// https://github.com/segmentio/kafka-go/issues/326#issuecomment-519375403
-		BatchTimeout: time.Nanosecond,
-		Transport:    &transport,
+	kafkaWriter, err := kafka.NewWriter(&config)
+	if err != nil {
+		return nil, err
 	}
 
 	return &encodeKafka{
 		kafkaParams:    config,
-		kafkaWriter:    &kafkaWriter,
+		kafkaWriter:    kafkaWriter,
 		recordsWritten: opMetrics.CreateRecordsWrittenCounter(params.Name),
 	}, nil
 }

--- a/pkg/pipeline/ingest/ingest_kafka.go
+++ b/pkg/pipeline/ingest/ingest_kafka.go
@@ -18,11 +18,11 @@
 package ingest
 
 import (
-	"errors"
 	"time"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/kafka"
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/decode"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
@@ -40,19 +40,13 @@ type kafkaReadMessage interface {
 }
 
 type ingestKafka struct {
-	kafkaReader      kafkaReadMessage
-	decoder          decode.Decoder
-	in               chan []byte
-	exitChan         <-chan struct{}
-	batchReadTimeout int64
-	batchMaxLength   int
-	metrics          *metrics
-	canLogMessages   bool
+	kafkaReader    kafkaReadMessage
+	decoder        decode.Decoder
+	in             chan []byte
+	exitChan       <-chan struct{}
+	metrics        *metrics
+	canLogMessages bool
 }
-
-const defaultBatchReadTimeout = int64(1000)
-const defaultKafkaBatchMaxLength = 500
-const defaultKafkaCommitInterval = 500
 
 const kafkaStatsPeriod = 15 * time.Second
 
@@ -175,125 +169,34 @@ func (k *ingestKafka) reportStats() {
 // NewIngestKafka create a new ingester
 // nolint:cyclop
 func NewIngestKafka(opMetrics *operational.Metrics, params config.StageParam) (Ingester, error) {
-	klog.Debugf("entering NewIngestKafka")
-	jsonIngestKafka := api.IngestKafka{}
+	config := &api.IngestKafka{}
 	var ingestType string
 	if params.Ingest != nil {
 		ingestType = params.Ingest.Type
 		if params.Ingest.Kafka != nil {
-			jsonIngestKafka = *params.Ingest.Kafka
+			config = params.Ingest.Kafka
 		}
 	}
 
-	// connect to the kafka server
-	startOffsetString := jsonIngestKafka.StartOffset
-	var startOffset int64
-	switch startOffsetString {
-	case "FirstOffset", "":
-		startOffset = kafkago.FirstOffset
-	case "LastOffset":
-		startOffset = kafkago.LastOffset
-	default:
-		startOffset = kafkago.FirstOffset
-		klog.Errorf("illegal value for StartOffset: %s\n", startOffsetString)
-	}
-	klog.Debugf("startOffset = %v", startOffset)
-	groupBalancers := make([]kafkago.GroupBalancer, 0)
-	for _, gb := range jsonIngestKafka.GroupBalancers {
-		switch gb {
-		case "range":
-			groupBalancers = append(groupBalancers, &kafkago.RangeGroupBalancer{})
-		case "roundRobin":
-			groupBalancers = append(groupBalancers, &kafkago.RoundRobinGroupBalancer{})
-		case "rackAffinity":
-			groupBalancers = append(groupBalancers, &kafkago.RackAffinityGroupBalancer{})
-		default:
-			klog.Warningf("groupbalancers parameter missing")
-			groupBalancers = append(groupBalancers, &kafkago.RoundRobinGroupBalancer{})
-		}
-	}
-
-	batchReadTimeout := defaultBatchReadTimeout
-	if jsonIngestKafka.BatchReadTimeout != 0 {
-		batchReadTimeout = jsonIngestKafka.BatchReadTimeout
-	}
-	klog.Infof("batchReadTimeout = %d", batchReadTimeout)
-
-	commitInterval := int64(defaultKafkaCommitInterval)
-	if jsonIngestKafka.CommitInterval != 0 {
-		commitInterval = jsonIngestKafka.CommitInterval
-	}
-	klog.Infof("commitInterval = %d", jsonIngestKafka.CommitInterval)
-
-	dialer := &kafkago.Dialer{
-		Timeout:   kafkago.DefaultDialer.Timeout,
-		DualStack: kafkago.DefaultDialer.DualStack,
-	}
-	if jsonIngestKafka.TLS != nil {
-		klog.Infof("Using TLS configuration: %v", jsonIngestKafka.TLS)
-		tlsConfig, err := jsonIngestKafka.TLS.Build()
-		if err != nil {
-			return nil, err
-		}
-		dialer.TLS = tlsConfig
-	}
-
-	if jsonIngestKafka.SASL != nil {
-		m, err := utils.SetupSASLMechanism(jsonIngestKafka.SASL)
-		if err != nil {
-			return nil, err
-		}
-		dialer.SASLMechanism = m
-	}
-
-	readerConfig := kafkago.ReaderConfig{
-		Brokers:        jsonIngestKafka.Brokers,
-		Topic:          jsonIngestKafka.Topic,
-		GroupID:        jsonIngestKafka.GroupID,
-		GroupBalancers: groupBalancers,
-		StartOffset:    startOffset,
-		CommitInterval: time.Duration(commitInterval) * time.Millisecond,
-		Dialer:         dialer,
-	}
-
-	if jsonIngestKafka.PullQueueCapacity > 0 {
-		readerConfig.QueueCapacity = jsonIngestKafka.PullQueueCapacity
-	}
-
-	if jsonIngestKafka.PullMaxBytes > 0 {
-		readerConfig.MaxBytes = jsonIngestKafka.PullMaxBytes
-	}
-
-	klog.Debugf("reader config: %#v", readerConfig)
-
-	kafkaReader := kafkago.NewReader(readerConfig)
-	if kafkaReader == nil {
-		errMsg := "NewIngestKafka: failed to create kafka-go reader"
-		klog.Errorf("%s", errMsg)
-		return nil, errors.New(errMsg)
-	}
-
-	decoder, err := decode.GetDecoder(jsonIngestKafka.Decoder)
+	kafkaReader, bml, err := kafka.NewReader(config)
 	if err != nil {
 		return nil, err
 	}
 
-	bml := defaultKafkaBatchMaxLength
-	if jsonIngestKafka.BatchMaxLen != 0 {
-		bml = jsonIngestKafka.BatchMaxLen
+	decoder, err := decode.GetDecoder(config.Decoder)
+	if err != nil {
+		return nil, err
 	}
 
 	in := make(chan []byte, 2*bml)
 	metrics := newMetrics(opMetrics, params.Name, ingestType, func() int { return len(in) })
 
 	return &ingestKafka{
-		kafkaReader:      kafkaReader,
-		decoder:          decoder,
-		exitChan:         utils.ExitChannel(),
-		in:               in,
-		batchMaxLength:   bml,
-		batchReadTimeout: batchReadTimeout,
-		metrics:          metrics,
-		canLogMessages:   jsonIngestKafka.Decoder.Type == api.DecoderJSON,
+		kafkaReader:    kafkaReader,
+		decoder:        decoder,
+		exitChan:       utils.ExitChannel(),
+		in:             in,
+		metrics:        metrics,
+		canLogMessages: config.Decoder.Type == api.DecoderJSON,
 	}, nil
 }

--- a/pkg/pipeline/ingest/ingest_kafka_test.go
+++ b/pkg/pipeline/ingest/ingest_kafka_test.go
@@ -89,8 +89,6 @@ func Test_NewIngestKafka1(t *testing.T) {
 	require.Equal(t, expectedBrokers, ingestKafka.kafkaReader.Config().Brokers)
 	require.Equal(t, int64(-2), ingestKafka.kafkaReader.Config().StartOffset)
 	require.Equal(t, 2, len(ingestKafka.kafkaReader.Config().GroupBalancers))
-	require.Equal(t, int64(300), ingestKafka.batchReadTimeout)
-	require.Equal(t, int(500), ingestKafka.batchMaxLength)
 	require.Equal(t, time.Duration(500)*time.Millisecond, ingestKafka.kafkaReader.Config().CommitInterval)
 }
 
@@ -103,8 +101,6 @@ func Test_NewIngestKafka2(t *testing.T) {
 	require.Equal(t, expectedBrokers, ingestKafka.kafkaReader.Config().Brokers)
 	require.Equal(t, int64(-1), ingestKafka.kafkaReader.Config().StartOffset)
 	require.Equal(t, 1, len(ingestKafka.kafkaReader.Config().GroupBalancers))
-	require.Equal(t, defaultBatchReadTimeout, ingestKafka.batchReadTimeout)
-	require.Equal(t, int(1000), ingestKafka.batchMaxLength)
 	require.Equal(t, time.Duration(1000)*time.Millisecond, ingestKafka.kafkaReader.Config().CommitInterval)
 }
 

--- a/pkg/pipeline/transform/kubernetes/datasource/datasource.go
+++ b/pkg/pipeline/transform/kubernetes/datasource/datasource.go
@@ -1,0 +1,127 @@
+package datasource
+
+import (
+	"context"
+	"sync"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/kafka"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/informers"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/model"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	"github.com/sirupsen/logrus"
+)
+
+var log = logrus.WithField("component", "transform.Network.Kubernetes")
+
+type Datasource struct {
+	Informers informers.InformersInterface
+	// We use map+mutex rather than sync.Map for better performance on writes, since the lock is acquired once to perform several writes.
+	kafkaIPCacheMut       sync.RWMutex
+	kafkaIPCache          map[string]model.ResourceMetaData
+	kafkaNodeNameCacheMut sync.RWMutex
+	kafkaNodeNameCache    map[string]model.ResourceMetaData
+}
+
+func NewInformerDatasource(kubeConfigPath string, kafkaConfig *api.EncodeKafka) (*Datasource, error) {
+	inf := &informers.Informers{}
+	if err := inf.InitFromConfig(kubeConfigPath, kafkaConfig); err != nil {
+		return nil, err
+	}
+	return &Datasource{Informers: inf}, nil
+}
+
+func NewKafkaCacheDatasource(kafkaConfig *api.IngestKafka) (*Datasource, error) {
+	// Init Kafka reader
+	log.Debug("Initializing Kafka reader datasource")
+	kafkaReader, _, err := kafka.NewReader(kafkaConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	d := Datasource{
+		kafkaIPCache:       make(map[string]model.ResourceMetaData),
+		kafkaNodeNameCache: make(map[string]model.ResourceMetaData),
+	}
+	exitChan := utils.ExitChannel()
+	go func() {
+		for {
+			select {
+			case <-exitChan:
+				log.Info("gracefully exiting")
+				return
+			default:
+			}
+			// Blocking
+			msg, err := kafkaReader.ReadMessage(context.Background())
+			if err != nil {
+				log.Errorln(err)
+				continue
+			}
+			if len(msg.Value) > 0 {
+				content, err := model.MessageFromBytes(msg.Value)
+				if err != nil {
+					log.Errorln(err)
+					continue
+				}
+				log.Debugf("Kafka reader: got message %v", content)
+				d.updateCache(content)
+			} else {
+				log.Debug("Kafka reader: empty message")
+			}
+		}
+	}()
+
+	return &d, nil
+}
+
+func (d *Datasource) updateCache(msg *model.KafkaCacheMessage) {
+	switch msg.Operation {
+	case model.OperationAdd, model.OperationUpdate:
+		d.kafkaIPCacheMut.Lock()
+		for _, ip := range msg.Resource.IPs {
+			d.kafkaIPCache[ip] = *msg.Resource
+		}
+		d.kafkaIPCacheMut.Unlock()
+		if msg.Resource.Kind == model.KindNode {
+			d.kafkaNodeNameCacheMut.Lock()
+			d.kafkaNodeNameCache[msg.Resource.Name] = *msg.Resource
+			d.kafkaNodeNameCacheMut.Unlock()
+		}
+	case model.OperationDelete:
+		d.kafkaIPCacheMut.Lock()
+		for _, ip := range msg.Resource.IPs {
+			delete(d.kafkaIPCache, ip)
+		}
+		d.kafkaIPCacheMut.Unlock()
+		if msg.Resource.Kind == model.KindNode {
+			d.kafkaNodeNameCacheMut.Lock()
+			delete(d.kafkaNodeNameCache, msg.Resource.Name)
+			d.kafkaNodeNameCacheMut.Unlock()
+		}
+	}
+}
+
+func (d *Datasource) GetByIP(ip string) *model.ResourceMetaData {
+	if d.Informers != nil {
+		return d.Informers.GetByIP(ip)
+	}
+	d.kafkaIPCacheMut.RLock()
+	defer d.kafkaIPCacheMut.RUnlock()
+	if obj, ok := d.kafkaIPCache[ip]; ok {
+		return &obj
+	}
+	return nil
+}
+
+func (d *Datasource) GetNodeByName(name string) (*model.ResourceMetaData, error) {
+	if d.Informers != nil {
+		return d.Informers.GetNodeByName(name)
+	}
+	d.kafkaNodeNameCacheMut.RLock()
+	defer d.kafkaNodeNameCacheMut.RUnlock()
+	if obj, ok := d.kafkaNodeNameCache[name]; ok {
+		return &obj, nil
+	}
+	return nil, nil
+}

--- a/pkg/pipeline/transform/kubernetes/datasource/datasource_test.go
+++ b/pkg/pipeline/transform/kubernetes/datasource/datasource_test.go
@@ -1,0 +1,123 @@
+package datasource
+
+import (
+	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/model"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	node1 = model.ResourceMetaData{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "node-1",
+		},
+		Kind: model.KindNode,
+		IPs:  []string{"1.2.3.4", "5.6.7.8"},
+	}
+	pod1 = model.ResourceMetaData{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "ns-1",
+		},
+		Kind: model.KindPod,
+		IPs:  []string{"10.0.0.1", "10.0.0.2"},
+	}
+	svc1 = model.ResourceMetaData{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "svc-1",
+			Namespace: "ns-1",
+		},
+		Kind: model.KindService,
+		IPs:  []string{"192.168.0.1"},
+	}
+)
+
+func TestCacheUpdate(t *testing.T) {
+	ds := Datasource{
+		kafkaIPCache:       make(map[string]model.ResourceMetaData),
+		kafkaNodeNameCache: make(map[string]model.ResourceMetaData),
+	}
+	var err error
+
+	res := ds.GetByIP("1.2.3.4")
+	require.Nil(t, res)
+	res, err = ds.GetNodeByName("node-1")
+	require.NoError(t, err)
+	require.Nil(t, res)
+
+	ds.updateCache(&model.KafkaCacheMessage{
+		Operation: model.OperationAdd,
+		Resource:  &node1,
+	})
+
+	ds.updateCache(&model.KafkaCacheMessage{
+		Operation: model.OperationAdd,
+		Resource:  &pod1,
+	})
+
+	ds.updateCache(&model.KafkaCacheMessage{
+		Operation: model.OperationAdd,
+		Resource:  &svc1,
+	})
+
+	res = ds.GetByIP("1.2.3.4")
+	require.Equal(t, node1, *res)
+	res, err = ds.GetNodeByName("node-1")
+	require.NoError(t, err)
+	require.Equal(t, node1, *res)
+
+	res = ds.GetByIP("5.6.7.8")
+	require.Equal(t, node1, *res)
+
+	res = ds.GetByIP("10.0.0.1")
+	require.Equal(t, pod1, *res)
+
+	res = ds.GetByIP("192.168.0.1")
+	require.Equal(t, svc1, *res)
+
+	svc2 := svc1
+	svc2.Labels = map[string]string{"label": "value"}
+	ds.updateCache(&model.KafkaCacheMessage{
+		Operation: model.OperationUpdate,
+		Resource:  &svc2,
+	})
+	ds.updateCache(&model.KafkaCacheMessage{
+		Operation: model.OperationDelete,
+		Resource:  &node1,
+	})
+
+	res = ds.GetByIP("192.168.0.1")
+	require.Equal(t, map[string]string{"label": "value"}, res.Labels)
+
+	res = ds.GetByIP("1.2.3.4")
+	require.Nil(t, res)
+	res, err = ds.GetNodeByName("node-1")
+	require.NoError(t, err)
+	require.Nil(t, res)
+}
+
+func BenchmarkPromEncode(b *testing.B) {
+	ds := Datasource{
+		kafkaIPCache:       make(map[string]model.ResourceMetaData),
+		kafkaNodeNameCache: make(map[string]model.ResourceMetaData),
+	}
+
+	for i := 0; i < b.N; i++ {
+		ds.updateCache(&model.KafkaCacheMessage{
+			Operation: model.OperationAdd,
+			Resource:  &node1,
+		})
+
+		ds.updateCache(&model.KafkaCacheMessage{
+			Operation: model.OperationAdd,
+			Resource:  &pod1,
+		})
+
+		ds.updateCache(&model.KafkaCacheMessage{
+			Operation: model.OperationAdd,
+			Resource:  &svc1,
+		})
+	}
+}

--- a/pkg/pipeline/transform/kubernetes/enrich.go
+++ b/pkg/pipeline/transform/kubernetes/enrich.go
@@ -20,7 +20,9 @@ func MockInformers() {
 
 func InitInformerDatasource(kubeConfigPath string, kafkaConfig *api.EncodeKafka) error {
 	var err error
-	ds, err = datasource.NewInformerDatasource(kubeConfigPath, kafkaConfig)
+	if ds == nil {
+		ds, err = datasource.NewInformerDatasource(kubeConfigPath, kafkaConfig)
+	}
 	return err
 }
 

--- a/pkg/pipeline/transform/kubernetes/informers/kafka_cache_writer.go
+++ b/pkg/pipeline/transform/kubernetes/informers/kafka_cache_writer.go
@@ -1,0 +1,52 @@
+package informers
+
+import (
+	"context"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/model"
+	kafkago "github.com/segmentio/kafka-go"
+	"k8s.io/client-go/tools/cache"
+)
+
+func getKafkaEventHandlers(kafka *kafkago.Writer) cache.ResourceEventHandler {
+	return &cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			if res, ok := obj.(*model.ResourceMetaData); ok {
+				publish(&model.KafkaCacheMessage{
+					Operation: model.OperationAdd,
+					Resource:  res,
+				}, kafka)
+			}
+		},
+		UpdateFunc: func(_, new any) {
+			if res, ok := new.(*model.ResourceMetaData); ok {
+				publish(&model.KafkaCacheMessage{
+					Operation: model.OperationUpdate,
+					Resource:  res,
+				}, kafka)
+			}
+		},
+		DeleteFunc: func(obj any) {
+			if res, ok := obj.(*model.ResourceMetaData); ok {
+				publish(&model.KafkaCacheMessage{
+					Operation: model.OperationDelete,
+					Resource:  res,
+				}, kafka)
+			}
+		},
+	}
+}
+
+func publish(content *model.KafkaCacheMessage, kafka *kafkago.Writer) {
+	log.Debugf("Publishing to Kafka: %v", content.Resource)
+	b, err := content.ToBytes()
+	if err != nil {
+		log.Errorf("kafka publish, encoding error: %v", err)
+		return
+	}
+	msg := kafkago.Message{Value: b}
+	err = kafka.WriteMessages(context.Background(), msg)
+	if err != nil {
+		log.Errorf("kafka publish, write error: %v", err)
+	}
+}

--- a/pkg/pipeline/transform/kubernetes/model/model.go
+++ b/pkg/pipeline/transform/kubernetes/model/model.go
@@ -1,0 +1,62 @@
+package model
+
+import (
+	"bytes"
+	"encoding/gob"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	KindNode    = "Node"
+	KindPod     = "Pod"
+	KindService = "Service"
+)
+
+// ResourceMetaData contains precollected metadata for Pods, Nodes and Services.
+// Not all the fields are populated for all the above types. To save
+// memory, we just keep in memory the necessary data for each Type.
+// For more information about which fields are set for each type, please
+// refer to the instantiation function of the respective informers.
+type ResourceMetaData struct {
+	// Informers need that internal object is an ObjectMeta instance
+	metav1.ObjectMeta
+	Kind      string
+	OwnerName string
+	OwnerKind string
+	HostName  string
+	HostIP    string
+	IPs       []string
+}
+
+type Operation string
+
+const (
+	OperationAdd    Operation = "add"
+	OperationDelete Operation = "delete"
+	OperationUpdate Operation = "update"
+)
+
+type KafkaCacheMessage struct {
+	Operation Operation
+	Resource  *ResourceMetaData
+}
+
+func (i *KafkaCacheMessage) ToBytes() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(i); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func MessageFromBytes(b []byte) (*KafkaCacheMessage, error) {
+	var msg KafkaCacheMessage
+	buf := bytes.NewReader(b)
+	dec := gob.NewDecoder(buf)
+	if err := dec.Decode(&msg); err != nil {
+		return nil, err
+	}
+	return &msg, nil
+}

--- a/pkg/pipeline/transform/kubernetes/model/model_test.go
+++ b/pkg/pipeline/transform/kubernetes/model/model_test.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEncodeDecode(t *testing.T) {
+	msg := KafkaCacheMessage{
+		Operation: OperationAdd,
+		Resource: &ResourceMetaData{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node1",
+				Labels: map[string]string{
+					"label-1": "value-1",
+				},
+			},
+			Kind: KindNode,
+			IPs:  []string{"1.2.3.4", "4.5.6.7"},
+		},
+	}
+
+	b, err := msg.ToBytes()
+	require.NoError(t, err)
+
+	decoded, err := MessageFromBytes(b)
+	require.NoError(t, err)
+
+	require.Equal(t, msg, *decoded)
+}

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -202,9 +202,16 @@ func NewTransformNetwork(params config.StageParam) (Transformer, error) {
 	}
 
 	if needToInitKubeData {
-		err := kubernetes.InitFromConfig(jsonNetworkTransform.KubeConfigPath)
-		if err != nil {
-			return nil, err
+		if jsonNetworkTransform.KafkaCacheConfig != nil {
+			// Get kube data from Kafka rather than informers
+			if err := kubernetes.InitKafkaCacheDatasource(jsonNetworkTransform.KafkaCacheConfig); err != nil {
+				return nil, err
+			}
+		} else {
+			// Init informers
+			if err := kubernetes.InitInformerDatasource(jsonNetworkTransform.KubeConfigPath, nil); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/pkg/pipeline/utils/exit.go
+++ b/pkg/pipeline/utils/exit.go
@@ -42,8 +42,7 @@ func CloseExitChannel() {
 	close(exitChannel)
 }
 
-func SetupElegantExit() {
-	logrus.Debugf("entering SetupElegantExit")
+func SetupElegantExit() (stopCh <-chan struct{}) {
 	// handle elegant exit; create support for channels of go routines that want to exit cleanly
 	exitChannel = make(chan struct{})
 	exitSigChan := make(chan os.Signal, 1)
@@ -54,7 +53,6 @@ func SetupElegantExit() {
 		sig := <-exitSigChan
 		logrus.Debugf("received exit signal = %v", sig)
 		close(exitChannel)
-		logrus.Debugf("exiting SetupElegantExit go function")
 	}()
-	logrus.Debugf("exiting SetupElegantExit")
+	return exitChannel
 }


### PR DESCRIPTION
The goal is to allow deploying a dedicated FLP instance as just a k8s cache component, alongside with the "traditional" FLP deployments.
The k8s cache is a Kafka producer, and traditional instances are
consumers.
    
- New FLP binary, k8s-cache, that just starts the informers and writes update events to
  Kafka
- New optional config for kubernetes enrichment, allowing to read from
  kafka instead of using informers


cf https://github.com/netobserv/flowlogs-pipeline/issues/641

Operator PR: https://github.com/netobserv/network-observability-operator/pull/684