### PR TITLE
NETOBSERV-1935: enable metrics from list/nested fields

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -30,6 +30,7 @@ Following is the supported API format for prometheus encode:
                  valueKey: entry key from which to resolve metric value
                  labels: labels to be associated with the metric
                  remap: optional remapping of labels
+                 flatten: list fields to be flattened
                  buckets: histogram buckets
                  valueScale: scale factor of the value (MetricVal := FlowVal / Scale)
          prefix: prefix added to each metric name
@@ -444,6 +445,7 @@ Following is the supported API format for writing metrics to an OpenTelemetry co
                  valueKey: entry key from which to resolve metric value
                  labels: labels to be associated with the metric
                  remap: optional remapping of labels
+                 flatten: list fields to be flattened
                  buckets: histogram buckets
                  valueScale: scale factor of the value (MetricVal := FlowVal / Scale)
          pushTimeInterval: how often should metrics be sent to collector:

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -53,6 +53,7 @@ type MetricsItem struct {
 	ValueKey   string                    `yaml:"valueKey" json:"valueKey" doc:"entry key from which to resolve metric value"`
 	Labels     []string                  `yaml:"labels" json:"labels" doc:"labels to be associated with the metric"`
 	Remap      map[string]string         `yaml:"remap" json:"remap" doc:"optional remapping of labels"`
+	Flatten    []string                  `yaml:"flatten" json:"flatten" doc:"list fields to be flattened"`
 	Buckets    []float64                 `yaml:"buckets" json:"buckets" doc:"histogram buckets"`
 	ValueScale float64                   `yaml:"valueScale,omitempty" json:"valueScale,omitempty" doc:"scale factor of the value (MetricVal := FlowVal / Scale)"`
 }

--- a/pkg/confgen/confgen_test.go
+++ b/pkg/confgen/confgen_test.go
@@ -152,6 +152,7 @@ func Test_RunShortConfGen(t *testing.T) {
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
 			Remap:    map[string]string{},
+			Flatten:  []string{},
 			Buckets:  []float64{},
 		}},
 	}, out.Parameters[3].Encode.Prom)
@@ -234,6 +235,7 @@ func Test_RunConfGenNoAgg(t *testing.T) {
 			ValueKey: "Bytes",
 			Labels:   []string{"service"},
 			Remap:    map[string]string{},
+			Flatten:  []string{},
 			Buckets:  []float64{},
 		}},
 	}, out.Parameters[2].Encode.Prom)
@@ -339,6 +341,7 @@ func Test_RunLongConfGen(t *testing.T) {
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
 			Remap:    map[string]string{},
+			Flatten:  []string{},
 			Buckets:  []float64{},
 		}, {
 			Name:     "test_histo",
@@ -347,6 +350,7 @@ func Test_RunLongConfGen(t *testing.T) {
 			ValueKey: "test_aggregates_value",
 			Labels:   []string{"groupByKeys", "aggregate"},
 			Remap:    map[string]string{},
+			Flatten:  []string{},
 			Buckets:  []float64{},
 		}},
 	}, out.Parameters[4].Encode.Prom)

--- a/pkg/config/pipeline_builder_test.go
+++ b/pkg/config/pipeline_builder_test.go
@@ -138,6 +138,7 @@ func TestKafkaPromPipeline(t *testing.T) {
 			ValueKey: "recent_count",
 			Labels:   []string{"by", "aggregate"},
 			Remap:    map[string]string{},
+			Flatten:  []string{},
 			Buckets:  []float64{},
 		}},
 		Prefix:     "flp_",
