### PR TITLE
NETOBSERV-1831: disambiguate overlapping IPs from MAC

### DIFF
--- a/pkg/pipeline/transform/kubernetes/enrich.go
+++ b/pkg/pipeline/transform/kubernetes/enrich.go
@@ -26,8 +26,9 @@ func Enrich(outputEntry config.GenericMap, rule *api.K8sRule) {
 	if !ok {
 		return
 	}
+	mac, _ := outputEntry.LookupString(rule.MACField)
 	potentialKeys := informers.BuildSecondaryNetworkKeys(outputEntry, rule)
-	kubeInfo, err := informers.GetInfo(potentialKeys, ip)
+	kubeInfo, err := informers.GetInfo(potentialKeys, ip, mac)
 	if err != nil {
 		logrus.WithError(err).Tracef("can't find kubernetes info for keys %v and IP %s", potentialKeys, ip)
 		return

--- a/pkg/pipeline/transform/kubernetes/informers/informers-mock.go
+++ b/pkg/pipeline/transform/kubernetes/informers/informers-mock.go
@@ -175,7 +175,7 @@ func (f *FakeInformers) InitFromConfig(_ api.NetworkTransformKubeConfig, _ *oper
 	return nil
 }
 
-func (f *FakeInformers) GetInfo(keys []cni.SecondaryNetKey, ip string) (*Info, error) {
+func (f *FakeInformers) GetInfo(keys []cni.SecondaryNetKey, ip, _ string) (*Info, error) {
 	if len(keys) > 0 {
 		i := f.customKeysInfo[keys[0].Key]
 		if i != nil {

--- a/pkg/pipeline/transform/kubernetes/informers/informers_test.go
+++ b/pkg/pipeline/transform/kubernetes/informers/informers_test.go
@@ -42,7 +42,7 @@ func TestGetInfo(t *testing.T) {
 	hidx.FallbackNotFound()
 
 	// Test get orphan pod
-	info, err := kubeData.GetInfo(nil, "1.2.3.4")
+	info, err := kubeData.GetInfo(nil, "1.2.3.4", "")
 	require.NoError(t, err)
 	pod1 := Info{
 		Type: "Pod",
@@ -60,13 +60,13 @@ func TestGetInfo(t *testing.T) {
 	require.Equal(t, pod1, *info)
 
 	// Test get same pod by mac
-	info, err = kubeData.GetInfo([]cni.SecondaryNetKey{{NetworkName: "custom-network", Key: "~~AA:BB:CC:DD:EE:FF"}}, "")
+	info, err = kubeData.GetInfo([]cni.SecondaryNetKey{{NetworkName: "custom-network", Key: "~~AA:BB:CC:DD:EE:FF"}}, "", "")
 	require.NoError(t, err)
 	pod1.NetworkName = "custom-network"
 	require.Equal(t, pod1, *info)
 
 	// Test get pod owned
-	info, err = kubeData.GetInfo(nil, "1.2.3.5")
+	info, err = kubeData.GetInfo(nil, "1.2.3.5", "")
 	require.NoError(t, err)
 
 	require.Equal(t, Info{
@@ -88,7 +88,7 @@ func TestGetInfo(t *testing.T) {
 	}, *info)
 
 	// Test get node
-	info, err = kubeData.GetInfo(nil, "10.0.0.1")
+	info, err = kubeData.GetInfo(nil, "10.0.0.1", "")
 	require.NoError(t, err)
 
 	require.Equal(t, Info{
@@ -102,7 +102,7 @@ func TestGetInfo(t *testing.T) {
 	}, *info)
 
 	// Test get service
-	info, err = kubeData.GetInfo(nil, "1.2.3.100")
+	info, err = kubeData.GetInfo(nil, "1.2.3.100", "")
 	require.NoError(t, err)
 
 	require.Equal(t, Info{
@@ -117,7 +117,7 @@ func TestGetInfo(t *testing.T) {
 	}, *info)
 
 	// Test no match
-	info, err = kubeData.GetInfo(nil, "1.2.3.200")
+	info, err = kubeData.GetInfo(nil, "1.2.3.200", "")
 	require.NotNil(t, err)
 	require.Nil(t, info)
 }


### PR DESCRIPTION
## Description

This is an alternative, best-effort solution when there are overlapping IPs and we cannot index by MAC due to lack of consistency of the observed MAC (because cross-node traffic might show node's MAC instead of Pod's MAC). Using MAC as index cannot work in this situation, however, we can still use solely IPs for indexing, which might result in having a shortlist of pods after cache lookup in case of overlapping IPs: the best-effort solution here is to then select by MAC from that shortlist.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
