### PR TITLE
NETOBSERV-1692: allow KEEP filtering logic

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -162,6 +162,7 @@ Following is the supported API format for filter transformations:
                     remove_entry_if_equal: removes the entry if the field value equals specified value
                     remove_entry_if_not_equal: removes the entry if the field value does not equal specified value
                     remove_entry_all_satisfied: removes the entry if all of the defined rules are satisfied
+                    keep_entry: keeps the entry if the set of rules are all satisfied
                     add_field: adds (input) field to the entry; overrides previous value if present (key=input, value=value)
                     add_field_if_doesnt_exist: adds a field to the entry if the field does not exist
                     add_field_if: add output field set to assignee if input field satisfies criteria from parameters field
@@ -187,6 +188,19 @@ Following is the supported API format for filter transformations:
                              input: entry input field
                              value: specified value of input field:
                              castInt: set true to cast the value field as an int (numeric values are float64 otherwise)
+                 keepEntryAllSatisfied: configuration for keep_entry rule
+                         type: (enum) one of the following:
+                            keep_entry_if_exists: keeps the entry if the field exists
+                            keep_entry_if_doesnt_exist: keeps the entry if the field does not exist
+                            keep_entry_if_equal: keeps the entry if the field value equals specified value
+                            keep_entry_if_not_equal: keeps the entry if the field value does not equal specified value
+                            keep_entry_if_regex_match: keeps the entry if the field value matches the specified regex
+                            keep_entry_if_not_regex_match: keeps the entry if the field value does not match the specified regex
+                         keepEntry: configuration for keep_entry_* rules
+                             input: entry input field
+                             value: specified value of input field:
+                             castInt: set true to cast the value field as an int (numeric values are float64 otherwise)
+                 keepEntrySampling: sampling value for keep_entry type: 1 flow on <sampling> is kept
                  addField: configuration for add_field rule
                      input: entry input field
                      value: specified value of input field:

--- a/docs/api.md
+++ b/docs/api.md
@@ -162,7 +162,7 @@ Following is the supported API format for filter transformations:
                     remove_entry_if_equal: removes the entry if the field value equals specified value
                     remove_entry_if_not_equal: removes the entry if the field value does not equal specified value
                     remove_entry_all_satisfied: removes the entry if all of the defined rules are satisfied
-                    keep_entry: keeps the entry if the set of rules are all satisfied
+                    keep_entry_all_satisfied: keeps the entry if the set of rules are all satisfied
                     add_field: adds (input) field to the entry; overrides previous value if present (key=input, value=value)
                     add_field_if_doesnt_exist: adds a field to the entry if the field does not exist
                     add_field_if: add output field set to assignee if input field satisfies criteria from parameters field

--- a/pkg/api/transform_filter.go
+++ b/pkg/api/transform_filter.go
@@ -17,23 +17,14 @@
 
 package api
 
-import (
-	"errors"
-	"regexp"
-)
-
 type TransformFilter struct {
 	Rules []TransformFilterRule `yaml:"rules,omitempty" json:"rules,omitempty" doc:"list of filter rules, each includes:"`
 }
 