@@ -171,7 +172,7 @@ func TestKafkaPromPipeline(t *testing.T) {
 
 	b, err = json.Marshal(params[4])
 	require.NoError(t, err)
-	require.JSONEq(t, `{"name":"prom","encode":{"type":"prom","prom":{"expiryTime":"50s", "metrics":[{"name":"connections_per_source_as","type":"counter","filters":[{"key":"name","value":"src_as_connection_count"}],"valueKey":"recent_count","labels":["by","aggregate"],"remap":{},"buckets":[]}],"prefix":"flp_"}}}`, string(b))
+	require.JSONEq(t, `{"name":"prom","encode":{"type":"prom","prom":{"expiryTime":"50s", "metrics":[{"name":"connections_per_source_as","type":"counter","filters":[{"key":"name","value":"src_as_connection_count"}],"valueKey":"recent_count","labels":["by","aggregate"],"flatten":[],"remap":{},"buckets":[]}],"prefix":"flp_"}}}`, string(b))
 }
 
 func TestForkPipeline(t *testing.T) {

--- a/pkg/pipeline/encode/encode_prom.go
+++ b/pkg/pipeline/encode/encode_prom.go
@@ -25,6 +25,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/encode/metrics"
 	promserver "github.com/netobserv/flowlogs-pipeline/pkg/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -114,25 +115,25 @@ func (e *EncodeProm) Cleanup(cleanupFunc interface{}) {
 	cleanupFunc.(func())()
 }
 
-func (e *EncodeProm) addCounter(fullMetricName string, mInfo *MetricInfo) prometheus.Collector {
+func (e *EncodeProm) addCounter(fullMetricName string, mInfo *metrics.Preprocessed) prometheus.Collector {
 	counter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: fullMetricName, Help: ""}, mInfo.TargetLabels())
 	e.metricCommon.AddCounter(fullMetricName, counter, mInfo)
 	return counter
 }
 
-func (e *EncodeProm) addGauge(fullMetricName string, mInfo *MetricInfo) prometheus.Collector {
+func (e *EncodeProm) addGauge(fullMetricName string, mInfo *metrics.Preprocessed) prometheus.Collector {
 	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: fullMetricName, Help: ""}, mInfo.TargetLabels())
 	e.metricCommon.AddGauge(fullMetricName, gauge, mInfo)
 	return gauge
 }
 
-func (e *EncodeProm) addHistogram(fullMetricName string, mInfo *MetricInfo) prometheus.Collector {
+func (e *EncodeProm) addHistogram(fullMetricName string, mInfo *metrics.Preprocessed) prometheus.Collector {
 	histogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: fullMetricName, Help: ""}, mInfo.TargetLabels())
 	e.metricCommon.AddHist(fullMetricName, histogram, mInfo)
 	return histogram
 }
 
-func (e *EncodeProm) addAgghistogram(fullMetricName string, mInfo *MetricInfo) prometheus.Collector {
+func (e *EncodeProm) addAgghistogram(fullMetricName string, mInfo *metrics.Preprocessed) prometheus.Collector {
 	agghistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: fullMetricName, Help: ""}, mInfo.TargetLabels())
 	e.metricCommon.AddAggHist(fullMetricName, agghistogram, mInfo)
 	return agghistogram
@@ -176,10 +177,10 @@ func (e *EncodeProm) cleanDeletedMetrics(newCfg api.PromEncode) {
 }
 
 // returns true if a registry restart is needed
