### PR TITLE
Align build steps - distinguish clean vs dev builds

### DIFF
--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -35,10 +35,10 @@ jobs:
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build and push manifest with images
         run: |
-          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.WF_VERSION }} make images
-          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.short_sha }} OCI_BUILD_OPTS="--label quay.expires-after=2w" make images
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.WF_VERSION }} CLEAN_BUILD=1 make images
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.short_sha }} CLEAN_BUILD=1 OCI_BUILD_OPTS="--label quay.expires-after=2w" make images
           if [[ "main" == "$WF_VERSION" ]]; then
-            MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=latest make images
+            MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=latest CLEAN_BUILD=1 make images
           fi
 
   codecov:

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -37,7 +37,7 @@ jobs:
       - name: get short sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - name: build and push manifest with images
-        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} make images
+        run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE_ORG=${{ env.WF_ORG }} IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${{ env.short_sha }} CLEAN_BUILD=1 make images
       - uses: actions/github-script@v6
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,4 @@ jobs:
           password: ${{ secrets.QUAY_SECRET }}
           registry: quay.io
       - name: build and push manifest with images
-        run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} make images
+        run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} CLEAN_BUILD=1 make images

--- a/cmd/confgenerator/main.go
+++ b/cmd/confgenerator/main.go
@@ -34,8 +34,8 @@ import (
 )
 
 var (
-	BuildVersion       string
-	BuildDate          string
+	buildVersion       = "unknown"
+	buildDate          = "unknown"
 	cfgFile            string
 	logLevel           string
 	envPrefix          = "FLP_CONFGEN"
@@ -151,8 +151,7 @@ func main() {
 
 func run() {
 	// Initial log message
-	fmt.Printf("Starting %s:\n=====\nBuild Version: %s\nBuild Date: %s\n\n",
-		filepath.Base(os.Args[0]), BuildVersion, BuildDate)
+	fmt.Printf("Starting %s:\n=====\nBuild version: %s\nBuild date: %s\n\n", filepath.Base(os.Args[0]), buildVersion, buildDate)
 	// Dump the configuration
 	dumpConfig(&opts)
 	// creating a new configuration generator

--- a/cmd/flowlogs-pipeline/main.go
+++ b/cmd/flowlogs-pipeline/main.go
@@ -42,8 +42,8 @@ import (
 )
 
 var (
-	BuildVersion       string
-	BuildDate          string
+	buildVersion       = "unknown"
+	buildDate          = "unknown"
 	cfgFile            string
 	logLevel           string
 	envPrefix          = "FLOWLOGS-PIPELINE"
@@ -168,8 +168,7 @@ func run() {
 	)
 
 	// Initial log message
-	fmt.Printf("Starting %s:\n=====\nBuild Version: %s\nBuild Date: %s\n\n",
-		filepath.Base(os.Args[0]), BuildVersion, BuildDate)
+	fmt.Printf("Starting %s:\n=====\nBuild version: %s\nBuild date: %s\n\n", filepath.Base(os.Args[0]), buildVersion, buildDate)
 
 	// Dump configuration
 	dumpConfig(&opts)

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -2,29 +2,21 @@ ARG TARGETARCH
 FROM docker.io/library/golang:1.22 as builder
 
 ARG TARGETARCH=amd64
+ARG LDFLAGS
 WORKDIR /app
 
 # Copy source code
 COPY go.mod .
 COPY go.sum .
-COPY Makefile .
-COPY .mk/ .mk/
-COPY .bingo/ .bingo/
 COPY vendor/ vendor/
-COPY .git/ .git/
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
-RUN git status --porcelain
-RUN GOARCH=$TARGETARCH make build_code
+RUN GOARCH=$TARGETARCH go build -ldflags "$LDFLAGS" -mod vendor -o flowlogs-pipeline cmd/flowlogs-pipeline/main.go
 
 # final stage
 FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:9.4
 
 COPY --from=builder /app/flowlogs-pipeline /app/
-COPY --from=builder /app/confgenerator /app/
-
-# expose ports
-EXPOSE 2055
 
 ENTRYPOINT ["/app/flowlogs-pipeline"]

--- a/contrib/docker/Dockerfile.downstream
+++ b/contrib/docker/Dockerfile.downstream
@@ -3,28 +3,23 @@ ARG COMMIT
 FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:v1.22.5-202407301806.g4c8b32d.el9 as builder
 
 ARG TARGETARCH=amd64
+ARG LDFLAGS
 WORKDIR /app
 
 # Copy source code
 COPY go.mod .
 COPY go.sum .
-COPY Makefile .
-COPY .mk/ .mk/
-COPY .bingo/ .bingo/
 COPY vendor/ vendor/
-COPY .git/ .git/
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
-RUN git status --porcelain
-RUN GOARCH=$TARGETARCH make build_code
+RUN GOARCH=$TARGETARCH go build -ldflags "$LDFLAGS" -mod vendor -o flowlogs-pipeline cmd/flowlogs-pipeline/main.go
 
 # final stage
 FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:9.4
 
 COPY --from=builder /app/flowlogs-pipeline /app/
 
-# expose ports
 ENTRYPOINT ["/app/flowlogs-pipeline"]
 
 LABEL com.redhat.component="network-observability-flowlogs-pipeline-container"
@@ -36,4 +31,4 @@ LABEL maintainer="support@redhat.com"
 LABEL io.openshift.tags="network-observability-flowlogs-pipeline"
 LABEL upstream-vcs-type="git"
 LABEL upstream-vcs-type="$COMMIT"
-LABEL description="Flow-Logs Pipeline (a.k.a. FLP) is an observability tool that consumes logs from various inputs, transform them and export logs to loki and / or time series metrics to prometheus."
+LABEL description="Flow-Logs Pipeline is an observability tool that consumes logs from various inputs, transform them and export logs to Loki and / or metrics to Prometheus."


### PR DESCRIPTION
- Reducing the Dockerfile dependencies allows faster dev builds
- Rename target build_code -> compile for consistency
- Remove now useless validate_go target
- Remove confgenerator from docker images (we may introduce another dockerfile if someone finds it useful and want it back)