-func (tf *TransformFilter) Preprocess() error {
-	var errs []error
+func (tf *TransformFilter) Preprocess() {
 	for i := range tf.Rules {
-		if err := tf.Rules[i].preprocess(); err != nil {
-			errs = append(errs, err)
-		}
+		tf.Rules[i].preprocess()
 	}
-	return errors.Join(errs...)
 }
 
 type TransformFilterEnum string
@@ -92,35 +83,22 @@ type TransformFilterRule struct {
 	ConditionalSampling     []*SamplingCondition             `yaml:"conditionalSampling,omitempty" json:"conditionalSampling,omitempty" doc:"sampling configuration rules"`
 }
 
-func (r *TransformFilterRule) preprocess() error {
-	var errs []error
+func (r *TransformFilterRule) preprocess() {
 	if r.RemoveField != nil {
-		if err := r.RemoveField.preprocess(false); err != nil {
-			errs = append(errs, err)
-		}
+		r.RemoveField.preprocess()
 	}
 	if r.RemoveEntry != nil {
-		if err := r.RemoveEntry.preprocess(false); err != nil {
-			errs = append(errs, err)
-		}
+		r.RemoveEntry.preprocess()
 	}
 	for i := range r.RemoveEntryAllSatisfied {
-		if err := r.RemoveEntryAllSatisfied[i].RemoveEntry.preprocess(false); err != nil {
-			errs = append(errs, err)
-		}
+		r.RemoveEntryAllSatisfied[i].RemoveEntry.preprocess()
 	}
 	for i := range r.KeepEntryAllSatisfied {
-		err := r.KeepEntryAllSatisfied[i].KeepEntry.preprocess(r.KeepEntryAllSatisfied[i].Type == KeepEntryIfRegexMatch || r.KeepEntryAllSatisfied[i].Type == KeepEntryIfNotRegexMatch)
-		if err != nil {
-			errs = append(errs, err)
-		}
+		r.KeepEntryAllSatisfied[i].KeepEntry.preprocess()
 	}
 	for i := range r.ConditionalSampling {
-		if err := r.ConditionalSampling[i].preprocess(); err != nil {
-			errs = append(errs, err)
-		}
+		r.ConditionalSampling[i].preprocess()
 	}
-	return errors.Join(errs...)
 }
 
 type TransformFilterGenericRule struct {
@@ -129,25 +107,12 @@ type TransformFilterGenericRule struct {
 	CastInt bool        `yaml:"castInt,omitempty" json:"castInt,omitempty" doc:"set true to cast the value field as an int (numeric values are float64 otherwise)"`
 }
 
-func (r *TransformFilterGenericRule) preprocess(isRegex bool) error {
-	if isRegex {
-		if s, ok := r.Value.(string); ok {
-			v, err := regexp.Compile(s)
-			if err != nil {
-				r.Value = nil
-				return err
-			}
-			r.Value = v
-		} else {
-			r.Value = nil
-			return errors.New("regex filter expects string value")
-		}
-	} else if r.CastInt {
+func (r *TransformFilterGenericRule) preprocess() {
+	if r.CastInt {
 		if f, ok := r.Value.(float64); ok {
 			r.Value = int(f)
 		}
 	}
-	return nil
 }
 
 type TransformFilterRuleWithAssignee struct {
@@ -172,12 +137,8 @@ type SamplingCondition struct {
 	Rules []*RemoveEntryRule `yaml:"rules,omitempty" json:"rules,omitempty" doc:"rules to be satisfied for this sampling configuration"`
 }
 
-func (s *SamplingCondition) preprocess() error {
-	var errs []error
+func (s *SamplingCondition) preprocess() {
 	for i := range s.Rules {
-		if err := s.Rules[i].RemoveEntry.preprocess(false); err != nil {
-			errs = append(errs, err)
-		}
+		s.Rules[i].RemoveEntry.preprocess()
 	}
-	return errors.Join(errs...)
 }

--- a/pkg/api/transform_filter.go
+++ b/pkg/api/transform_filter.go
@@ -46,7 +46,7 @@ const (
 	RemoveEntryIfEqual       TransformFilterEnum = "remove_entry_if_equal"        // removes the entry if the field value equals specified value
 	RemoveEntryIfNotEqual    TransformFilterEnum = "remove_entry_if_not_equal"    // removes the entry if the field value does not equal specified value
 	RemoveEntryAllSatisfied  TransformFilterEnum = "remove_entry_all_satisfied"   // removes the entry if all of the defined rules are satisfied
-	KeepEntry                TransformFilterEnum = "keep_entry"                   // keeps the entry if the set of rules are all satisfied
+	KeepEntryAllSatisfied    TransformFilterEnum = "keep_entry_all_satisfied"     // keeps the entry if the set of rules are all satisfied
 	AddField                 TransformFilterEnum = "add_field"                    // adds (input) field to the entry; overrides previous value if present (key=input, value=value)
 	AddFieldIfDoesntExist    TransformFilterEnum = "add_field_if_doesnt_exist"    // adds a field to the entry if the field does not exist
 	AddFieldIf               TransformFilterEnum = "add_field_if"                 // add output field set to assignee if input field satisfies criteria from parameters field

--- a/pkg/pipeline/encode/metrics/preprocess.go
+++ b/pkg/pipeline/encode/metrics/preprocess.go
@@ -1,13 +1,10 @@
 package metrics
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
-	"github.com/netobserv/flowlogs-pipeline/pkg/config"
-	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
 	"github.com/netobserv/flowlogs-pipeline/pkg/utils/filters"
 )
 
@@ -24,7 +21,7 @@ type MappedLabel struct {
 }
 
 type preprocessedFilter struct {
-	predicate Predicate
+	predicate filters.Predicate
 	useFlat   bool
 }
 
@@ -39,61 +36,7 @@ func (p *Preprocessed) TargetLabels() []string {
 	return targetLabels
 }
 
-func Presence(filter api.MetricsFilter) Predicate {
-	return func(flow config.GenericMap) bool {
-		_, found := flow[filter.Key]
-		return found
-	}
-}
-
-func Absence(filter api.MetricsFilter) Predicate {
-	pred := Presence(filter)
-	return func(flow config.GenericMap) bool { return !pred(flow) }
-}
-
-func Equal(filter api.MetricsFilter) Predicate {
-	varLookups := extractVarLookups(filter.Value)
-	return func(flow config.GenericMap) bool {
-		if val, found := flow[filter.Key]; found {
-			sVal, ok := val.(string)
-			if !ok {
-				sVal = fmt.Sprint(val)
-			}
-			value := filter.Value
-			if len(varLookups) > 0 {
-				value = injectVars(flow, value, varLookups)
-			}
-			return sVal == value
-		}
-		return false
-	}
-}
-
-func NotEqual(filter api.MetricsFilter) Predicate {
-	pred := Equal(filter)
-	return func(flow config.GenericMap) bool { return !pred(flow) }
-}
-
-func Regex(filter api.MetricsFilter) Predicate {
-	r, _ := regexp.Compile(filter.Value)
-	return func(flow config.GenericMap) bool {
-		if val, found := flow[filter.Key]; found {
-			sVal, ok := val.(string)
-			if !ok {
-				sVal = fmt.Sprint(val)
-			}
-			return r.MatchString(sVal)
-		}
-		return false
-	}
-}
-
-func NotRegex(filter api.MetricsFilter) Predicate {
-	pred := Regex(filter)
-	return func(flow config.GenericMap) bool { return !pred(flow) }
-}
-
-func filterToPredicate(filter api.MetricsFilter) Predicate {
+func filterToPredicate(filter api.MetricsFilter) filters.Predicate {
 	switch filter.Type {
 	case api.MetricFilterEqual:
 		return filters.Equal(filter.Key, filter.Value, true)
@@ -111,32 +54,7 @@ func filterToPredicate(filter api.MetricsFilter) Predicate {
 		return filters.NotRegex(filter.Key, r)
 	}
 	// Default = Exact
-	return Equal(filter)
-}
-
-func extractVarLookups(value string) [][]string {
-	// Extract list of variables to lookup
-	// E.g: filter "$(SrcAddr):$(SrcPort)" would return [SrcAddr,SrcPort]
-	if len(value) > 0 {
-		return variableExtractor.FindAllStringSubmatch(value, -1)
-	}
-	return nil
-}
-
-func injectVars(flow config.GenericMap, filterValue string, varLookups [][]string) string {
-	injected := filterValue
-	for _, matchGroup := range varLookups {
-		var value string
-		if rawVal, found := flow[matchGroup[1]]; found {
-			if sVal, ok := rawVal.(string); ok {
-				value = sVal
-			} else {
-				value = utils.ConvertToString(rawVal)
-			}
-		}
-		injected = strings.ReplaceAll(injected, matchGroup[0], value)
-	}
-	return injected
+	return filters.Equal(filter.Key, filter.Value, true)
 }
 
 func Preprocess(def *api.MetricsItem) *Preprocessed {

--- a/pkg/pipeline/encode/metrics/preprocess.go
+++ b/pkg/pipeline/encode/metrics/preprocess.go
@@ -8,11 +8,8 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
+	"github.com/netobserv/flowlogs-pipeline/pkg/utils/filters"
 )
-
-type Predicate func(config.GenericMap) bool
-
-var variableExtractor = regexp.MustCompile(`\$\(([^\)]+)\)`)
 
 type Preprocessed struct {
 	*api.MetricsItem
@@ -99,17 +96,19 @@ func NotRegex(filter api.MetricsFilter) Predicate {
 func filterToPredicate(filter api.MetricsFilter) Predicate {
 	switch filter.Type {
 	case api.MetricFilterEqual:
-		return Equal(filter)
+		return filters.Equal(filter.Key, filter.Value, true)
 	case api.MetricFilterNotEqual:
-		return NotEqual(filter)
+		return filters.NotEqual(filter.Key, filter.Value, true)
 	case api.MetricFilterPresence:
-		return Presence(filter)
+		return filters.Presence(filter.Key)
 	case api.MetricFilterAbsence:
-		return Absence(filter)
+		return filters.Absence(filter.Key)
 	case api.MetricFilterRegex:
-		return Regex(filter)
+		r, _ := regexp.Compile(filter.Value)
+		return filters.Regex(filter.Key, r)
 	case api.MetricFilterNotRegex:
-		return NotRegex(filter)
+		r, _ := regexp.Compile(filter.Value)
+		return filters.NotRegex(filter.Key, r)
 	}
 	// Default = Exact
 	return Equal(filter)

--- a/pkg/pipeline/encode/metrics/preprocess_test.go
+++ b/pkg/pipeline/encode/metrics/preprocess_test.go
@@ -8,15 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_Filters_extractVarLookups(t *testing.T) {
-	variables := extractVarLookups("$(abc)--$(def)")
-
-	assert.Equal(t, [][]string{{"$(abc)", "abc"}, {"$(def)", "def"}}, variables)
-
-	variables = extractVarLookups("")
-	assert.Empty(t, variables)
-}
-
 func Test_Flatten(t *testing.T) {
 	pp := Preprocess(&api.MetricsItem{Flatten: []string{"interfaces", "events"}})
 	fl := pp.GenerateFlatParts(config.GenericMap{

--- a/pkg/pipeline/transform/transform_filter.go
+++ b/pkg/pipeline/transform/transform_filter.go
@@ -157,7 +157,7 @@ func applyRule(entry config.GenericMap, labels map[string]string, rule *api.Tran
 		return !isRemoveEntrySatisfied(entry, rule.RemoveEntryAllSatisfied)
 	case api.ConditionalSampling:
 		return sample(entry, rule.ConditionalSampling)
-	case api.KeepEntry:
+	case api.KeepEntryAllSatisfied:
 		return rollSampling(rule.KeepEntrySampling) && isKeepEntrySatisfied(entry, rule.KeepEntryAllSatisfied)
 	default:
 		tlog.Panicf("unknown type %s for transform.Filter rule: %v", rule.Type, rule)
@@ -250,7 +250,7 @@ func NewTransformFilter(params config.StageParam) (Transformer, error) {
 			return nil, err
 		}
 		for i := range params.Transform.Filter.Rules {
-			if params.Transform.Filter.Rules[i].Type == api.KeepEntry {
+			if params.Transform.Filter.Rules[i].Type == api.KeepEntryAllSatisfied {
 				keepRules = append(keepRules, params.Transform.Filter.Rules[i])
 			} else {
 				rules = append(rules, params.Transform.Filter.Rules[i])

--- a/pkg/pipeline/transform/transform_filter_test.go
+++ b/pkg/pipeline/transform/transform_filter_test.go
@@ -676,7 +676,7 @@ func Test_Transform_KeepEntry(t *testing.T) {
 	newFilter := api.TransformFilter{
 		Rules: []api.TransformFilterRule{
 			{
-				Type: api.KeepEntry,
+				Type: api.KeepEntryAllSatisfied,
 				KeepEntryAllSatisfied: []*api.KeepEntryRule{
 					{
 						Type: api.KeepEntryIfEqual,
@@ -694,7 +694,7 @@ func Test_Transform_KeepEntry(t *testing.T) {
 				},
 			},
 			{
-				Type: api.KeepEntry,
+				Type: api.KeepEntryAllSatisfied,
 				KeepEntryAllSatisfied: []*api.KeepEntryRule{
 					{
 						Type: api.KeepEntryIfRegexMatch,
@@ -742,7 +742,7 @@ func Test_Transform_KeepEntrySampling(t *testing.T) {
 	newFilter := api.TransformFilter{
 		Rules: []api.TransformFilterRule{
 			{
-				Type: api.KeepEntry,
+				Type: api.KeepEntryAllSatisfied,
 				KeepEntryAllSatisfied: []*api.KeepEntryRule{
 					{
 						Type: api.KeepEntryIfEqual,
@@ -755,7 +755,7 @@ func Test_Transform_KeepEntrySampling(t *testing.T) {
 				KeepEntrySampling: 10,
 			},
 			{
-				Type: api.KeepEntry,
+				Type: api.KeepEntryAllSatisfied,
 				KeepEntryAllSatisfied: []*api.KeepEntryRule{
 					{
 						Type: api.KeepEntryIfEqual,

--- a/pkg/utils/convert.go
+++ b/pkg/utils/convert.go
@@ -246,9 +246,9 @@ func ConvertToBool(unk interface{}) (bool, error) {
 func ConvertToString(unk interface{}) string {
 	switch i := unk.(type) {
 	case float64:
-		return strconv.FormatFloat(i, 'E', -1, 64)
+		return strconv.FormatFloat(i, 'f', -1, 64)
 	case float32:
-		return strconv.FormatFloat(float64(i), 'E', -1, 32)
+		return strconv.FormatFloat(float64(i), 'f', -1, 32)
 	case int64:
 		return strconv.FormatInt(i, 10)
 	case int32:

--- a/pkg/utils/filters/filters.go
+++ b/pkg/utils/filters/filters.go
@@ -1,0 +1,153 @@
+package filters
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
+)
+
+type Predicate func(flow config.GenericMap) bool
+
+var variableExtractor = regexp.MustCompile(`\$\(([^\)]+)\)`)
+
+func Presence(key string) Predicate {
+	return func(flow config.GenericMap) bool {
+		_, found := flow[key]
+		return found
+	}
+}
+
+func Absence(key string) Predicate {
+	return func(flow config.GenericMap) bool {
+		_, found := flow[key]
+		return !found
+	}
+}
+
+func Equal(key string, filterValue any, convertString bool) Predicate {
+	varLookups := extractVarLookups(filterValue)
+	if len(varLookups) > 0 {
+		return func(flow config.GenericMap) bool {
+			if val, found := flow[key]; found {
+				// Variable injection => convert to string
+				sVal, ok := val.(string)
+				if !ok {
+					sVal = utils.ConvertToString(val)
+				}
+				injected := injectVars(flow, filterValue.(string), varLookups)
+				return sVal == injected
+			}
+			return false
+		}
+	}
+	if convertString {
+		return func(flow config.GenericMap) bool {
+			if val, found := flow[key]; found {
+				sVal, ok := val.(string)
+				if !ok {
+					sVal = utils.ConvertToString(val)
+				}
+				return sVal == filterValue
+			}
+			return false
+		}
+	}
+	return func(flow config.GenericMap) bool {
+		if val, found := flow[key]; found {
+			return val == filterValue
+		}
+		return false
+	}
+}
+
+func NotEqual(key string, filterValue any, convertString bool) Predicate {
+	pred := Equal(key, filterValue, convertString)
+	return func(flow config.GenericMap) bool { return !pred(flow) }
+}
+
+func Regex(key string, filterRegex *regexp.Regexp) Predicate {
+	return func(flow config.GenericMap) bool {
+		if val, found := flow[key]; found {
+			sVal, ok := val.(string)
+			if !ok {
+				sVal = utils.ConvertToString(val)
+			}
+			return filterRegex.MatchString(sVal)
+		}
+		return false
+	}
+}
+
+func NotRegex(key string, filterRegex *regexp.Regexp) Predicate {
+	pred := Regex(key, filterRegex)
+	return func(flow config.GenericMap) bool { return !pred(flow) }
+}
+
+func extractVarLookups(value any) [][]string {
+	// Extract list of variables to lookup
+	// E.g: filter "$(SrcAddr):$(SrcPort)" would return [SrcAddr,SrcPort]
+	if sVal, isString := value.(string); isString {
+		if len(sVal) > 0 {
+			return variableExtractor.FindAllStringSubmatch(sVal, -1)
+		}
+	}
+	return nil
+}
+
+func injectVars(flow config.GenericMap, filterValue string, varLookups [][]string) string {
+	injected := filterValue
+	for _, matchGroup := range varLookups {
+		var value string
+		if rawVal, found := flow[matchGroup[1]]; found {
+			if sVal, ok := rawVal.(string); ok {
+				value = sVal
+			} else {
+				value = fmt.Sprint(rawVal)
+			}
+		}
+		injected = strings.ReplaceAll(injected, matchGroup[0], value)
+	}
+	return injected
+}
+
+func FromKeepEntry(from *api.KeepEntryRule) (Predicate, error) {
+	switch from.Type {
+	case api.KeepEntryIfExists:
+		return Presence(from.KeepEntry.Input), nil
+	case api.KeepEntryIfDoesntExist:
+		return Absence(from.KeepEntry.Input), nil
+	case api.KeepEntryIfEqual:
+		return Equal(from.KeepEntry.Input, from.KeepEntry.Value, true), nil
+	case api.KeepEntryIfNotEqual:
+		return NotEqual(from.KeepEntry.Input, from.KeepEntry.Value, true), nil
+	case api.KeepEntryIfRegexMatch:
+		if r, err := compileRegex(from.KeepEntry); err != nil {
+			return nil, err
+		} else {
+			return Regex(from.KeepEntry.Input, r), nil
+		}
+	case api.KeepEntryIfNotRegexMatch:
+		if r, err := compileRegex(from.KeepEntry); err != nil {
+			return nil, err
+		} else {
+			return NotRegex(from.KeepEntry.Input, r), nil
+		}
+	}
+	return nil, fmt.Errorf("keep entry rule type not recognized: %s", from.Type)
+}
+
+func compileRegex(from *api.TransformFilterGenericRule) (*regexp.Regexp, error) {
+	s, ok := from.Value.(string)
+	if !ok {
+		return nil, fmt.Errorf("invalid regex keep rule: rule value must be a string [%v]", from)
+	}
+	r, err := regexp.Compile(s)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex keep rule: cannot compile regex [%w]", err)
+	}
+	return r, nil
+}

--- a/pkg/utils/filters/filters.go
+++ b/pkg/utils/filters/filters.go
@@ -10,7 +10,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
 )
 
-type Predicate func(flow config.GenericMap) bool
+type Predicate func(config.GenericMap) bool
 
 var variableExtractor = regexp.MustCompile(`\$\(([^\)]+)\)`)
 
@@ -106,7 +106,7 @@ func injectVars(flow config.GenericMap, filterValue string, varLookups [][]strin
 			if sVal, ok := rawVal.(string); ok {
 				value = sVal
 			} else {
-				value = fmt.Sprint(rawVal)
+				value = utils.ConvertToString(rawVal)
 			}
 		}
 		injected = strings.ReplaceAll(injected, matchGroup[0], value)

--- a/pkg/utils/filters/filters_test.go
+++ b/pkg/utils/filters/filters_test.go
@@ -1,0 +1,130 @@
+package filters
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+var flow = config.GenericMap{
+	"namespace":       "foo",
+	"name":            "bar",
+	"bytes":           15,
+	"other_namespace": "foo",
+}
+
+func TestFilterPresence(t *testing.T) {
+	pred := Presence("namespace")
+	assert.True(t, pred(flow))
+
+	pred = Presence("namespacezzz")
+	assert.False(t, pred(flow))
+}
+
+func TestFilterAbsence(t *testing.T) {
+	pred := Absence("namespace")
+	assert.False(t, pred(flow))
+
+	pred = Absence("namespacezzz")
+	assert.True(t, pred(flow))
+}
+
+func TestFilterEqual(t *testing.T) {
+	pred := Equal("namespace", "foo", false)
+	assert.True(t, pred(flow))
+
+	pred = Equal("namespace", "foozzz", false)
+	assert.False(t, pred(flow))
+
+	pred = Equal("namespacezzz", "foo", false)
+	assert.False(t, pred(flow))
+
+	pred = Equal("bytes", 15, false)
+	assert.True(t, pred(flow))
+
+	pred = Equal("bytes", "15", false)
+	assert.False(t, pred(flow))
+
+	pred = Equal("bytes", "15", true)
+	assert.True(t, pred(flow))
+
+	pred = Equal("namespace", "$(other_namespace)", false)
+	assert.True(t, pred(flow))
+
+	pred = Equal("namespace", "$(name)", false)
+	assert.False(t, pred(flow))
+}
+
+func TestFilterNotEqual(t *testing.T) {
+	pred := NotEqual("namespace", "foo", false)
+	assert.False(t, pred(flow))
+
+	pred = NotEqual("namespace", "foozzz", false)
+	assert.True(t, pred(flow))
+
+	pred = NotEqual("namespacezzz", "foo", false)
+	assert.True(t, pred(flow))
+
+	pred = NotEqual("bytes", 15, false)
+	assert.False(t, pred(flow))
+
+	pred = NotEqual("bytes", 15, true)
+	assert.True(t, pred(flow))
+
+	pred = NotEqual("bytes", "15", false)
+	assert.True(t, pred(flow))
+
+	pred = NotEqual("bytes", "15", true)
+	assert.False(t, pred(flow))
+
+	pred = NotEqual("namespace", "$(other_namespace)", false)
+	assert.False(t, pred(flow))
+
+	pred = NotEqual("namespace", "$(name)", false)
+	assert.True(t, pred(flow))
+}
+
+func TestFilterRegex(t *testing.T) {
+	pred := Regex("namespace", regexp.MustCompile("f.+"))
+	assert.True(t, pred(flow))
+
+	pred = Regex("namespace", regexp.MustCompile("g.+"))
+	assert.False(t, pred(flow))
+
+	pred = Regex("namespacezzz", regexp.MustCompile("f.+"))
+	assert.False(t, pred(flow))
+
+	pred = Regex("bytes", regexp.MustCompile("1[0-9]"))
+	assert.True(t, pred(flow))
+
+	pred = Regex("bytes", regexp.MustCompile("2[0-9]"))
+	assert.False(t, pred(flow))
+}
+
+func TestFilterNotRegex(t *testing.T) {
+	pred := NotRegex("namespace", regexp.MustCompile("f.+"))
+	assert.False(t, pred(flow))
+
+	pred = NotRegex("namespace", regexp.MustCompile("g.+"))
+	assert.True(t, pred(flow))
+
+	pred = NotRegex("namespacezzz", regexp.MustCompile("f.+"))
+	assert.True(t, pred(flow))
+
+	pred = NotRegex("bytes", regexp.MustCompile("1[0-9]"))
+	assert.False(t, pred(flow))
+
+	pred = NotRegex("bytes", regexp.MustCompile("2[0-9]"))
+	assert.True(t, pred(flow))
+}
+
+func Test_Filters_extractVarLookups(t *testing.T) {
+	variables := extractVarLookups("$(abc)--$(def)")
+
+	assert.Equal(t, [][]string{{"$(abc)", "abc"}, {"$(def)", "def"}}, variables)
+
+	variables = extractVarLookups("")
+	assert.Empty(t, variables)
+}


### PR DESCRIPTION
## Description

- Allow to define filters for keeping flows. These rules are processed separately as the logic is reverse (first match means it's kept)
- Allow sampling within these new rules
- Allow regex checks (pre-compiled; need to check error on preprocess)

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