-func (e *EncodeProm) checkMetricUpdate(prefix string, apiItem *api.MetricsItem, store map[string]mInfoStruct, createMetric func(string, *MetricInfo) prometheus.Collector) bool {
+func (e *EncodeProm) checkMetricUpdate(prefix string, apiItem *api.MetricsItem, store map[string]mInfoStruct, createMetric func(string, *metrics.Preprocessed) prometheus.Collector) bool {
 	fullMetricName := prefix + apiItem.Name
 	plog.Debugf("Checking metric: %s", fullMetricName)
-	mInfo := CreateMetricInfo(apiItem)
+	mInfo := metrics.Preprocess(apiItem)
 	if oldMetric, ok := store[fullMetricName]; ok {
 		if !reflect.DeepEqual(mInfo.TargetLabels(), oldMetric.info.TargetLabels()) {
 			plog.Debug("Changes detected in labels")
@@ -257,7 +258,7 @@ func (e *EncodeProm) resetRegistry() {
 	for i := range e.cfg.Metrics {
 		mCfg := &e.cfg.Metrics[i]
 		fullMetricName := e.cfg.Prefix + mCfg.Name
-		mInfo := CreateMetricInfo(mCfg)
+		mInfo := metrics.Preprocess(mCfg)
 		plog.Debugf("Create metric: %s, Labels: %v", fullMetricName, mInfo.TargetLabels())
 		var m prometheus.Collector
 		switch mCfg.Type {

--- a/pkg/pipeline/encode/metrics/filtering.go
+++ b/pkg/pipeline/encode/metrics/filtering.go
@@ -1,0 +1,28 @@
+package metrics
+
+import "github.com/netobserv/flowlogs-pipeline/pkg/config"
+
+func (p *Preprocessed) ApplyFilters(flow config.GenericMap, flatParts []config.GenericMap) (bool, []config.GenericMap) {
+	filteredParts := flatParts
+	for _, filter := range p.filters {
+		if filter.useFlat {
+			filteredParts = filter.filterFlatParts(filteredParts)
+			if len(filteredParts) == 0 {
+				return false, nil
+			}
+		} else if !filter.predicate(flow) {
+			return false, nil
+		}
+	}
+	return true, filteredParts
+}
+
+func (pf *preprocessedFilter) filterFlatParts(flatParts []config.GenericMap) []config.GenericMap {
+	var filteredParts []config.GenericMap
+	for _, part := range flatParts {
+		if pf.predicate(part) {
+			filteredParts = append(filteredParts, part)
+		}
+	}
+	return filteredParts
+}

--- a/pkg/pipeline/encode/metrics/flattening.go
+++ b/pkg/pipeline/encode/metrics/flattening.go
@@ -1,0 +1,88 @@
+package metrics
+
+import (
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+)
+
+func (p *Preprocessed) GenerateFlatParts(flow config.GenericMap) []config.GenericMap {
+	if len(p.MetricsItem.Flatten) == 0 {
+		return nil
+	}
+	// Want to generate sub-flows from {A=foo, B=[{B1=x, B2=y},{B1=z}], C=[foo,bar]}
+	//=> {B>B1=x, B>B2=y, C=foo}, {B>B1=z, C=foo}, {B>B1=x, B>B2=y, C=bar}, {B>B1=z, C=bar}
+	var partsPerLabel [][]config.GenericMap
+	for _, fl := range p.MetricsItem.Flatten {
+		if anyVal, ok := flow[fl]; ok {
+			// Intermediate step to get:
+			// [{B>B1=x, B>B2=y}, {B>B1=z}], [C=foo, C=bar]
+			var partsForLabel []config.GenericMap
+			switch v := anyVal.(type) {
+			case []any:
+				prefix := fl + ">"
+				for _, vv := range v {
+					switch vvv := vv.(type) {
+					case config.GenericMap:
+						partsForLabel = append(partsForLabel, flattenNested(prefix, vvv))
+					default:
+						partsForLabel = append(partsForLabel, config.GenericMap{fl: vv})
+					}
+				}
+			case []config.GenericMap:
+				prefix := fl + ">"
+				for _, vv := range v {
+					partsForLabel = append(partsForLabel, flattenNested(prefix, vv))
+				}
+			case []string:
+				for _, vv := range v {
+					partsForLabel = append(partsForLabel, config.GenericMap{fl: vv})
+				}
+			}
+			if len(partsForLabel) > 0 {
+				partsPerLabel = append(partsPerLabel, partsForLabel)
+			}
+		}
+	}
+	return distribute(partsPerLabel)
+}
+
+func distribute(allUnflat [][]config.GenericMap) []config.GenericMap {
+	// turn
+	// [{B>B1=x, B>B2=y}, {B>B1=z}], [{C=foo}, {C=bar}]
+	// into
+	// [{B>B1=x, B>B2=y, C=foo}, {B>B1=z, C=foo}, {B>B1=x, B>B2=y, C=bar}, {B>B1=z, C=bar}]
+	totalCard := 1
+	for _, part := range allUnflat {
+		if len(part) > 1 {
+			totalCard *= len(part)
+		}
+	}
+	ret := make([]config.GenericMap, totalCard)
+	indexes := make([]int, len(allUnflat))
+	for c := range ret {
+		ret[c] = config.GenericMap{}
+		incIndex := false
+		for i, part := range allUnflat {
+			index := indexes[i]
+			for k, v := range part[index] {
+				ret[c][k] = v
+			}
+			if !incIndex {
+				if index+1 == len(part) {
+					indexes[i] = 0
+				} else {
+					indexes[i] = index + 1
+					incIndex = true
+				}
+			}
+		}
+	}
+	return ret
+}
+
+func flattenNested(prefix string, nested config.GenericMap) config.GenericMap {
+	subFlow := config.GenericMap{}
+	for k, v := range nested {
+		subFlow[prefix+k] = v
+	}
+	return subFlow
+}

--- a/pkg/pipeline/encode/metrics/flattening.go
+++ b/pkg/pipeline/encode/metrics/flattening.go
@@ -9,7 +9,7 @@ func (p *Preprocessed) GenerateFlatParts(flow config.GenericMap) []config.Generi
 		return nil
 	}
 	// Want to generate sub-flows from {A=foo, B=[{B1=x, B2=y},{B1=z}], C=[foo,bar]}
-	//=> {B>B1=x, B>B2=y, C=foo}, {B>B1=z, C=foo}, {B>B1=x, B>B2=y, C=bar}, {B>B1=z, C=bar}
+	// => {B>B1=x, B>B2=y, C=foo}, {B>B1=z, C=foo}, {B>B1=x, B>B2=y, C=bar}, {B>B1=z, C=bar}
 	var partsPerLabel [][]config.GenericMap
 	for _, fl := range p.MetricsItem.Flatten {
 		if anyVal, ok := flow[fl]; ok {

--- a/pkg/pipeline/encode/metrics/preprocess_test.go
+++ b/pkg/pipeline/encode/metrics/preprocess_test.go
@@ -1,0 +1,53 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Filters_extractVarLookups(t *testing.T) {
+	variables := extractVarLookups("$(abc)--$(def)")
+
+	assert.Equal(t, [][]string{{"$(abc)", "abc"}, {"$(def)", "def"}}, variables)
+
+	variables = extractVarLookups("")
+	assert.Empty(t, variables)
+}
+
+func Test_Flatten(t *testing.T) {
+	pp := Preprocess(&api.MetricsItem{Flatten: []string{"interfaces", "events"}})
+	fl := pp.GenerateFlatParts(config.GenericMap{
+		"namespace":  "A",
+		"interfaces": []string{"eth0", "123456"},
+		"events": []any{
+			config.GenericMap{"type": "egress", "name": "my_egress"},
+			config.GenericMap{"type": "acl", "name": "my_policy"},
+		},
+		"bytes": 7,
+	})
+	assert.Equal(t, []config.GenericMap{
+		{
+			"interfaces":  "eth0",
+			"events>type": "egress",
+			"events>name": "my_egress",
+		},
+		{
+			"interfaces":  "123456",
+			"events>type": "egress",
+			"events>name": "my_egress",
+		},
+		{
+			"interfaces":  "eth0",
+			"events>type": "acl",
+			"events>name": "my_policy",
+		},
+		{
+			"interfaces":  "123456",
+			"events>type": "acl",
+			"events>name": "my_policy",
+		},
+	}, fl)
+}

--- a/pkg/pipeline/encode/metrics_common.go
+++ b/pkg/pipeline/encode/metrics_common.go
@@ -24,6 +24,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/encode/metrics"
 	putils "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
@@ -32,7 +33,7 @@ import (
 
 type mInfoStruct struct {
 	genericMetric interface{} // can be a counter, gauge, or histogram pointer
-	info          *MetricInfo
+	info          *metrics.Preprocessed
 }
 
 type MetricsCommonStruct struct {
@@ -84,22 +85,22 @@ var (
 	)
 )
 
-func (m *MetricsCommonStruct) AddCounter(name string, g interface{}, info *MetricInfo) {
+func (m *MetricsCommonStruct) AddCounter(name string, g interface{}, info *metrics.Preprocessed) {
 	mStruct := mInfoStruct{genericMetric: g, info: info}
 	m.counters[name] = mStruct
 }
 
-func (m *MetricsCommonStruct) AddGauge(name string, g interface{}, info *MetricInfo) {
+func (m *MetricsCommonStruct) AddGauge(name string, g interface{}, info *metrics.Preprocessed) {
 	mStruct := mInfoStruct{genericMetric: g, info: info}
 	m.gauges[name] = mStruct
 }
 
-func (m *MetricsCommonStruct) AddHist(name string, g interface{}, info *MetricInfo) {
+func (m *MetricsCommonStruct) AddHist(name string, g interface{}, info *metrics.Preprocessed) {
 	mStruct := mInfoStruct{genericMetric: g, info: info}
 	m.histos[name] = mStruct
 }
 
-func (m *MetricsCommonStruct) AddAggHist(name string, g interface{}, info *MetricInfo) {
+func (m *MetricsCommonStruct) AddAggHist(name string, g interface{}, info *metrics.Preprocessed) {
 	mStruct := mInfoStruct{genericMetric: g, info: info}
 	m.aggHistos[name] = mStruct
 }
@@ -109,91 +110,116 @@ func (m *MetricsCommonStruct) MetricCommonEncode(mci MetricsCommonInterface, met
 
 	// Process counters
 	for _, mInfo := range m.counters {
-		labels, value, _ := m.prepareMetric(mci, metricRecord, mInfo.info, mInfo.genericMetric)
-		if labels == nil {
+		labelSets, value := m.prepareMetric(mci, metricRecord, mInfo.info, mInfo.genericMetric)
+		if labelSets == nil {
 			continue
 		}
-		err := mci.ProcessCounter(mInfo.genericMetric, labels, value)
-		if err != nil {
-			log.Errorf("labels registering error on %s: %v", mInfo.info.Name, err)
-			m.errorsCounter.WithLabelValues("LabelsRegisteringError", mInfo.info.Name, "").Inc()
-			continue
+		for _, labels := range labelSets {
+			err := mci.ProcessCounter(mInfo.genericMetric, labels.lMap, value)
+			if err != nil {
+				log.Errorf("labels registering error on %s: %v", mInfo.info.Name, err)
+				m.errorsCounter.WithLabelValues("LabelsRegisteringError", mInfo.info.Name, "").Inc()
+				continue
+			}
+			m.metricsProcessed.Inc()
 		}
-		m.metricsProcessed.Inc()
 	}
 
 	// Process gauges
 	for _, mInfo := range m.gauges {
-		labels, value, key := m.prepareMetric(mci, metricRecord, mInfo.info, mInfo.genericMetric)
-		if labels == nil {
+		labelSets, value := m.prepareMetric(mci, metricRecord, mInfo.info, mInfo.genericMetric)
+		if labelSets == nil {
 			continue
 		}
-		err := mci.ProcessGauge(mInfo.genericMetric, labels, value, key)
-		if err != nil {
-			log.Errorf("labels registering error on %s: %v", mInfo.info.Name, err)
-			m.errorsCounter.WithLabelValues("LabelsRegisteringError", mInfo.info.Name, "").Inc()
-			continue
+		for _, labels := range labelSets {
+			err := mci.ProcessGauge(mInfo.genericMetric, labels.lMap, value, labels.key)
+			if err != nil {
+				log.Errorf("labels registering error on %s: %v", mInfo.info.Name, err)
+				m.errorsCounter.WithLabelValues("LabelsRegisteringError", mInfo.info.Name, "").Inc()
+				continue
+			}
+			m.metricsProcessed.Inc()
 		}
-		m.metricsProcessed.Inc()
 	}
 
 	// Process histograms
 	for _, mInfo := range m.histos {
-		labels, value, _ := m.prepareMetric(mci, metricRecord, mInfo.info, mInfo.genericMetric)
-		if labels == nil {
+		labelSets, value := m.prepareMetric(mci, metricRecord, mInfo.info, mInfo.genericMetric)
+		if labelSets == nil {
 			continue
 		}
-		err := mci.ProcessHist(mInfo.genericMetric, labels, value)
-		if err != nil {
-			log.Errorf("labels registering error on %s: %v", mInfo.info.Name, err)
-			m.errorsCounter.WithLabelValues("LabelsRegisteringError", mInfo.info.Name, "").Inc()
-			continue
+		for _, labels := range labelSets {
+			err := mci.ProcessHist(mInfo.genericMetric, labels.lMap, value)
+			if err != nil {
+				log.Errorf("labels registering error on %s: %v", mInfo.info.Name, err)
+				m.errorsCounter.WithLabelValues("LabelsRegisteringError", mInfo.info.Name, "").Inc()
+				continue
+			}
+			m.metricsProcessed.Inc()
 		}
-		m.metricsProcessed.Inc()
 	}
 
 	// Process pre-aggregated histograms
 	for _, mInfo := range m.aggHistos {
-		labels, values := m.prepareAggHisto(mci, metricRecord, mInfo.info, mInfo.genericMetric)
-		if labels == nil {
+		labelSets, values := m.prepareAggHisto(mci, metricRecord, mInfo.info, mInfo.genericMetric)
+		if labelSets == nil {
 			continue
 		}
-		err := mci.ProcessAggHist(mInfo.genericMetric, labels, values)
-		if err != nil {
-			log.Errorf("labels registering error on %s: %v", mInfo.info.Name, err)
-			m.errorsCounter.WithLabelValues("LabelsRegisteringError", mInfo.info.Name, "").Inc()
-			continue
+		for _, labels := range labelSets {
+			err := mci.ProcessAggHist(mInfo.genericMetric, labels.lMap, values)
+			if err != nil {
+				log.Errorf("labels registering error on %s: %v", mInfo.info.Name, err)
+				m.errorsCounter.WithLabelValues("LabelsRegisteringError", mInfo.info.Name, "").Inc()
+				continue
+			}
+			m.metricsProcessed.Inc()
 		}
-		m.metricsProcessed.Inc()
 	}
 }
 
-func (m *MetricsCommonStruct) prepareMetric(mci MetricsCommonInterface, flow config.GenericMap, info *MetricInfo, mv interface{}) (map[string]string, float64, string) {
+func (m *MetricsCommonStruct) prepareMetric(mci MetricsCommonInterface, flow config.GenericMap, info *metrics.Preprocessed, mv interface{}) ([]labelsKeyAndMap, float64) {
+	flatParts := info.GenerateFlatParts(flow)
+	ok, flatParts := info.ApplyFilters(flow, flatParts)
+	if !ok {
+		return nil, 0
+	}
+
 	val := m.extractGenericValue(flow, info)
 	if val == nil {
-		return nil, 0, ""
+		return nil, 0
 	}
 	floatVal, err := utils.ConvertToFloat64(val)
 	if err != nil {
 		m.errorsCounter.WithLabelValues("ValueConversionError", info.Name, info.ValueKey).Inc()
-		return nil, 0, ""
+		return nil, 0
 	}
 	if info.ValueScale != 0 {
 		floatVal /= info.ValueScale
 	}
 
-	entryLabels, key := extractLabelsAndKey(flow, info)
-	// Update entry for expiry mechanism (the entry itself is its own cleanup function)
-	cacheEntry := mci.GetChacheEntry(entryLabels, mv)
-	ok := m.mCache.UpdateCacheEntry(key, cacheEntry)
-	if !ok {
-		m.metricsDropped.Inc()
-		return nil, 0, ""
+	labelSets := extractLabels(flow, flatParts, info)
+	var lkms []labelsKeyAndMap
+	for _, ls := range labelSets {
+		// Update entry for expiry mechanism (the entry itself is its own cleanup function)
+		lkm := ls.toKeyAndMap(info)
+		lkms = append(lkms, lkm)
+		cacheEntry := mci.GetChacheEntry(lkm.lMap, mv)
+		ok := m.mCache.UpdateCacheEntry(lkm.key, cacheEntry)
+		if !ok {
+			m.metricsDropped.Inc()
+			return nil, 0
+		}
 	}
-	return entryLabels, floatVal, key
+	return lkms, floatVal
 }
 
-func (m *MetricsCommonStruct) prepareAggHisto(mci MetricsCommonInterface, flow config.GenericMap, info *MetricInfo, mc interface{}) (map[string]string, []float64) {
+func (m *MetricsCommonStruct) prepareAggHisto(mci MetricsCommonInterface, flow config.GenericMap, info *metrics.Preprocessed, mc interface{}) ([]labelsKeyAndMap, []float64) {
+	flatParts := info.GenerateFlatParts(flow)
+	ok, flatParts := info.ApplyFilters(flow, flatParts)
+	if !ok {
+		return nil, nil
+	}
+
 	val := m.extractGenericValue(flow, info)
 	if val == nil {
 		return nil, nil
@@ -204,23 +230,23 @@ func (m *MetricsCommonStruct) prepareAggHisto(mci MetricsCommonInterface, flow c
 		return nil, nil
 	}
 
-	entryLabels, key := extractLabelsAndKey(flow, info)
-	// Update entry for expiry mechanism (the entry itself is its own cleanup function)
-	cacheEntry := mci.GetChacheEntry(entryLabels, mc)
-	ok = m.mCache.UpdateCacheEntry(key, cacheEntry)
-	if !ok {
-		m.metricsDropped.Inc()
-		return nil, nil
-	}
-	return entryLabels, values
-}
-
-func (m *MetricsCommonStruct) extractGenericValue(flow config.GenericMap, info *MetricInfo) interface{} {
-	for _, pred := range info.FilterPredicates {
-		if !pred(flow) {
-			return nil
+	labelSets := extractLabels(flow, flatParts, info)
+	var lkms []labelsKeyAndMap
+	for _, ls := range labelSets {
+		// Update entry for expiry mechanism (the entry itself is its own cleanup function)
+		lkm := ls.toKeyAndMap(info)
+		lkms = append(lkms, lkm)
+		cacheEntry := mci.GetChacheEntry(lkm.lMap, mc)
+		ok := m.mCache.UpdateCacheEntry(lkm.key, cacheEntry)
+		if !ok {
+			m.metricsDropped.Inc()
+			return nil, nil
 		}
 	}
+	return lkms, values
+}
+
+func (m *MetricsCommonStruct) extractGenericValue(flow config.GenericMap, info *metrics.Preprocessed) interface{} {
 	if info.ValueKey == "" {
 		// No value key means it's a records / flows counter (1 flow = 1 increment), so just return 1
 		return 1
@@ -233,21 +259,58 @@ func (m *MetricsCommonStruct) extractGenericValue(flow config.GenericMap, info *
 	return val
 }
 
-func extractLabelsAndKey(flow config.GenericMap, info *MetricInfo) (map[string]string, string) {
-	entryLabels := make(map[string]string, len(info.MappedLabels))
+type label struct {
+	key   string
+	value string
+}
+
+type labelSet []label
+
+type labelsKeyAndMap struct {
+	key  string
+	lMap map[string]string
+}
+
+func (l labelSet) toKeyAndMap(info *metrics.Preprocessed) labelsKeyAndMap {
 	key := strings.Builder{}
 	key.WriteString(info.Name)
 	key.WriteRune('|')
-	for _, t := range info.MappedLabels {
-		value := ""
-		if v, ok := flow[t.Source]; ok {
-			value = utils.ConvertToString(v)
-		}
-		entryLabels[t.Target] = value
-		key.WriteString(value)
+	m := map[string]string{}
+	for _, kv := range l {
+		key.WriteString(kv.value)
 		key.WriteRune('|')
+		m[kv.key] = kv.value
 	}
-	return entryLabels, key.String()
+	return labelsKeyAndMap{key: key.String(), lMap: m}
+}
+
+// extractLabels takes the flow and a single metric definition as input.
+// It returns the flat labels maps (label names and values).
+// Most of the time it will return a single map; it may return several of them when the parsed flow fields are lists (e.g. "interfaces").
+func extractLabels(flow config.GenericMap, flatParts []config.GenericMap, info *metrics.Preprocessed) []labelSet {
+	common := newLabelSet(flow, info.MappedLabels)
+	if len(flatParts) == 0 {
+		return []labelSet{common}
+	}
+	var all []labelSet
+	for _, fp := range flatParts {
+		ls := newLabelSet(fp, info.FlattenedLabels)
+		ls = append(ls, common...)
+		all = append(all, ls)
+	}
+	return all
+}
+
+func newLabelSet(part config.GenericMap, labels []metrics.MappedLabel) labelSet {
+	var ls labelSet
+	for _, t := range labels {
+		label := label{key: t.Target, value: ""}
+		if v, ok := part[t.Source]; ok {
+			label.value = utils.ConvertToString(v)
+		}
+		ls = append(ls, label)
+	}
+	return ls
 }
 
 func (m *MetricsCommonStruct) cleanupExpiredEntriesLoop(callback putils.CacheCallback) {

--- a/pkg/pipeline/encode/opentelemetry/encode_otlpmetrics.go
+++ b/pkg/pipeline/encode/opentelemetry/encode_otlpmetrics.go
@@ -25,6 +25,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/encode"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/encode/metrics"
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -135,7 +136,7 @@ func NewEncodeOtlpMetrics(opMetrics *operational.Metrics, params config.StagePar
 		fullMetricName := cfg.Prefix + mCfg.Name
 		log.Debugf("fullMetricName = %v", fullMetricName)
 		log.Debugf("Labels = %v", mCfg.Labels)
-		mInfo := encode.CreateMetricInfo(mCfg)
+		mInfo := metrics.Preprocess(mCfg)
 		switch mCfg.Type {
 		case api.MetricCounter:
 			counter, err := meter.Float64Counter(fullMetricName)

--- a/pkg/pipeline/extract/aggregate/aggregate.go
+++ b/pkg/pipeline/extract/aggregate/aggregate.go
@@ -71,7 +71,7 @@ func (aggregate *Aggregate) LabelsFromEntry(entry config.GenericMap) (Labels, bo
 		if !ok {
 			allLabelsFound = false
 		}
-		labels[key] = fmt.Sprint(value)
+		labels[key] = util.ConvertToString(value)
 	}
 
 	return labels, allLabelsFound

--- a/pkg/pipeline/ingest/ingest_grpc.go
+++ b/pkg/pipeline/ingest/ingest_grpc.go
@@ -7,7 +7,8 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
-	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	pUtils "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/decode"
 	grpc "github.com/netobserv/netobserv-ebpf-agent/pkg/grpc/flow"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/pbflow"
@@ -60,7 +61,7 @@ func NewGRPCProtobuf(opMetrics *operational.Metrics, params config.StageParam) (
 func (no *GRPCProtobuf) Ingest(out chan<- config.GenericMap) {
 	no.metrics.createOutQueueLen(out)
 	go func() {
-		<-utils.ExitChannel()
+		<-pUtils.ExitChannel()
 		close(no.flowPackets)
 		no.collector.Close()
 	}()
@@ -108,7 +109,7 @@ func instrumentGRPC(m *metrics) grpc2.UnaryServerInterceptor {
 		if err != nil {
 			// "trace" level used to minimize performance impact
 			glog.Tracef("Reporting metric error: %v", err)
-			m.error(fmt.Sprint(status.Code(err)))
+			m.error(utils.ConvertToString(status.Code(err)))
 		}
 
 		// Stage duration

--- a/pkg/pipeline/write/write_loki.go
+++ b/pkg/pipeline/write/write_loki.go
@@ -27,6 +27,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
 	pUtils "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
 
 	logAdapter "github.com/go-kit/kit/log/logrus"
 	jsonIter "github.com/json-iterator/go"
@@ -173,7 +174,7 @@ func (l *Loki) addLabels(record config.GenericMap, labels model.LabelSet) {
 		if !ok {
 			continue
 		}
-		lv := model.LabelValue(fmt.Sprint(val))
+		lv := model.LabelValue(utils.ConvertToString(val))
 		if !lv.IsValid() {
 			log.WithFields(logrus.Fields{"key": label, "value": val}).
 				Debug("Invalid label value. Ignoring it")


### PR DESCRIPTION
This makes it possible to generate metrics with labels/filters set on list fields (e.g. interfaces) and nested fields (e.g. soon-coming structured network events)

In metrics API, user needs to configure explicitly which list field needs to be "flattened", in order to be consumable as filters/labels.

Nested fields can be consumed as filters/labels with the ">" character;

E.g: `flatten: [networkEvents], filters: [{key: "networkEvents>type", value: "acl"}], labels: [networkEvents>name]` This is a sample config to filter a metric for ACL events and label it by name

## Description

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
