### PR TITLE
NETOBSERV-1633: Enable prefetch in konflux

### DIFF
--- a/.tekton/flowlogs-pipeline-pull-request.yaml
+++ b/.tekton/flowlogs-pipeline-pull-request.yaml
@@ -98,7 +98,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: "{\"type\":\"gomod\", \"path\":\".\"}"
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string

--- a/.tekton/flowlogs-pipeline-push.yaml
+++ b/.tekton/flowlogs-pipeline-push.yaml
@@ -96,7 +96,7 @@ spec:
       description: Execute the build with network isolation
       name: hermetic
       type: string
-    - default: ""
+    - default: "{\"type\":\"gomod\", \"path\":\".\"}"
       description: Build dependencies to be prefetched by Cachi2
       name: prefetch-input
       type: string


### PR DESCRIPTION
## Description

Enable prefetch konflux task.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [X] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
