### PR TITLE
NETOBSERV-1890: decode TCP flags (new stage/rule)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -241,6 +241,7 @@ Following is the supported API format for network transformations:
                     add_kubernetes_infra: add output kubernetes isInfra field from input
                     reinterpret_direction: reinterpret flow direction at the node level (instead of net interface), to ease the deduplication process
                     add_subnet_label: categorize IPs based on known subnets configuration
+                    decode_tcp_flags: decode bitwise TCP flags into a string
                  kubernetes_infra: Kubernetes infra rule configuration
                      namespaceNameFields: entries for namespace and name input fields
                              name: name of the object
@@ -272,6 +273,9 @@ Following is the supported API format for network transformations:
                      input: entry input field
                      output: entry output field
                      protocol: entry protocol field
+                 decode_tcp_flags: Decode bitwise TCP flags into a string
+                     input: entry input field
+                     output: entry output field
          kubeConfig: global configuration related to Kubernetes (optional)
              configPath: path to kubeconfig file (optional)
              secondaryNetworks: configuration for secondary networks

--- a/pkg/api/transform_network.go
+++ b/pkg/api/transform_network.go
@@ -59,6 +59,7 @@ const (
 	NetworkAddKubernetesInfra   TransformNetworkOperationEnum = "add_kubernetes_infra"  // add output kubernetes isInfra field from input
 	NetworkReinterpretDirection TransformNetworkOperationEnum = "reinterpret_direction" // reinterpret flow direction at the node level (instead of net interface), to ease the deduplication process
 	NetworkAddSubnetLabel       TransformNetworkOperationEnum = "add_subnet_label"      // categorize IPs based on known subnets configuration
+	NetworkDecodeTCPFlags       TransformNetworkOperationEnum = "decode_tcp_flags"      // decode bitwise TCP flags into a string
 )
 
 type NetworkTransformRule struct {
@@ -69,6 +70,7 @@ type NetworkTransformRule struct {
 	AddLocation     *NetworkGenericRule           `yaml:"add_location,omitempty" json:"add_location,omitempty" doc:"Add location rule configuration"`
 	AddSubnetLabel  *NetworkAddSubnetLabelRule    `yaml:"add_subnet_label,omitempty" json:"add_subnet_label,omitempty" doc:"Add subnet label rule configuration"`
 	AddService      *NetworkAddServiceRule        `yaml:"add_service,omitempty" json:"add_service,omitempty" doc:"Add service rule configuration"`
+	DecodeTCPFlags  *NetworkGenericRule           `yaml:"decode_tcp_flags,omitempty" json:"decode_tcp_flags,omitempty" doc:"Decode bitwise TCP flags into a string"`
 }
 
 type K8sInfraRule struct {

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -22,7 +22,6 @@ import (
 	"net"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
@@ -146,7 +145,7 @@ func (n *Network) Transform(inputEntry config.GenericMap) (config.GenericMap, bo
 			if anyFlags, ok := outputEntry[rule.DecodeTCPFlags.Input]; ok && anyFlags != nil {
 				if flags, ok := anyFlags.(uint16); ok {
 					flags := util.DecodeTCPFlags(flags)
-					outputEntry[rule.DecodeTCPFlags.Output] = strings.Join(flags, ",")
+					outputEntry[rule.DecodeTCPFlags.Output] = flags
 				}
 			}
 

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
@@ -141,6 +142,13 @@ func (n *Network) Transform(inputEntry config.GenericMap) (config.GenericMap, bo
 					}
 				}
 			}
+		case api.NetworkDecodeTCPFlags:
+			if anyFlags, ok := outputEntry[rule.DecodeTCPFlags.Input]; ok && anyFlags != nil {
+				if flags, ok := anyFlags.(uint16); ok {
+					flags := util.DecodeTCPFlags(flags)
+					outputEntry[rule.DecodeTCPFlags.Output] = strings.Join(flags, ",")
+				}
+			}
 
 		default:
 			log.Panicf("unknown type %s for transform.Network rule: %v", rule.Type, rule)
@@ -194,7 +202,8 @@ func NewTransformNetwork(params config.StageParam, opMetrics *operational.Metric
 			if len(jsonNetworkTransform.SubnetLabels) == 0 {
 				return nil, fmt.Errorf("a rule '%s' was found, but there are no subnet labels configured", api.NetworkAddSubnetLabel)
 			}
-		case api.NetworkAddSubnet:
+		case api.NetworkAddSubnet, api.NetworkDecodeTCPFlags:
+			// nothing
 		}
 	}
 

--- a/pkg/utils/tcp_flags.go
+++ b/pkg/utils/tcp_flags.go
@@ -1,0 +1,30 @@
+package utils
+
+type tcpFlag struct {
+	value uint16
+	name  string
+}
+
+var tcpFlags = []tcpFlag{
+	{value: 1, name: "FIN"},
+	{value: 2, name: "SYN"},
+	{value: 4, name: "RST"},
+	{value: 8, name: "PSH"},
+	{value: 16, name: "ACK"},
+	{value: 32, name: "URG"},
+	{value: 64, name: "ECE"},
+	{value: 128, name: "CWR"},
+	{value: 256, name: "SYN_ACK"},
+	{value: 512, name: "FIN_ACK"},
+	{value: 1024, name: "RST_ACK"},
+}
+
+func DecodeTCPFlags(bitfield uint16) []string {
+	var values []string
+	for _, flag := range tcpFlags {
+		if bitfield&flag.value != 0 {
+			values = append(values, flag.name)
+		}
+	}
+	return values
+}

--- a/pkg/utils/tcp_flags_test.go
+++ b/pkg/utils/tcp_flags_test.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeFlags(t *testing.T) {
+	flags528 := DecodeTCPFlags(528)
+	assert.Equal(t, []string{"ACK", "FIN_ACK"}, flags528)
+
+	flags256 := DecodeTCPFlags(256)
+	assert.Equal(t, []string{"SYN_ACK"}, flags256)
+
+	flags666 := DecodeTCPFlags(666)
+	assert.Equal(t, []string{"SYN", "PSH", "ACK", "CWR", "FIN_ACK"}, flags666)
+}


### PR DESCRIPTION
## Description

Introduces new transform rule "decode_tcp_flags" that allows to convert a uint46 flag (e.g: 2) into its strings list representation (eg. "SYN")

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
More PRs are necessary for the full feature in netobserv but this one can be merged alone independently

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
