### PR TITLE
NETOBSERV-1772: allow prom label remapping

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -29,6 +29,7 @@ Following is the supported API format for prometheus encode:
                             not_match_regex: the filter value must not match the provided regular expression
                  valueKey: entry key from which to resolve metric value
                  labels: labels to be associated with the metric
+                 remap: optional remapping of labels
                  buckets: histogram buckets
                  valueScale: scale factor of the value (MetricVal := FlowVal / Scale)
          prefix: prefix added to each metric name
@@ -433,6 +434,7 @@ Following is the supported API format for writing metrics to an OpenTelemetry co
                             not_match_regex: the filter value must not match the provided regular expression
                  valueKey: entry key from which to resolve metric value
                  labels: labels to be associated with the metric
+                 remap: optional remapping of labels
                  buckets: histogram buckets
                  valueScale: scale factor of the value (MetricVal := FlowVal / Scale)
          pushTimeInterval: how often should metrics be sent to collector:

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -52,6 +52,7 @@ type MetricsItem struct {
 	Filters    []MetricsFilter           `yaml:"filters" json:"filters" doc:"a list of criteria to filter entries by"`
 	ValueKey   string                    `yaml:"valueKey" json:"valueKey" doc:"entry key from which to resolve metric value"`
 	Labels     []string                  `yaml:"labels" json:"labels" doc:"labels to be associated with the metric"`
+	Remap      map[string]string         `yaml:"remap" json:"remap" doc:"optional remapping of labels"`
 	Buckets    []float64                 `yaml:"buckets" json:"buckets" doc:"histogram buckets"`
 	ValueScale float64                   `yaml:"valueScale,omitempty" json:"valueScale,omitempty" doc:"scale factor of the value (MetricVal := FlowVal / Scale)"`
 }

--- a/pkg/confgen/confgen_test.go
+++ b/pkg/confgen/confgen_test.go
@@ -151,6 +151,7 @@ func Test_RunShortConfGen(t *testing.T) {
 			Filters:  []api.MetricsFilter{{Key: "K", Value: "V"}},
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
+			Remap:    map[string]string{},
 			Buckets:  []float64{},
 		}},
 	}, out.Parameters[3].Encode.Prom)
@@ -232,6 +233,7 @@ func Test_RunConfGenNoAgg(t *testing.T) {
 			Filters:  []api.MetricsFilter{{Key: "K", Value: "V"}},
 			ValueKey: "Bytes",
 			Labels:   []string{"service"},
+			Remap:    map[string]string{},
 			Buckets:  []float64{},
 		}},
 	}, out.Parameters[2].Encode.Prom)
@@ -336,6 +338,7 @@ func Test_RunLongConfGen(t *testing.T) {
 			Filters:  []api.MetricsFilter{{Key: "K", Value: "V"}},
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
+			Remap:    map[string]string{},
 			Buckets:  []float64{},
 		}, {
 			Name:     "test_histo",
@@ -343,6 +346,7 @@ func Test_RunLongConfGen(t *testing.T) {
 			Filters:  []api.MetricsFilter{{Key: "K", Value: "V"}},
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
+			Remap:    map[string]string{},
 			Buckets:  []float64{},
 		}},
 	}, out.Parameters[4].Encode.Prom)

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -137,6 +137,7 @@ func TestKafkaPromPipeline(t *testing.T) {
 			}},
 			ValueKey: "recent_count",
 			Labels:   []string{"by", "aggregate"},
+			Remap:    map[string]string{},
 			Buckets:  []float64{},
 		}},
 		Prefix:     "flp_",
@@ -170,7 +171,7 @@ func TestKafkaPromPipeline(t *testing.T) {
 
 	b, err = json.Marshal(params[4])
 	require.NoError(t, err)
-	require.JSONEq(t, `{"name":"prom","encode":{"type":"prom","prom":{"expiryTime":"50s", "metrics":[{"name":"connections_per_source_as","type":"counter","filters":[{"key":"name","value":"src_as_connection_count"}],"valueKey":"recent_count","labels":["by","aggregate"],"buckets":[]}],"prefix":"flp_"}}}`, string(b))
+	require.JSONEq(t, `{"name":"prom","encode":{"type":"prom","prom":{"expiryTime":"50s", "metrics":[{"name":"connections_per_source_as","type":"counter","filters":[{"key":"name","value":"src_as_connection_count"}],"valueKey":"recent_count","labels":["by","aggregate"],"remap":{},"buckets":[]}],"prefix":"flp_"}}}`, string(b))
 }
 
 func TestForkPipeline(t *testing.T) {

--- a/pkg/pipeline/encode/encode_prom.go
+++ b/pkg/pipeline/encode/encode_prom.go
@@ -115,25 +115,25 @@ func (e *EncodeProm) Cleanup(cleanupFunc interface{}) {
 }
 
 func (e *EncodeProm) addCounter(fullMetricName string, mInfo *MetricInfo) prometheus.Collector {
-	counter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: fullMetricName, Help: ""}, mInfo.Labels)
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: fullMetricName, Help: ""}, mInfo.TargetLabels())
 	e.metricCommon.AddCounter(fullMetricName, counter, mInfo)
 	return counter
 }
 
 func (e *EncodeProm) addGauge(fullMetricName string, mInfo *MetricInfo) prometheus.Collector {
-	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: fullMetricName, Help: ""}, mInfo.Labels)
+	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: fullMetricName, Help: ""}, mInfo.TargetLabels())
 	e.metricCommon.AddGauge(fullMetricName, gauge, mInfo)
 	return gauge
 }
 
 func (e *EncodeProm) addHistogram(fullMetricName string, mInfo *MetricInfo) prometheus.Collector {
-	histogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: fullMetricName, Help: ""}, mInfo.Labels)
+	histogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: fullMetricName, Help: ""}, mInfo.TargetLabels())
 	e.metricCommon.AddHist(fullMetricName, histogram, mInfo)
 	return histogram
 }
 
 func (e *EncodeProm) addAgghistogram(fullMetricName string, mInfo *MetricInfo) prometheus.Collector {
-	agghistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: fullMetricName, Help: ""}, mInfo.Labels)
+	agghistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: fullMetricName, Help: ""}, mInfo.TargetLabels())
 	e.metricCommon.AddAggHist(fullMetricName, agghistogram, mInfo)
 	return agghistogram
 }
