### PR TITLE
Refactoring prior to informers-cache rework

### DIFF
--- a/pkg/kafka/reader.go
+++ b/pkg/kafka/reader.go
@@ -1,0 +1,117 @@
+package kafka
+
+import (
+	"errors"
+	"os"
+	"time"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	kafkago "github.com/segmentio/kafka-go"
+	"github.com/sirupsen/logrus"
+)
+
+var klog = logrus.WithField("component", "kafka-reader")
+
+const defaultBatchReadTimeout = int64(1000)
+const defaultKafkaBatchMaxLength = 500
+const defaultKafkaCommitInterval = 500
+
+func NewReader(config *api.IngestKafka) (*kafkago.Reader, int, error) {
+	startOffsetString := config.StartOffset
+	var startOffset int64
+	switch startOffsetString {
+	case "FirstOffset", "":
+		startOffset = kafkago.FirstOffset
+	case "LastOffset":
+		startOffset = kafkago.LastOffset
+	default:
+		startOffset = kafkago.FirstOffset
+		klog.Errorf("illegal value for StartOffset: %s; using default\n", startOffsetString)
+	}
+	klog.Debugf("startOffset = %v", startOffset)
+	groupBalancers := make([]kafkago.GroupBalancer, 0)
+	for _, gb := range config.GroupBalancers {
+		switch gb {
+		case "range":
+			groupBalancers = append(groupBalancers, &kafkago.RangeGroupBalancer{})
+		case "roundRobin":
+			groupBalancers = append(groupBalancers, &kafkago.RoundRobinGroupBalancer{})
+		case "rackAffinity":
+			groupBalancers = append(groupBalancers, &kafkago.RackAffinityGroupBalancer{})
+		default:
+			klog.Warningf("groupbalancers parameter missing")
+			groupBalancers = append(groupBalancers, &kafkago.RoundRobinGroupBalancer{})
+		}
+	}
+
+	batchReadTimeout := defaultBatchReadTimeout
+	if config.BatchReadTimeout != 0 {
+		batchReadTimeout = config.BatchReadTimeout
+	}
+	klog.Debugf("batchReadTimeout = %d", batchReadTimeout)
+
+	commitInterval := int64(defaultKafkaCommitInterval)
+	if config.CommitInterval != 0 {
+		commitInterval = config.CommitInterval
+	}
+	klog.Debugf("commitInterval = %d", config.CommitInterval)
+
+	dialer := &kafkago.Dialer{
+		Timeout:   kafkago.DefaultDialer.Timeout,
+		DualStack: kafkago.DefaultDialer.DualStack,
+	}
+	if config.TLS != nil {
+		klog.Infof("Using TLS configuration: %v", config.TLS)
+		tlsConfig, err := config.TLS.Build()
+		if err != nil {
+			return nil, 0, err
+		}
+		dialer.TLS = tlsConfig
+	}
+
+	if config.SASL != nil {
+		m, err := utils.SetupSASLMechanism(config.SASL)
+		if err != nil {
+			return nil, 0, err
+		}
+		dialer.SASLMechanism = m
+	}
+
+	readerConfig := kafkago.ReaderConfig{
+		Brokers:        config.Brokers,
+		Topic:          config.Topic,
+		GroupID:        config.GroupID,
+		GroupBalancers: groupBalancers,
+		StartOffset:    startOffset,
+		CommitInterval: time.Duration(commitInterval) * time.Millisecond,
+		Dialer:         dialer,
+	}
+
+	if readerConfig.GroupID == "" {
+		// Use hostname
+		readerConfig.GroupID = os.Getenv("HOSTNAME")
+	}
+
+	if config.PullQueueCapacity > 0 {
+		readerConfig.QueueCapacity = config.PullQueueCapacity
+	}
+
+	if config.PullMaxBytes > 0 {
+		readerConfig.MaxBytes = config.PullMaxBytes
+	}
+
+	bml := defaultKafkaBatchMaxLength
+	if config.BatchMaxLen != 0 {
+		bml = config.BatchMaxLen
+	}
+
+	klog.Debugf("reader config: %#v", readerConfig)
+
+	kafkaReader := kafkago.NewReader(readerConfig)
+	if kafkaReader == nil {
+		return nil, 0, errors.New("NewIngestKafka: failed to create kafka-go reader")
+	}
+
+	return kafkaReader, bml, nil
+}

