### PR TITLE
NETOBSERV-2254: Disambiguate cluster udn and namespaced udn

### DIFF
--- a/pkg/pipeline/transform/kubernetes/cni/udn.go
+++ b/pkg/pipeline/transform/kubernetes/cni/udn.go
@@ -1,13 +1,19 @@
 package cni
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 )
 
 const (
@@ -58,7 +64,7 @@ func (m *UDNHandler) BuildKeys(flow config.GenericMap, rule *api.K8sRule) []Seco
 	return keys
 }
 
-func (m *UDNHandler) GetPodUniqueKeys(pod *v1.Pod) ([]string, error) {
+func (m *UDNHandler) GetPodUniqueKeys(ctx context.Context, dynClient *dynamic.DynamicClient, pod *v1.Pod) ([]string, error) {
 	// Example:
 	// k8s.ovn.org/pod-networks: '{"default":{"ip_addresses":["10.128.2.20/23"],"mac_address":"0a:58:0a:80:02:14","routes":[{"dest":"10.128.0.0/14","nextHop":"10.128.2.1"},{"dest":"100.64.0.0/16","nextHop":"10.128.2.1"}],"ip_address":"10.128.2.20/23","role":"infrastructure-locked"},"mesh-arena/primary-udn":{"ip_addresses":["10.200.200.12/24"],"mac_address":"0a:58:0a:c8:c8:0c","gateway_ips":["10.200.200.1"],"routes":[{"dest":"172.30.0.0/16","nextHop":"10.200.200.1"},{"dest":"100.65.0.0/16","nextHop":"10.200.200.1"}],"ip_address":"10.200.200.12/24","gateway_ip":"10.200.200.1","tunnel_id":16,"role":"primary"}}'
 	if statusAnnotationJSON, ok := pod.Annotations[ovnAnnotation]; ok {
@@ -74,6 +80,9 @@ func (m *UDNHandler) GetPodUniqueKeys(pod *v1.Pod) ([]string, error) {
 						// IP has a CIDR prefix (bug??)
 						parts := strings.SplitN(ip, "/", 2)
 						if len(parts) > 0 {
+							if dynClient != nil {
+								label = disambiguateClusterUDN(ctx, dynClient, label)
+							}
 							key := UDNKey(label, parts[0])
 							keys = append(keys, key.Key)
 						}
@@ -85,4 +94,45 @@ func (m *UDNHandler) GetPodUniqueKeys(pod *v1.Pod) ([]string, error) {
 	}
 	// Annotation not present => just ignore, no error
 	return nil, nil
+}
+
+func disambiguateClusterUDN(ctx context.Context, dynClient *dynamic.DynamicClient, name string) string {
+	// "name" can look like this: "my-namespace/my-udn"; namespace included even for Cluster UDN
+	parts := strings.SplitN(name, "/", 2)
+	if len(parts) < 2 {
+		// no disambiguation
+		return name
+	}
+	ns := parts[0]
+	udnName := parts[1]
+	// Does it exist as a namespaced-udn?
+	_, err := dynClient.
+		Resource(schema.GroupVersionResource{
+			Group:    "k8s.ovn.org",
+			Resource: "userdefinednetworks",
+			Version:  "v1",
+		}).
+		Namespace(ns).
+		Get(ctx, udnName, metav1.GetOptions{})
+	if err == nil {
+		// found => return as is
+		return name
+	} else if !errors.IsNotFound(err) {
+		log.Errorf("could not fetch UDN %s: %v", name, err)
+	}
+	// Does it exist as a cluster-udn?
+	_, err = dynClient.
+		Resource(schema.GroupVersionResource{
+			Group:    "k8s.ovn.org",
+			Resource: "clusteruserdefinednetworks",
+			Version:  "v1",
+		}).
+		Get(ctx, udnName, metav1.GetOptions{})
+	if err == nil {
+		// found => return just the udn name part
+		return udnName
+	} else if !errors.IsNotFound(err) {
+		log.Errorf("could not fetch CUDN %s: %v", udnName, err)
+	}
+	return name
 }

--- a/pkg/pipeline/transform/kubernetes/cni/udn_test.go
+++ b/pkg/pipeline/transform/kubernetes/cni/udn_test.go
@@ -1,6 +1,7 @@
 package cni
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -29,7 +30,7 @@ func udnConfigAnnotation(ip string) string {
 
 func TestExtractUDNStatusKeys(t *testing.T) {
 	// Annotation not found => no error, no key
-	keys, err := udnHandler.GetPodUniqueKeys(&udnPod)
+	keys, err := udnHandler.GetPodUniqueKeys(context.TODO(), nil, &udnPod)
 	require.NoError(t, err)
 	require.Empty(t, keys)
 
@@ -37,7 +38,7 @@ func TestExtractUDNStatusKeys(t *testing.T) {
 	udnPod.Annotations = map[string]string{
 		ovnAnnotation: udnConfigAnnotation("10.200.200.12"),
 	}
-	keys, err = udnHandler.GetPodUniqueKeys(&udnPod)
+	keys, err = udnHandler.GetPodUniqueKeys(context.TODO(), nil, &udnPod)
 	require.NoError(t, err)
 	require.Equal(t, []string{"mesh-arena/primary-udn~10.200.200.12"}, keys)
 
@@ -45,7 +46,7 @@ func TestExtractUDNStatusKeys(t *testing.T) {
 	udnPod.Annotations = map[string]string{
 		ovnAnnotation: udnConfigAnnotation("10.200.200.12/24"),
 	}
-	keys, err = udnHandler.GetPodUniqueKeys(&udnPod)
+	keys, err = udnHandler.GetPodUniqueKeys(context.TODO(), nil, &udnPod)
 	require.NoError(t, err)
 	require.Equal(t, []string{"mesh-arena/primary-udn~10.200.200.12"}, keys)
 
@@ -53,7 +54,7 @@ func TestExtractUDNStatusKeys(t *testing.T) {
 	udnPod.Annotations = map[string]string{
 		ovnAnnotation: udnConfigAnnotation("2001:0db8::1111"),
 	}
-	keys, err = udnHandler.GetPodUniqueKeys(&udnPod)
+	keys, err = udnHandler.GetPodUniqueKeys(context.TODO(), nil, &udnPod)
 	require.NoError(t, err)
 	require.Equal(t, []string{"mesh-arena/primary-udn~2001:0db8::1111"}, keys)
 
@@ -61,7 +62,7 @@ func TestExtractUDNStatusKeys(t *testing.T) {
 	udnPod.Annotations = map[string]string{
 		ovnAnnotation: udnConfigAnnotation("2001:0db8::1111/24"),
 	}
-	keys, err = udnHandler.GetPodUniqueKeys(&udnPod)
+	keys, err = udnHandler.GetPodUniqueKeys(context.TODO(), nil, &udnPod)
 	require.NoError(t, err)
 	require.Equal(t, []string{"mesh-arena/primary-udn~2001:0db8::1111"}, keys)
 }


### PR DESCRIPTION
## Description

When pod annotations are processed to get the UDN info, check whether it's a known cluster/namespace UDN; if cluster, we drop the namespace part that OVN writes in the annotation.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
Operator: https://github.com/netobserv/network-observability-operator/pull/1508

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