@@ -181,7 +181,7 @@ func (e *EncodeProm) checkMetricUpdate(prefix string, apiItem *api.MetricsItem, 
 	plog.Debugf("Checking metric: %s", fullMetricName)
 	mInfo := CreateMetricInfo(apiItem)
 	if oldMetric, ok := store[fullMetricName]; ok {
-		if !reflect.DeepEqual(mInfo.MetricsItem.Labels, oldMetric.info.MetricsItem.Labels) {
+		if !reflect.DeepEqual(mInfo.TargetLabels(), oldMetric.info.TargetLabels()) {
 			plog.Debug("Changes detected in labels")
 			return true
 		}
@@ -257,9 +257,8 @@ func (e *EncodeProm) resetRegistry() {
 	for i := range e.cfg.Metrics {
 		mCfg := &e.cfg.Metrics[i]
 		fullMetricName := e.cfg.Prefix + mCfg.Name
-		labels := mCfg.Labels
-		plog.Debugf("Create metric: %s, Labels: %v", fullMetricName, labels)
 		mInfo := CreateMetricInfo(mCfg)
+		plog.Debugf("Create metric: %s, Labels: %v", fullMetricName, mInfo.TargetLabels())
 		var m prometheus.Collector
 		switch mCfg.Type {
 		case api.MetricCounter:

--- a/pkg/pipeline/encode/encode_prom_metric.go
+++ b/pkg/pipeline/encode/encode_prom_metric.go
@@ -16,6 +16,20 @@ var variableExtractor, _ = regexp.Compile(`\$\(([^\)]+)\)`)
 type MetricInfo struct {
 	*api.MetricsItem
 	FilterPredicates []Predicate
+	MappedLabels     []MappedLabel
+}
+
+type MappedLabel struct {
+	Source string
+	Target string
+}
+
+func (m *MetricInfo) TargetLabels() []string {
+	var targetLabels []string
+	for _, l := range m.MappedLabels {
+		targetLabels = append(targetLabels, l.Target)
+	}
+	return targetLabels
 }
 
 func Presence(filter api.MetricsFilter) Predicate {
@@ -121,6 +135,13 @@ func injectVars(flow config.GenericMap, filterValue string, varLookups [][]strin
 func CreateMetricInfo(def *api.MetricsItem) *MetricInfo {
 	mi := MetricInfo{
 		MetricsItem: def,
+	}
+	for _, l := range def.Labels {
+		ml := MappedLabel{Source: l, Target: l}
+		if as := def.Remap[l]; as != "" {
+			ml.Target = as
+		}
+		mi.MappedLabels = append(mi.MappedLabels, ml)
 	}
 	for _, f := range def.Filters {
 		mi.FilterPredicates = append(mi.FilterPredicates, filterToPredicate(f))

--- a/pkg/pipeline/encode/opentelemetry/encode_otlpmetrics.go
+++ b/pkg/pipeline/encode/opentelemetry/encode_otlpmetrics.go
@@ -133,9 +133,8 @@ func NewEncodeOtlpMetrics(opMetrics *operational.Metrics, params config.StagePar
 	for i := range cfg.Metrics {
 		mCfg := &cfg.Metrics[i]
 		fullMetricName := cfg.Prefix + mCfg.Name
-		labels := mCfg.Labels
 		log.Debugf("fullMetricName = %v", fullMetricName)
-		log.Debugf("Labels = %v", labels)
+		log.Debugf("Labels = %v", mCfg.Labels)
 		mInfo := encode.CreateMetricInfo(mCfg)
 		switch mCfg.Type {
 		case api.MetricCounter:


### PR DESCRIPTION
## Description

- New "remap" field in MetricItem API
- New struct to distinguish source labels (from flow logs) and target labels (to use in metrics)

## Dependencies

- Operator: https://github.com/netobserv/network-observability-operator/pull/733

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [x] Does this PR require a product release notes entry?
  * [x] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
