### PR TITLE
NETOBSERV-1799: Use converToString insted of Sprintf

### DIFF
--- a/cmd/confgenerator/main.go
+++ b/cmd/confgenerator/main.go
@@ -26,6 +26,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/netobserv/flowlogs-pipeline/pkg/confgen"
+	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -110,7 +111,7 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 			val := v.Get(f.Name)
 			switch val.(type) {
 			case bool, uint, string, int32, int16, int8, int, uint32, uint64, int64, float64, float32, []string, []int:
-				_ = cmd.Flags().Set(f.Name, fmt.Sprintf("%v", val))
+				_ = cmd.Flags().Set(f.Name, utils.ConvertToString(val))
 			default:
 				var jsoniterJSON = jsoniter.ConfigCompatibleWithStandardLibrary
 				b, err := jsoniterJSON.Marshal(&val)

--- a/pkg/pipeline/extract/aggregate/aggregate.go
+++ b/pkg/pipeline/extract/aggregate/aggregate.go
@@ -29,6 +29,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	util "github.com/netobserv/flowlogs-pipeline/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -152,7 +153,7 @@ func (aggregate *Aggregate) UpdateByEntry(entry config.GenericMap, normalizedVal
 		if operationKey != "" {
 			value, ok := entry[operationKey]
 			if ok {
-				valueString := fmt.Sprintf("%v", value)
+				valueString := util.ConvertToString(value)
 				if valueFloat64, err := strconv.ParseFloat(valueString, 64); err != nil {
 					// Log as debug to avoid performance impact
 					log.Debugf("UpdateByEntry error when parsing float '%s': %v", valueString, err)

--- a/pkg/pipeline/extract/conntrack/conn.go
+++ b/pkg/pipeline/extract/conntrack/conn.go
@@ -162,12 +162,12 @@ func (c *connType) isMatchSelector(selector map[string]interface{}) bool {
 				return false
 			}
 		case string:
-			selectorValue := fmt.Sprintf("%v", v)
+			selectorValue := utils.ConvertToString(v)
 			if connValue != selectorValue {
 				return false
 			}
 		default:
-			connValue = fmt.Sprintf("%v", connValue)
+			connValue = utils.ConvertToString(connValue)
 			selectorValue := fmt.Sprintf("%v", v)
 			if connValue != selectorValue {
 				return false

--- a/pkg/pipeline/transform/kubernetes/enrich.go
+++ b/pkg/pipeline/transform/kubernetes/enrich.go
@@ -1,12 +1,12 @@
 package kubernetes
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	inf "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/informers"
+	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -22,7 +22,7 @@ func InitFromConfig(kubeConfigPath string) error {
 }
 
 func Enrich(outputEntry config.GenericMap, rule api.K8sRule) {
-	kubeInfo, err := informers.GetInfo(fmt.Sprintf("%s", outputEntry[rule.Input]))
+	kubeInfo, err := informers.GetInfo(utils.ConvertToString(outputEntry[rule.Input]))
 	if err != nil {
 		logrus.WithError(err).Tracef("can't find kubernetes info for IP %v", outputEntry[rule.Input])
 		return
@@ -123,7 +123,7 @@ func fillInK8sZone(outputEntry config.GenericMap, rule api.K8sRule, kubeInfo *in
 func EnrichLayer(outputEntry config.GenericMap, rule *api.K8sInfraRule) {
 	outputEntry[rule.Output] = "infra"
 	for _, input := range rule.Inputs {
-		if objectIsApp(fmt.Sprintf("%s", outputEntry[input]), rule) {
+		if objectIsApp(utils.ConvertToString(outputEntry[input]), rule) {
 			outputEntry[rule.Output] = "app"
 			return
 		}

--- a/pkg/pipeline/transform/transform_filter.go
+++ b/pkg/pipeline/transform/transform_filter.go
@@ -101,7 +101,7 @@ func applyRule(entry config.GenericMap, labels map[string]string, rule *api.Tran
 			entry[rule.AddFieldIfDoesntExist.Input] = rule.AddFieldIfDoesntExist.Value
 		}
 	case api.AddRegExIf:
-		matched, err := regexp.MatchString(rule.AddRegExIf.Parameters, fmt.Sprintf("%s", entry[rule.AddRegExIf.Input]))
+		matched, err := regexp.MatchString(rule.AddRegExIf.Parameters, utils.ConvertToString(entry[rule.AddRegExIf.Input]))
 		if err != nil {
 			return true
 		}

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -30,6 +30,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/location"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/netdb"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	util "github.com/netobserv/flowlogs-pipeline/pkg/utils"
 	"github.com/sirupsen/logrus"
 )
 
@@ -72,7 +73,7 @@ func (n *Network) Transform(inputEntry config.GenericMap) (config.GenericMap, bo
 				continue
 			}
 			var locationInfo *location.Info
-			locationInfo, err := location.GetLocation(fmt.Sprintf("%s", outputEntry[rule.AddLocation.Input]))
+			locationInfo, err := location.GetLocation(util.ConvertToString(outputEntry[rule.AddLocation.Input]))
 			if err != nil {
 				log.Warningf("Can't find location for IP %v err %v", outputEntry[rule.AddLocation.Input], err)
 				continue


### PR DESCRIPTION
## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