--- a/pkg/kafka/writer.go
+++ b/pkg/kafka/writer.go
@@ -1,0 +1,77 @@
+package kafka
+
+import (
+	"time"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	kafkago "github.com/segmentio/kafka-go"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	defaultReadTimeoutSeconds  = int64(10)
+	defaultWriteTimeoutSeconds = int64(10)
+)
+
+func NewWriter(config *api.EncodeKafka) (*kafkago.Writer, error) {
+	var balancer kafkago.Balancer
+	switch config.Balancer {
+	case api.KafkaRoundRobin:
+		balancer = &kafkago.RoundRobin{}
+	case api.KafkaLeastBytes:
+		balancer = &kafkago.LeastBytes{}
+	case api.KafkaHash:
+		balancer = &kafkago.Hash{}
+	case api.KafkaCrc32:
+		balancer = &kafkago.CRC32Balancer{}
+	case api.KafkaMurmur2:
+		balancer = &kafkago.Murmur2Balancer{}
+	default:
+		balancer = nil
+	}
+
+	readTimeoutSecs := defaultReadTimeoutSeconds
+	if config.ReadTimeout != 0 {
+		readTimeoutSecs = config.ReadTimeout
+	}
+
+	writeTimeoutSecs := defaultWriteTimeoutSeconds
+	if config.WriteTimeout != 0 {
+		writeTimeoutSecs = config.WriteTimeout
+	}
+
+	transport := kafkago.Transport{}
+	if config.TLS != nil {
+		log.Infof("Using TLS configuration: %v", config.TLS)
+		tlsConfig, err := config.TLS.Build()
+		if err != nil {
+			return nil, err
+		}
+		transport.TLS = tlsConfig
+	}
+
+	if config.SASL != nil {
+		m, err := utils.SetupSASLMechanism(config.SASL)
+		if err != nil {
+			return nil, err
+		}
+		transport.SASL = m
+	}
+
+	kafkaWriter := kafkago.Writer{
+		Addr:         kafkago.TCP(config.Address),
+		Topic:        config.Topic,
+		Balancer:     balancer,
+		ReadTimeout:  time.Duration(readTimeoutSecs) * time.Second,
+		WriteTimeout: time.Duration(writeTimeoutSecs) * time.Second,
+		BatchSize:    config.BatchSize,
+		BatchBytes:   config.BatchBytes,
+		// Temporary fix may be we should implement a batching systems
+		// https://github.com/segmentio/kafka-go/issues/326#issuecomment-519375403
+		BatchTimeout: time.Nanosecond,
+		Transport:    &transport,
+	}
+
+	return &kafkaWriter, nil
+}

