### PR TITLE
NETOBSERV-1904: Enrich using UDN info

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -268,6 +268,7 @@ Following is the supported API format for network transformations:
                  kubernetes: Kubernetes rule configuration
                      ipField: entry IP input field
                      interfacesField: entry Interfaces input field
+                     udnsField: entry UDNs input field
                      macField: entry MAC input field
                      output: entry output field
                      assignee: value needs to assign to output field
@@ -294,7 +295,7 @@ Following is the supported API format for network transformations:
              configPath: path to kubeconfig file (optional)
              secondaryNetworks: configuration for secondary networks
                      name: name of the secondary network, as mentioned in the annotation 'k8s.v1.cni.cncf.io/network-status'
-                     index: fields to use for indexing, must be any combination of 'mac', 'ip', 'interface'
+                     index: fields to use for indexing, must be any combination of 'mac', 'ip', 'interface', or 'udn'
              managedCNI: a list of CNI (network plugins) to manage, for detecting additional interfaces. Currently supported: ovn
          servicesFile: path to services file (optional, default: /etc/services)
          protocolsFile: path to protocols file (optional, default: /etc/protocols)

--- a/pkg/api/transform_network.go
+++ b/pkg/api/transform_network.go
@@ -88,6 +88,7 @@ type K8sReference struct {
 type K8sRule struct {
 	IPField         string `yaml:"ipField,omitempty" json:"ipField,omitempty" doc:"entry IP input field"`
 	InterfacesField string `yaml:"interfacesField,omitempty" json:"interfacesField,omitempty" doc:"entry Interfaces input field"`
+	UDNsField       string `yaml:"udnsField,omitempty" json:"udnsField,omitempty" doc:"entry UDNs input field"`
 	MACField        string `yaml:"macField,omitempty" json:"macField,omitempty" doc:"entry MAC input field"`
 	Output          string `yaml:"output,omitempty" json:"output,omitempty" doc:"entry output field"`
 	Assignee        string `yaml:"assignee,omitempty" json:"assignee,omitempty" doc:"value needs to assign to output field"`
@@ -97,7 +98,7 @@ type K8sRule struct {
 
 type SecondaryNetwork struct {
 	Name  string         `yaml:"name,omitempty" json:"name,omitempty" doc:"name of the secondary network, as mentioned in the annotation 'k8s.v1.cni.cncf.io/network-status'"`
-	Index map[string]any `yaml:"index,omitempty" json:"index,omitempty" doc:"fields to use for indexing, must be any combination of 'mac', 'ip', 'interface'"`
+	Index map[string]any `yaml:"index,omitempty" json:"index,omitempty" doc:"fields to use for indexing, must be any combination of 'mac', 'ip', 'interface', or 'udn'"`
 }
 
 type NetworkGenericRule struct {

--- a/pkg/pipeline/transform/kubernetes/cni/multus.go
+++ b/pkg/pipeline/transform/kubernetes/cni/multus.go
@@ -26,6 +26,10 @@ type SecondaryNetKey struct {
 	Key         string
 }
 
+func (m *MultusHandler) Manages(indexKey string) bool {
+	return indexKey == indexIP || indexKey == indexMAC || indexKey == indexInterface
+}
+
 func (m *MultusHandler) BuildKeys(flow config.GenericMap, rule *api.K8sRule, secNets []api.SecondaryNetwork) []SecondaryNetKey {
 	if len(secNets) == 0 {
 		return nil
@@ -66,6 +70,9 @@ func (m *MultusHandler) buildSNKeys(flow config.GenericMap, rule *api.K8sRule, s
 		if !ok {
 			return nil
 		}
+	}
+	if mac == "" && ip == "" && len(interfaces) == 0 {
+		return nil
 	}
 
 	macIP := "~" + ip + "~" + mac

--- a/pkg/pipeline/transform/kubernetes/cni/udn.go
+++ b/pkg/pipeline/transform/kubernetes/cni/udn.go
@@ -1,0 +1,88 @@
+package cni
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	ovnAnnotation = "k8s.ovn.org/pod-networks"
+)
+
+type UDNHandler struct {
+}
+
+func UDNKey(label, ip string) SecondaryNetKey {
+	key := label + "~" + ip
+	return SecondaryNetKey{NetworkName: label, Key: key}
+}
+
+func (m *UDNHandler) Manages(indexKey string) bool {
+	return indexKey == "udn"
+}
+
+func (m *UDNHandler) BuildKeys(flow config.GenericMap, rule *api.K8sRule) []SecondaryNetKey {
+	var keys []SecondaryNetKey
+
+	var ip string
+	var udns []string
+	var ok bool
+	if len(rule.IPField) > 0 {
+		ip, ok = flow.LookupString(rule.IPField)
+		if !ok {
+			return nil
+		}
+	}
+	if len(rule.UDNsField) > 0 {
+		v, ok := flow[rule.UDNsField]
+		if !ok {
+			return nil
+		}
+		udns, ok = v.([]string)
+		if !ok || len(udns) == 0 {
+			return nil
+		}
+	}
+
+	for _, udn := range udns {
+		if udn != "" && udn != "default" {
+			keys = append(keys, UDNKey(udn, ip))
+		}
+	}
+
+	return keys
+}
+
+func (m *UDNHandler) GetPodUniqueKeys(pod *v1.Pod) ([]string, error) {
+	// Example:
+	// k8s.ovn.org/pod-networks: '{"default":{"ip_addresses":["10.128.2.20/23"],"mac_address":"0a:58:0a:80:02:14","routes":[{"dest":"10.128.0.0/14","nextHop":"10.128.2.1"},{"dest":"100.64.0.0/16","nextHop":"10.128.2.1"}],"ip_address":"10.128.2.20/23","role":"infrastructure-locked"},"mesh-arena/primary-udn":{"ip_addresses":["10.200.200.12/24"],"mac_address":"0a:58:0a:c8:c8:0c","gateway_ips":["10.200.200.1"],"routes":[{"dest":"172.30.0.0/16","nextHop":"10.200.200.1"},{"dest":"100.65.0.0/16","nextHop":"10.200.200.1"}],"ip_address":"10.200.200.12/24","gateway_ip":"10.200.200.1","tunnel_id":16,"role":"primary"}}'
+	if statusAnnotationJSON, ok := pod.Annotations[ovnAnnotation]; ok {
+		var annot map[string]map[string]any
+		if err := json.Unmarshal([]byte(statusAnnotationJSON), &annot); err != nil {
+			return nil, fmt.Errorf("failed to index from OVN annotation, cannot read annotation %s: %w", ovnAnnotation, err)
+		}
+		var keys []string
+		for label, info := range annot {
+			if label != "default" {
+				if rawip, ok := info["ip_address"]; ok {
+					if ip, ok := rawip.(string); ok {
+						// IP has a CIDR prefix (bug??)
+						parts := strings.SplitN(ip, "/", 2)
+						if len(parts) > 0 {
+							key := UDNKey(label, parts[0])
+							keys = append(keys, key.Key)
+						}
+					}
+				}
+			}
+		}
+		return keys, nil
+	}
+	// Annotation not present => just ignore, no error
+	return nil, nil
+}

--- a/pkg/pipeline/transform/kubernetes/cni/udn_test.go
+++ b/pkg/pipeline/transform/kubernetes/cni/udn_test.go
@@ -1,0 +1,31 @@
+package cni
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	udnHandler = UDNHandler{}
+	udnPod     = v1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
+	udnConfig  = `{"default":{"ip_addresses":["10.128.2.20/23"],"mac_address":"0a:58:0a:80:02:14","routes":[{"dest":"10.128.0.0/14","nextHop":"10.128.2.1"},{"dest":"100.64.0.0/16","nextHop":"10.128.2.1"}],"ip_address":"10.128.2.20/23","role":"infrastructure-locked"},
+	"mesh-arena/primary-udn":{"ip_addresses":["10.200.200.12/24"],"mac_address":"0a:58:0a:c8:c8:0c","gateway_ips":["10.200.200.1"],"routes":[{"dest":"172.30.0.0/16","nextHop":"10.200.200.1"},{"dest":"100.65.0.0/16","nextHop":"10.200.200.1"}],"ip_address":"10.200.200.12/24","gateway_ip":"10.200.200.1","tunnel_id":16,"role":"primary"}}`
+)
+
+func TestExtractUDNStatusKeys(t *testing.T) {
+	// Annotation not found => no error, no key
+	keys, err := udnHandler.GetPodUniqueKeys(&udnPod)
+	require.NoError(t, err)
+	require.Empty(t, keys)
+
+	// Valid annotation => no error, key
+	udnPod.Annotations = map[string]string{
+		ovnAnnotation: udnConfig,
+	}
+	keys, err = udnHandler.GetPodUniqueKeys(&udnPod)
+	require.NoError(t, err)
+	require.Equal(t, []string{"mesh-arena/primary-udn~10.200.200.12"}, keys)
+}

--- a/pkg/pipeline/transform/kubernetes/cni/udn_test.go
+++ b/pkg/pipeline/transform/kubernetes/cni/udn_test.go
@@ -1,6 +1,7 @@
 package cni
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,9 +12,20 @@ import (
 var (
 	udnHandler = UDNHandler{}
 	udnPod     = v1.Pod{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}}}
-	udnConfig  = `{"default":{"ip_addresses":["10.128.2.20/23"],"mac_address":"0a:58:0a:80:02:14","routes":[{"dest":"10.128.0.0/14","nextHop":"10.128.2.1"},{"dest":"100.64.0.0/16","nextHop":"10.128.2.1"}],"ip_address":"10.128.2.20/23","role":"infrastructure-locked"},
-	"mesh-arena/primary-udn":{"ip_addresses":["10.200.200.12/24"],"mac_address":"0a:58:0a:c8:c8:0c","gateway_ips":["10.200.200.1"],"routes":[{"dest":"172.30.0.0/16","nextHop":"10.200.200.1"},{"dest":"100.65.0.0/16","nextHop":"10.200.200.1"}],"ip_address":"10.200.200.12/24","gateway_ip":"10.200.200.1","tunnel_id":16,"role":"primary"}}`
 )
+
+func udnConfigAnnotation(ip string) string {
+	return fmt.Sprintf(`{"default":{"ip_addresses":["10.128.2.20/23"],"mac_address":"0a:58:0a:80:02:14","routes":[{"dest":"10.128.0.0/14","nextHop":"10.128.2.1"},{"dest":"100.64.0.0/16","nextHop":"10.128.2.1"}],"ip_address":"10.128.2.20/23","role":"infrastructure-locked"},
+	"mesh-arena/primary-udn":
+		{"ip_addresses":["%s"],
+		"mac_address":"0a:58:0a:c8:c8:0c",
+		"gateway_ips":["10.200.200.1"],
+		"routes":[{"dest":"172.30.0.0/16","nextHop":"10.200.200.1"},{"dest":"100.65.0.0/16","nextHop":"10.200.200.1"}],
+		"ip_address":"%s",
+		"gateway_ip":"10.200.200.1",
+		"tunnel_id":16,
+		"role":"primary"}}`, ip, ip)
+}
 
 func TestExtractUDNStatusKeys(t *testing.T) {
 	// Annotation not found => no error, no key
@@ -21,11 +33,35 @@ func TestExtractUDNStatusKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, keys)
 
-	// Valid annotation => no error, key
+	// Valid annotation => no error, valid key
 	udnPod.Annotations = map[string]string{
-		ovnAnnotation: udnConfig,
+		ovnAnnotation: udnConfigAnnotation("10.200.200.12"),
 	}
 	keys, err = udnHandler.GetPodUniqueKeys(&udnPod)
 	require.NoError(t, err)
 	require.Equal(t, []string{"mesh-arena/primary-udn~10.200.200.12"}, keys)
+
+	// Same check with a somewhat surprising CIDR found here as an IP, but it's really the IP part that should be used
+	udnPod.Annotations = map[string]string{
+		ovnAnnotation: udnConfigAnnotation("10.200.200.12/24"),
+	}
+	keys, err = udnHandler.GetPodUniqueKeys(&udnPod)
+	require.NoError(t, err)
+	require.Equal(t, []string{"mesh-arena/primary-udn~10.200.200.12"}, keys)
+
+	// Same with IPv6
+	udnPod.Annotations = map[string]string{
+		ovnAnnotation: udnConfigAnnotation("2001:0db8::1111"),
+	}
+	keys, err = udnHandler.GetPodUniqueKeys(&udnPod)
+	require.NoError(t, err)
+	require.Equal(t, []string{"mesh-arena/primary-udn~2001:0db8::1111"}, keys)
+
+	// Same with IPv6 as a CIDR
+	udnPod.Annotations = map[string]string{
+		ovnAnnotation: udnConfigAnnotation("2001:0db8::1111/24"),
+	}
+	keys, err = udnHandler.GetPodUniqueKeys(&udnPod)
+	require.NoError(t, err)
+	require.Equal(t, []string{"mesh-arena/primary-udn~2001:0db8::1111"}, keys)
 }

--- a/pkg/pipeline/transform/kubernetes/enrich_test.go
+++ b/pkg/pipeline/transform/kubernetes/enrich_test.go
@@ -479,6 +479,7 @@ func TestEnrichUsingUDN(t *testing.T) {
 			Type: api.NetworkAddKubernetes,
 			Kubernetes: &api.K8sRule{
 				IPField:   "SrcAddr",
+				MACField:  "SrcMAC",
 				UDNsField: "Udns",
 				Output:    "SrcK8s",
 				AddZone:   true,
@@ -488,14 +489,15 @@ func TestEnrichUsingUDN(t *testing.T) {
 			Type: api.NetworkAddKubernetes,
 			Kubernetes: &api.K8sRule{
 				IPField:   "DstAddr",
+				MACField:  "DstMAC",
 				UDNsField: "Udns",
 				Output:    "DstK8s",
 				AddZone:   true,
 			},
 		},
 	}
-	udnInfo := map[string]*inf.Info{
-		"ns-1/primary-udn~10.200.200.12": {
+	customIndexes := map[string]*inf.Info{
+		"~~AA:BB:CC:DD:EE:FF": {
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "pod-1",
 				Namespace: "ns-1",
@@ -503,32 +505,55 @@ func TestEnrichUsingUDN(t *testing.T) {
 			Type:        "Pod",
 			HostName:    "host-1",
 			HostIP:      "100.0.0.1",
-			NetworkName: "ns-1/primary-udn",
+			NetworkName: "custom-network",
+		},
+		"ns-2/primary-udn~10.200.200.12": {
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "pod-2",
+				Namespace: "ns-2",
+			},
+			Type:        "Pod",
+			HostName:    "host-2",
+			HostIP:      "100.0.0.2",
+			NetworkName: "ns-2/primary-udn",
 		},
 	}
-	informers = inf.SetupStubs(ipInfo, udnInfo, nodes)
+	informers = inf.SetupStubs(ipInfo, customIndexes, nodes)
 
-	// Pod to unknown using UDN
+	// MAC-indexed Pod 1 to UDN-indexed Pod 2
 	entry := config.GenericMap{
 		"SrcAddr": "8.8.8.8",
-		"DstAddr": "10.200.200.12",
-		"Udns":    []string{"", "default", "ns-1/primary-udn"},
+		"SrcMAC":  "AA:BB:CC:DD:EE:FF", // pod-1
+		"DstAddr": "10.200.200.12",     // pod-2 (UDN)
+		"DstMAC":  "GG:HH:II:JJ:KK:LL", // unknown
+		"Udns":    []string{"", "default", "ns-2/primary-udn"},
 	}
 	for _, r := range udnRules {
 		Enrich(entry, r.Kubernetes)
 	}
 	assert.Equal(t, config.GenericMap{
 		"SrcAddr":            "8.8.8.8",
+		"SrcMAC":             "AA:BB:CC:DD:EE:FF",
 		"DstAddr":            "10.200.200.12",
-		"Udns":               []string{"", "default", "ns-1/primary-udn"},
-		"DstK8s_HostIP":      "100.0.0.1",
-		"DstK8s_HostName":    "host-1",
-		"DstK8s_Name":        "pod-1",
-		"DstK8s_Namespace":   "ns-1",
+		"DstMAC":             "GG:HH:II:JJ:KK:LL",
+		"Udns":               []string{"", "default", "ns-2/primary-udn"},
+		"SrcK8s_HostIP":      "100.0.0.1",
+		"SrcK8s_HostName":    "host-1",
+		"SrcK8s_Name":        "pod-1",
+		"SrcK8s_Namespace":   "ns-1",
+		"SrcK8s_OwnerName":   "",
+		"SrcK8s_OwnerType":   "",
+		"SrcK8s_Type":        "Pod",
+		"SrcK8s_Zone":        "us-east-1a",
+		"SrcK8s_NetworkName": "custom-network",
+		"DstK8s_HostIP":      "100.0.0.2",
+		"DstK8s_HostName":    "host-2",
+		"DstK8s_Name":        "pod-2",
+		"DstK8s_Namespace":   "ns-2",
 		"DstK8s_OwnerName":   "",
 		"DstK8s_OwnerType":   "",
 		"DstK8s_Type":        "Pod",
-		"DstK8s_Zone":        "us-east-1a",
-		"DstK8s_NetworkName": "ns-1/primary-udn",
+		"DstK8s_Zone":        "us-east-1b",
+		"DstK8s_NetworkName": "ns-2/primary-udn",
 	}, entry)
 }

--- a/pkg/pipeline/transform/kubernetes/informers/informers-mock.go
+++ b/pkg/pipeline/transform/kubernetes/informers/informers-mock.go
@@ -180,8 +180,8 @@ func (f *FakeInformers) InitFromConfig(_ api.NetworkTransformKubeConfig, _ *oper
 }
 
 func (f *FakeInformers) GetInfo(keys []cni.SecondaryNetKey, ip string) (*Info, error) {
-	if len(keys) > 0 {
-		i := f.customKeysInfo[keys[0].Key]
+	for _, key := range keys {
+		i := f.customKeysInfo[key.Key]
 		if i != nil {
 			return i, nil
 		}

--- a/pkg/pipeline/transform/kubernetes/informers/informers-mock.go
+++ b/pkg/pipeline/transform/kubernetes/informers/informers-mock.go
@@ -18,6 +18,10 @@ var (
 			Name:  "my-network",
 			Index: map[string]any{"mac": nil},
 		},
+		{
+			Name:  "ovn-udn",
+			Index: map[string]any{"udn": nil},
+		},
 	}
 )
 
@@ -191,8 +195,7 @@ func (f *FakeInformers) GetInfo(keys []cni.SecondaryNetKey, ip string) (*Info, e
 }
 
 func (f *FakeInformers) BuildSecondaryNetworkKeys(flow config.GenericMap, rule *api.K8sRule) []cni.SecondaryNetKey {
-	m := cni.MultusHandler{}
-	return m.BuildKeys(flow, rule, secondaryNetConfig)
+	return buildSecondaryNetworkKeys(flow, rule, secondaryNetConfig, true, true)
 }
 
 func (f *FakeInformers) GetNodeInfo(n string) (*Info, error) {


### PR DESCRIPTION
## Description

Use the OVN annotation "k8s.ovn.org/pod-networks" to index pods  based on their IP + UDN label.
This is only enabled when SecondaryNetworks is configured with the "udn" index.
It leverages the "Udns" field that the ebpf agent populates, to find udn labels per flow. This should allow indexing with overlapping IPs.

It also populates the Src/Dst Network Name with the matched UDN label.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a
