### PR TITLE
NetFlow/IPFIX: render sampler address as string

### DIFF
--- a/pkg/pipeline/ingest/ingest_collector.go
+++ b/pkg/pipeline/ingest/ingest_collector.go
@@ -70,6 +70,7 @@ func RenderMessage(message *goflowpb.FlowMessage) (map[string]interface{}, error
 	}
 	outputMap["DstAddr"] = goflowCommonFormat.RenderIP(message.DstAddr)
 	outputMap["SrcAddr"] = goflowCommonFormat.RenderIP(message.SrcAddr)
+	outputMap["SamplerAddress"] = goflowCommonFormat.RenderIP(message.SamplerAddress)
 	outputMap["DstMac"] = renderMac(message.DstMac)
 	outputMap["SrcMac"] = renderMac(message.SrcMac)
 	return outputMap, nil

--- a/pkg/pipeline/ingest/ingest_collector_test.go
+++ b/pkg/pipeline/ingest/ingest_collector_test.go
@@ -53,6 +53,7 @@ func TestIngest(t *testing.T) {
 	assert.EqualValues(t, 12345678, flow["TimeFlowStart"])
 	assert.EqualValues(t, 12345678, flow["TimeFlowEnd"])
 	assert.Equal(t, "1.2.3.4", flow["SrcAddr"])
+	assert.Equal(t, "127.0.0.1", flow["SamplerAddress"])
 }
 
 // The IPFIX client might send information before the Ingester is actually listening,


### PR DESCRIPTION
Fixes https://github.com/netobserv/flowlogs-pipeline/issues/940

cc @Nachtfalkeaw