--- a/pkg/pipeline/encode/encode_kafka.go
+++ b/pkg/pipeline/encode/encode_kafka.go
@@ -19,21 +19,15 @@ package encode
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/kafka"
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
-	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	kafkago "github.com/segmentio/kafka-go"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
-)
-
-const (
-	defaultReadTimeoutSeconds  = int64(10)
-	defaultWriteTimeoutSeconds = int64(10)
 )
 
 type kafkaWriteMessage interface {
@@ -78,68 +72,14 @@ func NewEncodeKafka(opMetrics *operational.Metrics, params config.StageParam) (E
 		config = *params.Encode.Kafka
 	}
 
-	var balancer kafkago.Balancer
-	switch config.Balancer {
-	case api.KafkaRoundRobin:
-		balancer = &kafkago.RoundRobin{}
-	case api.KafkaLeastBytes:
-		balancer = &kafkago.LeastBytes{}
-	case api.KafkaHash:
-		balancer = &kafkago.Hash{}
-	case api.KafkaCrc32:
-		balancer = &kafkago.CRC32Balancer{}
-	case api.KafkaMurmur2:
-		balancer = &kafkago.Murmur2Balancer{}
-	default:
-		balancer = nil
-	}
-
-	readTimeoutSecs := defaultReadTimeoutSeconds
-	if config.ReadTimeout != 0 {
-		readTimeoutSecs = config.ReadTimeout
-	}
-
-	writeTimeoutSecs := defaultWriteTimeoutSeconds
-	if config.WriteTimeout != 0 {
-		writeTimeoutSecs = config.WriteTimeout
-	}
-
-	transport := kafkago.Transport{}
-	if config.TLS != nil {
-		log.Infof("Using TLS configuration: %v", config.TLS)
-		tlsConfig, err := config.TLS.Build()
-		if err != nil {
-			return nil, err
-		}
-		transport.TLS = tlsConfig
-	}
-
-	if config.SASL != nil {
-		m, err := utils.SetupSASLMechanism(config.SASL)
-		if err != nil {
-			return nil, err
-		}
-		transport.SASL = m
-	}
-
-	// connect to the kafka server
-	kafkaWriter := kafkago.Writer{
-		Addr:         kafkago.TCP(config.Address),
-		Topic:        config.Topic,
-		Balancer:     balancer,
-		ReadTimeout:  time.Duration(readTimeoutSecs) * time.Second,
-		WriteTimeout: time.Duration(writeTimeoutSecs) * time.Second,
-		BatchSize:    config.BatchSize,
-		BatchBytes:   config.BatchBytes,
-		// Temporary fix may be we should implement a batching systems
-		// https://github.com/segmentio/kafka-go/issues/326#issuecomment-519375403
-		BatchTimeout: time.Nanosecond,
-		Transport:    &transport,
+	kafkaWriter, err := kafka.NewWriter(&config)
+	if err != nil {
+		return nil, err
 	}
 
 	return &encodeKafka{
 		kafkaParams:    config,
-		kafkaWriter:    &kafkaWriter,
+		kafkaWriter:    kafkaWriter,
 		recordsWritten: opMetrics.CreateRecordsWrittenCounter(params.Name),
 	}, nil
 }

--- a/pkg/pipeline/ingest/ingest_kafka.go
+++ b/pkg/pipeline/ingest/ingest_kafka.go
@@ -18,11 +18,11 @@
 package ingest
 
 import (
-	"errors"
 	"time"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/kafka"
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/decode"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
@@ -40,19 +40,13 @@ type kafkaReadMessage interface {
 }
 
 type ingestKafka struct {
-	kafkaReader      kafkaReadMessage
-	decoder          decode.Decoder
-	in               chan []byte
-	exitChan         <-chan struct{}
-	batchReadTimeout int64
-	batchMaxLength   int
-	metrics          *metrics
-	canLogMessages   bool
+	kafkaReader    kafkaReadMessage
+	decoder        decode.Decoder
+	in             chan []byte
+	exitChan       <-chan struct{}
+	metrics        *metrics
+	canLogMessages bool
 }
-
-const defaultBatchReadTimeout = int64(1000)
-const defaultKafkaBatchMaxLength = 500
-const defaultKafkaCommitInterval = 500
 
 const kafkaStatsPeriod = 15 * time.Second
 
@@ -175,125 +169,34 @@ func (k *ingestKafka) reportStats() {
 // NewIngestKafka create a new ingester
 // nolint:cyclop
 func NewIngestKafka(opMetrics *operational.Metrics, params config.StageParam) (Ingester, error) {
-	klog.Debugf("entering NewIngestKafka")
-	jsonIngestKafka := api.IngestKafka{}
+	config := &api.IngestKafka{}
 	var ingestType string
 	if params.Ingest != nil {
 		ingestType = params.Ingest.Type
 		if params.Ingest.Kafka != nil {
-			jsonIngestKafka = *params.Ingest.Kafka
+			config = params.Ingest.Kafka
 		}
 	}
 
-	// connect to the kafka server
-	startOffsetString := jsonIngestKafka.StartOffset
-	var startOffset int64
-	switch startOffsetString {
-	case "FirstOffset", "":
-		startOffset = kafkago.FirstOffset
-	case "LastOffset":
-		startOffset = kafkago.LastOffset
-	default:
-		startOffset = kafkago.FirstOffset
-		klog.Errorf("illegal value for StartOffset: %s\n", startOffsetString)
-	}
-	klog.Debugf("startOffset = %v", startOffset)
-	groupBalancers := make([]kafkago.GroupBalancer, 0)
-	for _, gb := range jsonIngestKafka.GroupBalancers {
-		switch gb {
-		case "range":
-			groupBalancers = append(groupBalancers, &kafkago.RangeGroupBalancer{})
-		case "roundRobin":
-			groupBalancers = append(groupBalancers, &kafkago.RoundRobinGroupBalancer{})
-		case "rackAffinity":
-			groupBalancers = append(groupBalancers, &kafkago.RackAffinityGroupBalancer{})
-		default:
-			klog.Warningf("groupbalancers parameter missing")
-			groupBalancers = append(groupBalancers, &kafkago.RoundRobinGroupBalancer{})
-		}
-	}
-
-	batchReadTimeout := defaultBatchReadTimeout
-	if jsonIngestKafka.BatchReadTimeout != 0 {
-		batchReadTimeout = jsonIngestKafka.BatchReadTimeout
-	}
-	klog.Infof("batchReadTimeout = %d", batchReadTimeout)
-
-	commitInterval := int64(defaultKafkaCommitInterval)
-	if jsonIngestKafka.CommitInterval != 0 {
-		commitInterval = jsonIngestKafka.CommitInterval
-	}
-	klog.Infof("commitInterval = %d", jsonIngestKafka.CommitInterval)
-
-	dialer := &kafkago.Dialer{
-		Timeout:   kafkago.DefaultDialer.Timeout,
-		DualStack: kafkago.DefaultDialer.DualStack,
-	}
-	if jsonIngestKafka.TLS != nil {
-		klog.Infof("Using TLS configuration: %v", jsonIngestKafka.TLS)
-		tlsConfig, err := jsonIngestKafka.TLS.Build()
-		if err != nil {
-			return nil, err
-		}
-		dialer.TLS = tlsConfig
-	}
-
-	if jsonIngestKafka.SASL != nil {
-		m, err := utils.SetupSASLMechanism(jsonIngestKafka.SASL)
-		if err != nil {
-			return nil, err
-		}
-		dialer.SASLMechanism = m
-	}
-
-	readerConfig := kafkago.ReaderConfig{
-		Brokers:        jsonIngestKafka.Brokers,
-		Topic:          jsonIngestKafka.Topic,
-		GroupID:        jsonIngestKafka.GroupID,
-		GroupBalancers: groupBalancers,
-		StartOffset:    startOffset,
-		CommitInterval: time.Duration(commitInterval) * time.Millisecond,
-		Dialer:         dialer,
-	}
-
-	if jsonIngestKafka.PullQueueCapacity > 0 {
-		readerConfig.QueueCapacity = jsonIngestKafka.PullQueueCapacity
-	}
-
-	if jsonIngestKafka.PullMaxBytes > 0 {
-		readerConfig.MaxBytes = jsonIngestKafka.PullMaxBytes
-	}
-
-	klog.Debugf("reader config: %#v", readerConfig)
-
-	kafkaReader := kafkago.NewReader(readerConfig)
-	if kafkaReader == nil {
-		errMsg := "NewIngestKafka: failed to create kafka-go reader"
-		klog.Errorf("%s", errMsg)
-		return nil, errors.New(errMsg)
-	}
-
-	decoder, err := decode.GetDecoder(jsonIngestKafka.Decoder)
+	kafkaReader, bml, err := kafka.NewReader(config)
 	if err != nil {
 		return nil, err
 	}
 
-	bml := defaultKafkaBatchMaxLength
-	if jsonIngestKafka.BatchMaxLen != 0 {
-		bml = jsonIngestKafka.BatchMaxLen
+	decoder, err := decode.GetDecoder(config.Decoder)
+	if err != nil {
+		return nil, err
 	}
 
 	in := make(chan []byte, 2*bml)
 	metrics := newMetrics(opMetrics, params.Name, ingestType, func() int { return len(in) })
 
 	return &ingestKafka{
-		kafkaReader:      kafkaReader,
-		decoder:          decoder,
-		exitChan:         utils.ExitChannel(),
-		in:               in,
-		batchMaxLength:   bml,
-		batchReadTimeout: batchReadTimeout,
-		metrics:          metrics,
-		canLogMessages:   jsonIngestKafka.Decoder.Type == api.DecoderJSON,
+		kafkaReader:    kafkaReader,
+		decoder:        decoder,
+		exitChan:       utils.ExitChannel(),
+		in:             in,
+		metrics:        metrics,
+		canLogMessages: config.Decoder.Type == api.DecoderJSON,
 	}, nil
 }

--- a/pkg/pipeline/ingest/ingest_kafka_test.go
+++ b/pkg/pipeline/ingest/ingest_kafka_test.go
@@ -89,8 +89,6 @@ func Test_NewIngestKafka1(t *testing.T) {
 	require.Equal(t, expectedBrokers, ingestKafka.kafkaReader.Config().Brokers)
 	require.Equal(t, int64(-2), ingestKafka.kafkaReader.Config().StartOffset)
 	require.Equal(t, 2, len(ingestKafka.kafkaReader.Config().GroupBalancers))
-	require.Equal(t, int64(300), ingestKafka.batchReadTimeout)
-	require.Equal(t, int(500), ingestKafka.batchMaxLength)
 	require.Equal(t, time.Duration(500)*time.Millisecond, ingestKafka.kafkaReader.Config().CommitInterval)
 }
 
@@ -103,8 +101,6 @@ func Test_NewIngestKafka2(t *testing.T) {
 	require.Equal(t, expectedBrokers, ingestKafka.kafkaReader.Config().Brokers)
 	require.Equal(t, int64(-1), ingestKafka.kafkaReader.Config().StartOffset)
 	require.Equal(t, 1, len(ingestKafka.kafkaReader.Config().GroupBalancers))
-	require.Equal(t, defaultBatchReadTimeout, ingestKafka.batchReadTimeout)
-	require.Equal(t, int(1000), ingestKafka.batchMaxLength)
 	require.Equal(t, time.Duration(1000)*time.Millisecond, ingestKafka.kafkaReader.Config().CommitInterval)
 }
 

--- a/pkg/pipeline/transform/kubernetes/datasource/datasource.go
+++ b/pkg/pipeline/transform/kubernetes/datasource/datasource.go
@@ -1,0 +1,28 @@
+package datasource
+
+import (
+	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/cni"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/informers"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/model"
+)
+
+type Datasource struct {
+	Informers informers.InformersInterface
+}
+
+func NewInformerDatasource(kubeconfig string, infConfig informers.Config, opMetrics *operational.Metrics) (*Datasource, error) {
+	inf := &informers.Informers{}
+	if err := inf.InitFromConfig(kubeconfig, infConfig, opMetrics); err != nil {
+		return nil, err
+	}
+	return &Datasource{Informers: inf}, nil
+}
+
+func (d *Datasource) IndexLookup(potentialKeys []cni.SecondaryNetKey, ip string) *model.ResourceMetaData {
+	return d.Informers.IndexLookup(potentialKeys, ip)
+}
+
+func (d *Datasource) GetNodeByName(name string) (*model.ResourceMetaData, error) {
+	return d.Informers.GetNodeByName(name)
+}

--- a/pkg/pipeline/transform/kubernetes/informers/config.go
+++ b/pkg/pipeline/transform/kubernetes/informers/config.go
@@ -1,0 +1,59 @@
+package informers
+
+import (
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/cni"
+)
+
+var (
+	cniPlugins = map[string]cni.Plugin{
+		api.OVN: &cni.OVNPlugin{},
+	}
+	multus = cni.MultusHandler{}
+	udn    = cni.UDNHandler{}
+)
+
+type Config struct {
+	managedCNI        []string
+	secondaryNetworks []api.SecondaryNetwork
+	hasMultus         bool
+	hasUDN            bool
+}
+
+func NewConfig(cfg api.NetworkTransformKubeConfig) Config {
+	c := Config{
+		managedCNI:        cfg.ManagedCNI,
+		secondaryNetworks: cfg.SecondaryNetworks,
+	}
+	if c.managedCNI == nil {
+		c.managedCNI = []string{api.OVN}
+	}
+	c.secondaryNetworks = cfg.SecondaryNetworks
+	for _, netConfig := range cfg.SecondaryNetworks {
+		for index := range netConfig.Index {
+			if multus.Manages(index) {
+				c.hasMultus = true
+			}
+			if udn.Manages(index) {
+				c.hasUDN = true
+			}
+		}
+	}
+	return c
+}
+
+func (k *Config) BuildSecondaryNetworkKeys(flow config.GenericMap, rule *api.K8sRule) []cni.SecondaryNetKey {
+	return buildSecondaryNetworkKeys(flow, rule, k.secondaryNetworks, k.hasMultus, k.hasUDN)
+}
+
+func buildSecondaryNetworkKeys(flow config.GenericMap, rule *api.K8sRule, secNet []api.SecondaryNetwork, hasMultus, hasUDN bool) []cni.SecondaryNetKey {
+	var keys []cni.SecondaryNetKey
+	if hasMultus {
+		keys = append(keys, multus.BuildKeys(flow, rule, secNet)...)
+	}
+	if hasUDN {
+		keys = append(keys, udn.BuildKeys(flow, rule)...)
+	}
+	return keys
+}

--- a/pkg/pipeline/transform/kubernetes/informers/informers-mock.go
+++ b/pkg/pipeline/transform/kubernetes/informers/informers-mock.go
@@ -4,9 +4,9 @@ import (
 	"errors"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
-	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/cni"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/model"
 	"github.com/stretchr/testify/mock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -32,18 +32,19 @@ type Mock struct {
 
 func NewInformersMock() *Mock {
 	inf := new(Mock)
-	inf.On("InitFromConfig", mock.Anything, mock.Anything).Return(nil)
+	inf.On("InitFromConfig", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	return inf
 }
 
-func (o *Mock) InitFromConfig(cfg api.NetworkTransformKubeConfig, opMetrics *operational.Metrics) error {
-	args := o.Called(cfg, opMetrics)
+func (o *Mock) InitFromConfig(kubeconfig string, infConfig Config, opMetrics *operational.Metrics) error {
+	args := o.Called(kubeconfig, infConfig, opMetrics)
 	return args.Error(0)
 }
 
 type IndexerMock struct {
 	mock.Mock
 	cache.Indexer
+	parentChecker func(*model.ResourceMetaData)
 }
 
 type InformerMock struct {
@@ -72,62 +73,64 @@ func (m *InformerMock) GetIndexer() cache.Indexer {
 	return args.Get(0).(cache.Indexer)
 }
 
-func (m *IndexerMock) MockPod(ip, mac, intf, name, namespace, nodeIP string, owner *Owner) {
-	var ownerRef []metav1.OwnerReference
-	if owner != nil {
-		ownerRef = []metav1.OwnerReference{{
-			Kind: owner.Type,
-			Name: owner.Name,
-		}}
-	}
-	info := Info{
-		Type: "Pod",
+func (m *IndexerMock) MockPod(ip, mac, intf, name, namespace, nodeIP, ownerName, ownerKind string) {
+	res := model.ResourceMetaData{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            name,
-			Namespace:       namespace,
-			OwnerReferences: ownerRef,
+			Name:      name,
+			Namespace: namespace,
 		},
-		HostIP:           nodeIP,
-		ips:              []string{},
-		secondaryNetKeys: []string{},
+		Kind:      "Pod",
+		OwnerName: ownerName,
+		OwnerKind: ownerKind,
+		HostIP:    nodeIP,
 	}
+	m.parentChecker(&res)
 	if len(mac) > 0 {
 		nsi := cni.NetStatItem{
 			Interface: intf,
 			MAC:       mac,
 			IPs:       []string{ip},
 		}
-		info.secondaryNetKeys = nsi.Keys(secondaryNetConfig[0])
-		m.On("ByIndex", IndexCustom, info.secondaryNetKeys[0]).Return([]interface{}{&info}, nil)
+		res.SecondaryNetKeys = nsi.Keys(secondaryNetConfig[0])
+		m.On("ByIndex", IndexCustom, res.SecondaryNetKeys[0]).Return([]interface{}{&res}, nil)
 	}
 	if len(ip) > 0 {
-		info.ips = []string{ip}
-		m.On("ByIndex", IndexIP, ip).Return([]interface{}{&info}, nil)
+		res.IPs = []string{ip}
+		m.On("ByIndex", IndexIP, ip).Return([]interface{}{&res}, nil)
 	}
 }
 
 func (m *IndexerMock) MockNode(ip, name string) {
-	m.On("ByIndex", IndexIP, ip).Return([]interface{}{&Info{
-		Type:       "Node",
-		ObjectMeta: metav1.ObjectMeta{Name: name},
-		ips:        []string{ip},
+	m.On("ByIndex", IndexIP, ip).Return([]interface{}{&model.ResourceMetaData{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Kind:      "Node",
+		OwnerKind: "Node",
+		OwnerName: name,
+		IPs:       []string{ip},
 	}}, nil)
 }
 
 func (m *IndexerMock) MockService(ip, name, namespace string) {
-	m.On("ByIndex", IndexIP, ip).Return([]interface{}{&Info{
-		Type:       "Service",
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		ips:        []string{ip},
+	m.On("ByIndex", IndexIP, ip).Return([]interface{}{&model.ResourceMetaData{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Kind:      "Service",
+		OwnerKind: "Service",
+		OwnerName: name,
+		IPs:       []string{ip},
 	}}, nil)
 }
 
-func (m *IndexerMock) MockReplicaSet(name, namespace string, owner Owner) {
+func (m *IndexerMock) MockReplicaSet(name, namespace, ownerName, ownerKind string) {
 	m.On("GetByKey", namespace+"/"+name).Return(&metav1.ObjectMeta{
 		Name: name,
 		OwnerReferences: []metav1.OwnerReference{{
-			Kind: owner.Type,
-			Name: owner.Name,
+			Kind: ownerKind,
+			Name: ownerName,
 		}},
 	}, true, nil)
 }
@@ -138,7 +141,7 @@ func (m *IndexerMock) FallbackNotFound() {
 
 func SetupIndexerMocks(kd *Informers) (pods, nodes, svc, rs *IndexerMock) {
 	// pods informer
-	pods = &IndexerMock{}
+	pods = &IndexerMock{parentChecker: kd.checkParent}
 	pim := InformerMock{}
 	pim.On("GetIndexer").Return(pods)
 	kd.pods = &pim
@@ -162,43 +165,40 @@ func SetupIndexerMocks(kd *Informers) (pods, nodes, svc, rs *IndexerMock) {
 
 type FakeInformers struct {
 	InformersInterface
-	ipInfo         map[string]*Info
-	customKeysInfo map[string]*Info
-	nodes          map[string]*Info
+	ipInfo         map[string]*model.ResourceMetaData
+	customKeysInfo map[string]*model.ResourceMetaData
+	nodes          map[string]*model.ResourceMetaData
 }
 
-func SetupStubs(ipInfo map[string]*Info, customKeysInfo map[string]*Info, nodes map[string]*Info) *FakeInformers {
-	return &FakeInformers{
+func SetupStubs(ipInfo, customKeysInfo, nodes map[string]*model.ResourceMetaData) (Config, *FakeInformers) {
+	cfg := NewConfig(api.NetworkTransformKubeConfig{SecondaryNetworks: secondaryNetConfig})
+	return cfg, &FakeInformers{
 		ipInfo:         ipInfo,
 		customKeysInfo: customKeysInfo,
 		nodes:          nodes,
 	}
 }
 
-func (f *FakeInformers) InitFromConfig(_ api.NetworkTransformKubeConfig, _ *operational.Metrics) error {
+func (f *FakeInformers) InitFromConfig(_ string, _ Config, _ *operational.Metrics) error {
 	return nil
 }
 
-func (f *FakeInformers) GetInfo(keys []cni.SecondaryNetKey, ip string) (*Info, error) {
+func (f *FakeInformers) IndexLookup(keys []cni.SecondaryNetKey, ip string) *model.ResourceMetaData {
 	for _, key := range keys {
 		i := f.customKeysInfo[key.Key]
 		if i != nil {
-			return i, nil
+			return i
 		}
 	}
 
 	i := f.ipInfo[ip]
 	if i != nil {
-		return i, nil
+		return i
 	}
-	return nil, errors.New("notFound")
+	return nil
 }
 
-func (f *FakeInformers) BuildSecondaryNetworkKeys(flow config.GenericMap, rule *api.K8sRule) []cni.SecondaryNetKey {
-	return buildSecondaryNetworkKeys(flow, rule, secondaryNetConfig, true, true)
-}
-
-func (f *FakeInformers) GetNodeInfo(n string) (*Info, error) {
+func (f *FakeInformers) GetNodeByName(n string) (*model.ResourceMetaData, error) {
 	i := f.nodes[n]
 	if i != nil {
 		return i, nil

--- a/pkg/pipeline/transform/kubernetes/model/model.go
+++ b/pkg/pipeline/transform/kubernetes/model/model.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	KindNode    = "Node"
+	KindPod     = "Pod"
+	KindService = "Service"
+)
+
+// ResourceMetaData contains precollected metadata for Pods, Nodes and Services.
+// Not all the fields are populated for all the above types. To save
+// memory, we just keep in memory the necessary data for each Type.
+// For more information about which fields are set for each type, please
+// refer to the instantiation function of the respective informers.
+type ResourceMetaData struct {
+	// Informers need that internal object is an ObjectMeta instance
+	metav1.ObjectMeta
+	Kind             string
+	OwnerName        string
+	OwnerKind        string
+	HostName         string
+	HostIP           string
+	NetworkName      string
+	IPs              []string
+	SecondaryNetKeys []string
+}

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -214,7 +214,7 @@ func NewTransformNetwork(params config.StageParam, opMetrics *operational.Metric
 	}
 
 	if needToInitKubeData {
-		err := kubernetes.InitFromConfig(jsonNetworkTransform.KubeConfig, opMetrics)
+		err := kubernetes.InitInformerDatasource(jsonNetworkTransform.KubeConfig, opMetrics)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

Related: https://github.com/netobserv/flowlogs-pipeline/pull/681

This is a preliminary work preparing the ground for NETOBSERV-1248. No functional change here.
The goal is to minimize rebase hassle in #681

    Details:
    - Kafka read/write logic extracted from ingest/encode pipelines and put
      into a dedicated kafka package
    - New k8s "datasource" struct for k8s enrichment - currently only has
      the usual informers datasource, but later will include a kafka-based
    datasource as well
    - Config related to k8s datasource moved into its own package. It
      includes the SecondaryNetwork config.
    - Some minor variables/functions renaming


## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [x] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
