### PR TITLE
NETOBSERV-1792: Added update-build script to add downstream labels

### DIFF
--- a/.tekton/flowlogs-pipeline-pull-request.yaml
+++ b/.tekton/flowlogs-pipeline-pull-request.yaml
@@ -183,12 +183,29 @@ spec:
         workspace: workspace
       - name: basic-auth
         workspace: git-auth
+    - name: update-downstream
+      taskSpec:
+        steps:
+          - image: ubuntu
+            script: |
+              #!/usr/bin/env bash
+              echo "Starting update-downstream task"
+              cd workspace/source/source
+              COMMIT={{revision}} ./hack/update-build.sh
+      runAfter:
+      - clone-repository
+      workspaces:
+      - name: source
+        workspace: workspace
+      - name: git-basic-auth
+        workspace: git-auth
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       runAfter:
       - clone-repository
+      - update-downstream
       taskRef:
         params:
         - name: name

--- a/.tekton/flowlogs-pipeline-push.yaml
+++ b/.tekton/flowlogs-pipeline-push.yaml
@@ -180,12 +180,29 @@ spec:
         workspace: workspace
       - name: basic-auth
         workspace: git-auth
+    - name: update-downstream
+      taskSpec:
+        steps:
+          - image: ubuntu
+            script: |
+              #!/usr/bin/env bash
+              echo "Starting update-downstream task"
+              cd workspace/source/source
+              COMMIT={{revision}} ./hack/update-build.sh
+      runAfter:
+      - clone-repository
+      workspaces:
+      - name: source
+        workspace: workspace
+      - name: git-basic-auth
+        workspace: git-auth
     - name: prefetch-dependencies
       params:
       - name: input
         value: $(params.prefetch-input)
       runAfter:
       - clone-repository
+      - update-downstream
       taskRef:
         params:
         - name: name

--- a/hack/update-build.sh
+++ b/hack/update-build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+echo "Updating container file"
+
+: "${CONTAINER_FILE:=./contrib/docker/Dockerfile}"
+: "${COMMIT:=$(git rev-list --abbrev-commit --tags --max-count=1)}"
+
+cat <<EOF >>"${CONTAINER_FILE}"
+LABEL com.redhat.component="network-observability-flowlogs-pipeline-container"
+LABEL name="network-observability-flowlogs-pipeline"
+LABEL io.k8s.display-name="Network Observability Flow-Logs Pipeline"
+LABEL io.k8s.description="Network Observability Flow-Logs Pipeline"
+LABEL summary="Network Observability Flow-Logs Pipeline"
+LABEL maintainer="support@redhat.com"
+LABEL io.openshift.tags="network-observability-flowlogs-pipeline"
+LABEL upstream-vcs-ref="${COMMIT}"
+LABEL upstream-vcs-type="git"
+EOF


### PR DESCRIPTION
## Description

Added update-build script to add downstream labels

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
