### PR TITLE
Optimizations on prom-encode and loki-write

### DIFF
--- a/pkg/pipeline/encode/encode_prom.go
+++ b/pkg/pipeline/encode/encode_prom.go
@@ -98,7 +98,8 @@ func (e *EncodeProm) ProcessAggHist(m interface{}, labels map[string]string, val
 	return nil
 }
 
-func (e *EncodeProm) GetChacheEntry(entryLabels map[string]string, m interface{}) interface{} {
+func (e *EncodeProm) GetCacheEntry(entryLabels map[string]string, m interface{}) interface{} {
+	// In prom_encode, the metrics cache just contains cleanup callbacks
 	switch mv := m.(type) {
 	case *prometheus.CounterVec:
 		return func() { mv.Delete(entryLabels) }

--- a/pkg/pipeline/encode/opentelemetry/encode_otlpmetrics.go
+++ b/pkg/pipeline/encode/opentelemetry/encode_otlpmetrics.go
@@ -90,7 +90,7 @@ func (e *EncodeOtlpMetrics) ProcessAggHist(m interface{}, labels map[string]stri
 	return nil
 }
 
-func (e *EncodeOtlpMetrics) GetChacheEntry(entryLabels map[string]string, _ interface{}) interface{} {
+func (e *EncodeOtlpMetrics) GetCacheEntry(entryLabels map[string]string, _ interface{}) interface{} {
 	return entryLabels
 }
 

--- a/pkg/pipeline/extract/aggregate/aggregate.go
+++ b/pkg/pipeline/extract/aggregate/aggregate.go
@@ -140,7 +140,9 @@ func (aggregate *Aggregate) UpdateByEntry(entry config.GenericMap, normalizedVal
 	} else {
 		groupState = oldEntry.(*GroupState)
 	}
-	aggregate.cache.UpdateCacheEntry(string(normalizedValues), groupState)
+	aggregate.cache.UpdateCacheEntry(string(normalizedValues), func() interface{} {
+		return groupState
+	})
 
 	// update value
 	operationKey := aggregate.definition.OperationKey

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -130,7 +130,7 @@ func (n *Network) Transform(inputEntry config.GenericMap) (config.GenericMap, bo
 					lbl, ok := n.ipLabelCache.GetCacheEntry(strIP)
 					if !ok {
 						lbl = n.applySubnetLabel(strIP)
-						n.ipLabelCache.UpdateCacheEntry(strIP, lbl)
+						n.ipLabelCache.UpdateCacheEntry(strIP, func() interface{} { return lbl })
 					}
 					if lbl != "" {
 						outputEntry[rule.AddSubnetLabel.Output] = lbl

--- a/pkg/pipeline/utils/timed_cache.go
+++ b/pkg/pipeline/utils/timed_cache.go
@@ -65,9 +65,9 @@ func (tc *TimedCache) GetCacheEntry(key string) (interface{}, bool) {
 
 var uclog = log.WithField("method", "UpdateCacheEntry")
 
-// If cache entry exists, update it and return it; if it does not exist, create it if there is room.
+// If cache entry exists, update its timestamp; if it does not exist, create it if there is room.
 // If we exceed the size of the cache, then do not allocate new entry
-func (tc *TimedCache) UpdateCacheEntry(key string, entry interface{}) bool {
+func (tc *TimedCache) UpdateCacheEntry(key string, entryProvider func() interface{}) bool {
 	nowInSecs := time.Now()
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
@@ -85,7 +85,7 @@ func (tc *TimedCache) UpdateCacheEntry(key string, entry interface{}) bool {
 		cEntry = &cacheEntry{
 			lastUpdatedTime: nowInSecs,
 			key:             key,
-			SourceEntry:     entry,
+			SourceEntry:     entryProvider(),
 		}
 		uclog.Tracef("adding entry: %#v", cEntry)
 		// place at end of list

--- a/pkg/pipeline/write/write_loki_test.go
+++ b/pkg/pipeline/write/write_loki_test.go
@@ -289,7 +289,7 @@ parameters:
 	loki.client = &fe
 
 	require.NoError(t, loki.ProcessRecord(map[string]interface{}{
-		"ba/z": "isBaz", "fo.o": "isFoo", "ba-r": "isBar", "ignored?": "yes!"}))
+		"ba/z": "isBaz", "fo.o": "isFoo", "ba-r": "isBar", "ignored?": "yes!", "md": "md"}))
 
 	fe.AssertCalled(t, "Handle", model.LabelSet{
 		"ba_r": "isBar",
@@ -336,6 +336,7 @@ func buildFlow(t time.Time) config.GenericMap {
 		"bytes":     rand.Intn(100),
 		"packets":   rand.Intn(10),
 		"latency":   rand.Float64(),
+		"toIgnore":  "--",
 	}
 }
 
@@ -359,9 +360,10 @@ func BenchmarkWriteLoki(b *testing.B) {
 		StaticLabels: model.LabelSet{
 			"app": "flp-benchmark",
 		},
-		Labels:         []string{"srcIP", "dstIP"},
+		Labels:         []string{"srcIP", "dstIP", "toIgnore"},
 		TimestampLabel: "timestamp",
 		TimestampScale: "1ms",
+		IgnoreList:     []string{"toIgnore"},
 	}
 
 	loki, err := NewWriteLoki(operational.NewMetrics(&config.MetricsSettings{}), config.StageParam{Write: &config.Write{Loki: &params}})


### PR DESCRIPTION
- Pre-allocate slices/maps to avoid dynamic reallocations
- In loki write, split labels/lines in 1 pass rather than copying everything then deleting labels from lines.
