### PR TITLE
NETOBSERV-1522 & NETOBSERV-1750 FLP otel fixes

### DIFF
--- a/pkg/pipeline/encode/opentelemetry/opentelemetry.go
+++ b/pkg/pipeline/encode/opentelemetry/opentelemetry.go
@@ -275,19 +275,45 @@ func obtainAttributesFromEntry(entry config.GenericMap) *[]attribute.KeyValue {
 	var att = make([]attribute.KeyValue, len(entry))
 	index := 0
 	for k, v := range entry {
-		switch v.(type) {
+		switch v := v.(type) {
+		case []string:
+			att[index] = attribute.StringSlice(k, v)
 		case string:
-			valString := v
-			att[index] = attribute.String(k, valString.(string))
-		case int, int32, int64, int16, uint, uint8, uint16, uint32, uint64:
+			att[index] = attribute.String(k, v)
+		case []int:
+			att[index] = attribute.IntSlice(k, v)
+		case []int32:
+			valInt64Slice := []int64{}
+			for _, valInt32 := range v {
+				valInt64, _ := utils.ConvertToInt64(valInt32)
+				valInt64Slice = append(valInt64Slice, valInt64)
+			}
+			att[index] = attribute.Int64Slice(k, valInt64Slice)
+		case []int64:
+			att[index] = attribute.Int64Slice(k, v)
+		case int:
+			att[index] = attribute.Int(k, v)
+		case int32, int64, int16, uint, uint8, uint16, uint32, uint64:
 			valInt, _ := utils.ConvertToInt64(v)
 			att[index] = attribute.Int64(k, valInt)
-		case float32, float64:
+		case []float32:
+			valFloat64Slice := []float64{}
+			for _, valFloat32 := range v {
+				valFloat64, _ := utils.ConvertToFloat64(valFloat32)
+				valFloat64Slice = append(valFloat64Slice, valFloat64)
+			}
+			att[index] = attribute.Float64Slice(k, valFloat64Slice)
+		case []float64:
+			att[index] = attribute.Float64Slice(k, v)
+		case float32:
 			valFloat, _ := utils.ConvertToFloat64(v)
 			att[index] = attribute.Float64(k, valFloat)
+		case float64:
+			att[index] = attribute.Float64(k, v)
+		case []bool:
+			att[index] = attribute.BoolSlice(k, v)
 		case bool:
-			valBool := v
-			att[index] = attribute.Bool(k, valBool.(bool))
+			att[index] = attribute.Bool(k, v)
 		case nil:
 			// skip this field
 			continue

--- a/pkg/pipeline/utils/timed_cache.go
+++ b/pkg/pipeline/utils/timed_cache.go
@@ -141,7 +141,9 @@ func (tc *TimedCache) CleanupExpiredEntries(expiry time.Duration, callback Cache
 			return
 		}
 		deleted++
-		callback(pCacheInfo.SourceEntry)
+		if callback != nil {
+			callback(pCacheInfo.SourceEntry)
+		}
 		delete(tc.cacheMap, pCacheInfo.key)
 		tc.cacheList.Remove(listEntry)
 		if tc.cacheLenMetric != nil {


### PR DESCRIPTION
## Description

- [x] Fix open telemetry attributes (for arrays)
```
Attributes:
-> timeflowstart: Int(1720623609511)
-> destination.k8s.name: Str(ip-10-0-1-172.ec2.internal)
-> dns.errno: Int(0)
-> source.mac: Str(02:BF:1A:CD:98:51)
-> host.direction: Int(0)
-> destination.mac: Str(02:60:C1:E6:97:15)
-> destination.k8s.kind: Str(Node)
-> protocol: Int(17)
-> source.k8s.name: Str(ip-10-0-1-125.ec2.internal)
-> source.k8s.kind: Str(Node)
-> destination.address: Str(10.0.1.172)
-> timereceived: Int(1720623613)
-> bytes: Int(124)
-> interface.directions: Slice([0,0])
-> timeflowend: Int(1720623609511)
-> source.k8s.host.name: Str(ip-10-0-1-125.ec2.internal)
-> destination.k8s.owner.kind: Str(Node)
-> destination.k8s.host.name: Str(ip-10-0-1-172.ec2.internal)
-> source.k8s.node.name: Str(ip-10-0-1-125.ec2.internal)
-> source.port: Int(45558)
-> destination.k8s.owner.name: Str(ip-10-0-1-172.ec2.internal)
-> interface.names: Slice(["ens5","br-ex"])
-> source.address: Str(10.0.1.125)
-> destination.port: Int(6081)
-> destination.k8s.host.address: Str(10.0.1.172)
-> packets: Int(1)
-> dscp: Int(0)
-> source.k8s.owner.name: Str(ip-10-0-1-125.ec2.internal)
-> source.k8s.owner.kind: Str(Node)
-> destination.k8s.node.name: Str(ip-10-0-1-172.ec2.internal)
-> source.k8s.host.address: Str(10.0.1.125)
-> k8s.layer: Str(infra)
```

- [x] Fix FLP crash (see https://issues.redhat.com/browse/NETOBSERV-1750)
```
Backtrace:

time=2024-07-09T17:41:44Z level=info msg=connecting stages: enrich --> Otel-export-0-metricstime=2024-07-09T17:41:44Z level=info msg=starting PProf HTTP listener port=6060panic: runtime error: invalid memory address or nil pointer dereference[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xbc08a3]
goroutine 151 [running]:github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils.(*TimedCache).CleanupExpiredEntries(0xc0002f32c0, 0x1bf08eb000, 0x0)	/app/pkg/pipeline/utils/timed_cache.go:144 +0x303github.com/netobserv/flowlogs-pipeline/pkg/pipeline/encode.(*MetricsCommonStruct).cleanupExpiredEntriesLoop(0xc0003245b0, 0x0)	/app/pkg/pipeline/encode/metrics_common.go:261 +0x4ccreated by github.com/netobserv/flowlogs-pipeline/pkg/pipeline/encode.NewMetricsCommonStruct in goroutine 1	/app/pkg/pipeline/encode/metrics_common.go:281 +0x426
```

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
