### PR TITLE
NETOBSERV-2285: opt: use uint64 hash instead of string for cache key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/netobserv/gopipes v0.3.0
 	github.com/netobserv/loki-client-go v0.0.0-20250425113517-526b43e51847
-	github.com/netobserv/netobserv-ebpf-agent v1.9.0-crc0.0.20250528064221-6f34e5b85d2c
+	github.com/netobserv/netobserv-ebpf-agent v1.9.0-crc0.0.20250610144135-d64c5d99f2da
 	github.com/netsampler/goflow2 v1.3.7
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ github.com/netobserv/gopipes v0.3.0 h1:IYmPnnAVCdSK7VmHmpFhrVBOEm45qpgbZmJz1sSW+
 github.com/netobserv/gopipes v0.3.0/go.mod h1:N7/Gz05EOF0CQQSKWsv3eof22Cj2PB08Pbttw98YFYU=
 github.com/netobserv/loki-client-go v0.0.0-20250425113517-526b43e51847 h1:hjzhVZSSKIOmAzHbGUV4JhVIPkgKs/UtrWDx6JSVKMw=
 github.com/netobserv/loki-client-go v0.0.0-20250425113517-526b43e51847/go.mod h1:Zb/jtD3Lnu88Poo+jnhTASzxYnvncmHOoZaT93xQjJ8=
-github.com/netobserv/netobserv-ebpf-agent v1.9.0-crc0.0.20250528064221-6f34e5b85d2c h1:HhObTHfakq06NAPkljppnT1UT9MV2o5obH2dPD0jxmk=
-github.com/netobserv/netobserv-ebpf-agent v1.9.0-crc0.0.20250528064221-6f34e5b85d2c/go.mod h1:sqvri+RCx8QefV2g+pbJktbNuO3ebB1TE1Zl7M2qqDo=
+github.com/netobserv/netobserv-ebpf-agent v1.9.0-crc0.0.20250610144135-d64c5d99f2da h1:fahbLlD/5BidF+7rcvydhro3Tu0pY81OUGOkxmaY07A=
+github.com/netobserv/netobserv-ebpf-agent v1.9.0-crc0.0.20250610144135-d64c5d99f2da/go.mod h1:IfxvtBeSfhJaCO/7ie3R7mna+j8sAer2vqtbwaBTlzA=
 github.com/netsampler/goflow2 v1.3.7 h1:XZaTy8kkMnGXpJ9hS3KbO1McyrFTpVNhVFEx9rNhMmc=
 github.com/netsampler/goflow2 v1.3.7/go.mod h1:4UZsVGVAs//iMCptUHn3WNScztJeUhZH7kDW2+/vDdQ=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=

--- a/pkg/pipeline/encode/encode_prom.go
+++ b/pkg/pipeline/encode/encode_prom.go
@@ -66,7 +66,7 @@ func (e *EncodeProm) ProcessCounter(m interface{}, labels map[string]string, val
 	return nil
 }
 
-func (e *EncodeProm) ProcessGauge(m interface{}, labels map[string]string, value float64, _ string) error {
+func (e *EncodeProm) ProcessGauge(m interface{}, _ string, labels map[string]string, value float64, _ []string) error {
 	gauge := m.(*prometheus.GaugeVec)
 	mm, err := gauge.GetMetricWith(labels)
 	if err != nil {

--- a/pkg/pipeline/encode/encode_prom_test.go
+++ b/pkg/pipeline/encode/encode_prom_test.go
@@ -819,14 +819,6 @@ func buildFlow() config.GenericMap {
 	}
 }
 
-func thousandsFlows() []config.GenericMap {
-	flows := make([]config.GenericMap, 1000)
-	for i := 0; i < 1000; i++ {
-		flows[i] = buildFlow()
-	}
-	return flows
-}
-
 func BenchmarkPromEncode(b *testing.B) {
 	var expiryTimeDuration api.Duration
 	expiryTimeDuration.Duration = time.Duration(60 * time.Second)
@@ -869,9 +861,8 @@ func BenchmarkPromEncode(b *testing.B) {
 	require.NoError(b, err)
 
 	for i := 0; i < b.N; i++ {
-		for _, metric := range thousandsFlows() {
-			prom.Encode(metric)
-		}
+		m := buildFlow()
+		prom.Encode(m)
 	}
 }
 

--- a/pkg/pipeline/encode/opentelemetry/encode_otlpmetrics.go
+++ b/pkg/pipeline/encode/opentelemetry/encode_otlpmetrics.go
@@ -19,6 +19,7 @@ package opentelemetry
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
@@ -64,10 +65,22 @@ func (e *EncodeOtlpMetrics) ProcessCounter(m interface{}, labels map[string]stri
 	return nil
 }
 
-func (e *EncodeOtlpMetrics) ProcessGauge(m interface{}, labels map[string]string, value float64, key string) error {
+func createKey(name string, keys []string) string {
+	key := strings.Builder{}
+	key.WriteString(name)
+	key.WriteRune('|')
+	for _, k := range keys {
+		key.WriteString(k)
+		key.WriteRune('|')
+	}
+	return key.String()
+}
+
+func (e *EncodeOtlpMetrics) ProcessGauge(m interface{}, name string, labels map[string]string, value float64, lvs []string) error {
 	obs := m.(Float64Gauge)
 	// set attributes using the labels
 	attributes := obtainAttributesFromLabels(labels)
+	key := createKey(name, lvs)
 	obs.Set(key, value, attributes)
 	return nil
 }

--- a/pkg/pipeline/extract/aggregate/aggregate.go
+++ b/pkg/pipeline/extract/aggregate/aggregate.go
@@ -43,7 +43,7 @@ const (
 )
 
 type Labels map[string]string
-type NormalizedValues string
+type NormalizedValues []string
 
 type Aggregate struct {
 	definition *api.AggregateDefinition
@@ -78,7 +78,7 @@ func (aggregate *Aggregate) LabelsFromEntry(entry config.GenericMap) (Labels, bo
 }
 
 func (labels Labels) getNormalizedValues() NormalizedValues {
-	var normalizedAsString string
+	var normalized NormalizedValues
 
 	keys := make([]string, 0, len(labels))
 	for k := range labels {
@@ -87,20 +87,16 @@ func (labels Labels) getNormalizedValues() NormalizedValues {
 	sort.Strings(keys)
 
 	for _, k := range keys {
-		normalizedAsString += labels[k] + ","
+		normalized = append(normalized, labels[k])
 	}
 
-	if len(normalizedAsString) > 0 {
-		normalizedAsString = normalizedAsString[:len(normalizedAsString)-1]
-	}
-
-	return NormalizedValues(normalizedAsString)
+	return normalized
 }
 
 func (aggregate *Aggregate) filterEntry(entry config.GenericMap) (NormalizedValues, Labels, error) {
 	labels, allLabelsFound := aggregate.LabelsFromEntry(entry)
 	if !allLabelsFound {
-		return "", nil, fmt.Errorf("missing keys in entry")
+		return nil, nil, fmt.Errorf("missing keys in entry")
 	}
 
 	normalizedValues := labels.getNormalizedValues()
@@ -128,7 +124,7 @@ func (aggregate *Aggregate) UpdateByEntry(entry config.GenericMap, normalizedVal
 	defer aggregate.mutex.Unlock()
 
 	var groupState *GroupState
-	oldEntry, ok := aggregate.cache.GetCacheEntry(string(normalizedValues))
+	oldEntry, ok := aggregate.cache.GetCacheEntry(normalizedValues)
 	if !ok {
 		groupState = &GroupState{normalizedValues: normalizedValues, labels: labels}
 		initVal := getInitValue(string(aggregate.definition.OperationType))
@@ -140,7 +136,7 @@ func (aggregate *Aggregate) UpdateByEntry(entry config.GenericMap, normalizedVal
 	} else {
 		groupState = oldEntry.(*GroupState)
 	}
-	aggregate.cache.UpdateCacheEntry(string(normalizedValues), func() interface{} {
+	aggregate.cache.UpdateCacheEntry(normalizedValues, func() interface{} {
 		return groupState
 	})
 
@@ -212,20 +208,21 @@ func (aggregate *Aggregate) GetMetrics() []config.GenericMap {
 	var metrics []config.GenericMap
 
 	// iterate over the items in the cache
-	aggregate.cache.Iterate(func(_ string, value interface{}) {
+	aggregate.cache.Iterate(func(_ uint64, value interface{}) {
 		group := value.(*GroupState)
+		nv := strings.Join(group.normalizedValues, ",")
 		newEntry := config.GenericMap{
 			"name":              aggregate.definition.Name,
 			"operation_type":    aggregate.definition.OperationType,
 			"operation_key":     aggregate.definition.OperationKey,
 			"by":                strings.Join(aggregate.definition.GroupByKeys, ","),
-			"aggregate":         string(group.normalizedValues),
+			"aggregate":         nv,
 			"total_value":       group.totalValue,
 			"total_count":       group.totalCount,
 			"recent_raw_values": group.recentRawValues,
 			"recent_op_value":   group.recentOpValue,
 			"recent_count":      group.recentCount,
-			strings.Join(aggregate.definition.GroupByKeys, "_"): string(group.normalizedValues),
+			strings.Join(aggregate.definition.GroupByKeys, "_"): nv,
 		}
 		// add the items in aggregate.definition.GroupByKeys individually to the entry
 		for _, key := range aggregate.definition.GroupByKeys {

--- a/pkg/pipeline/extract/aggregate/aggregate_test.go
+++ b/pkg/pipeline/extract/aggregate/aggregate_test.go
@@ -62,7 +62,7 @@ func getMockLabels(reverseOrder bool) Labels {
 }
 
 func Test_getNormalizedValues(t *testing.T) {
-	expectedLabels := NormalizedValues("20.0.0.2,10.0.0.1")
+	expectedLabels := NormalizedValues{"20.0.0.2", "10.0.0.1"}
 
 	labels := getMockLabels(false)
 
@@ -103,7 +103,7 @@ func Test_FilterEntry(t *testing.T) {
 	normalizedLabels, labels, err := aggregate.filterEntry(entry)
 	require.Equal(t, err, nil)
 	require.Equal(t, Labels{"srcIP": "10.0.0.1", "dstIP": "20.0.0.2"}, labels)
-	require.Equal(t, NormalizedValues("20.0.0.2,10.0.0.1"), normalizedLabels)
+	require.Equal(t, NormalizedValues{"20.0.0.2", "10.0.0.1"}, normalizedLabels)
 
 	entry = test.GetIngestMockEntry(true)
 
@@ -125,7 +125,7 @@ func Test_Evaluate(t *testing.T) {
 
 	require.Equal(t, nil, err)
 	require.Equal(t, 1, aggregate.cache.GetCacheLen())
-	cacheEntry, found := aggregate.cache.GetCacheEntry(string(normalizedValues))
+	cacheEntry, found := aggregate.cache.GetCacheEntry(normalizedValues)
 	gState := cacheEntry.(*GroupState)
 	require.Equal(t, true, found)
 	require.Equal(t, 2, gState.totalCount)

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -127,10 +127,11 @@ func (n *Network) Transform(inputEntry config.GenericMap) (config.GenericMap, bo
 			}
 			if anyIP, ok := outputEntry[rule.AddSubnetLabel.Input]; ok {
 				if strIP, ok := anyIP.(string); ok {
-					lbl, ok := n.ipLabelCache.GetCacheEntry(strIP)
+					keys := []string{strIP}
+					lbl, ok := n.ipLabelCache.GetCacheEntry(keys)
 					if !ok {
 						lbl = n.applySubnetLabel(strIP)
-						n.ipLabelCache.UpdateCacheEntry(strIP, func() interface{} { return lbl })
+						n.ipLabelCache.UpdateCacheEntry(keys, func() interface{} { return lbl })
 					}
 					if lbl != "" {
 						outputEntry[rule.AddSubnetLabel.Output] = lbl

--- a/pkg/pipeline/utils/fnv.go
+++ b/pkg/pipeline/utils/fnv.go
@@ -1,0 +1,44 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Borrowed from https://github.com/prometheus/client_golang/blob/7c924b7c82b5a61e1e7e2be165bff781700b5365/prometheus/fnv.go
+
+package utils
+
+// Inline and byte-free variant of hash/fnv's fnv64a.
+
+const (
+	offset64 = 14695981039346656037
+	prime64  = 1099511628211
+)
+
+// hashNew initializies a new fnv64a hash value.
+func hashNew() uint64 {
+	return offset64
+}
+
+// hashAdd adds a string to a fnv64a hash value, returning the updated hash.
+func hashAdd(h uint64, s string) uint64 {
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= prime64
+	}
+	return h
+}
+
+// hashAddByte adds a byte to a fnv64a hash value, returning the updated hash.
+func hashAddByte(h uint64, b byte) uint64 {
+	h ^= uint64(b)
+	h *= prime64
+	return h
+}

--- a/pkg/pipeline/utils/timed_cache.go
+++ b/pkg/pipeline/utils/timed_cache.go
@@ -35,13 +35,13 @@ var log = logrus.WithField("component", "utils.TimedCache")
 type CacheCallback func(entry interface{})
 
 type cacheEntry struct {
-	key             string
+	key             uint64
 	lastUpdatedTime time.Time
 	e               *list.Element
 	SourceEntry     interface{}
 }
 
-type TimedCacheMap map[string]*cacheEntry
+type TimedCacheMap map[uint64]*cacheEntry
 
 // If maxEntries is non-zero, this limits the number of entries in the cache to the number specified.
 // If maxEntries is zero, the cache has no size limit.
@@ -53,25 +53,36 @@ type TimedCache struct {
 	cacheLenMetric prometheus.Gauge
 }
 
-func (tc *TimedCache) GetCacheEntry(key string) (interface{}, bool) {
+var sep byte = '|'
+
+func computeHash(keys []string) uint64 {
+	h := hashNew()
+	for _, k := range keys {
+		h = hashAdd(h, k)
+		h = hashAddByte(h, sep)
+	}
+	return h
+}
+
+func (tc *TimedCache) GetCacheEntry(keys []string) (interface{}, bool) {
+	h := computeHash(keys)
 	tc.mu.RLock()
 	defer tc.mu.RUnlock()
-	cEntry, ok := tc.cacheMap[key]
+	cEntry, ok := tc.cacheMap[h]
 	if ok {
 		return cEntry.SourceEntry, ok
 	}
 	return nil, ok
 }
 
-var uclog = log.WithField("method", "UpdateCacheEntry")
-
 // If cache entry exists, update its timestamp; if it does not exist, create it if there is room.
 // If we exceed the size of the cache, then do not allocate new entry
-func (tc *TimedCache) UpdateCacheEntry(key string, entryProvider func() interface{}) bool {
+func (tc *TimedCache) UpdateCacheEntry(keys []string, entryProvider func() interface{}) bool {
 	nowInSecs := time.Now()
+	h := computeHash(keys)
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
-	cEntry, ok := tc.cacheMap[key]
+	cEntry, ok := tc.cacheMap[h]
 	if ok {
 		// item already exists in cache; update the element and move to end of list
 		cEntry.lastUpdatedTime = nowInSecs
@@ -84,13 +95,13 @@ func (tc *TimedCache) UpdateCacheEntry(key string, entryProvider func() interfac
 		}
 		cEntry = &cacheEntry{
 			lastUpdatedTime: nowInSecs,
-			key:             key,
+			key:             h,
 			SourceEntry:     entryProvider(),
 		}
-		uclog.Tracef("adding entry: %#v", cEntry)
+		log.Tracef("adding entry: %#v", cEntry)
 		// place at end of list
 		cEntry.e = tc.cacheList.PushBack(cEntry)
-		tc.cacheMap[key] = cEntry
+		tc.cacheMap[h] = cEntry
 		if tc.cacheLenMetric != nil {
 			tc.cacheLenMetric.Inc()
 		}
@@ -107,7 +118,7 @@ func (tc *TimedCache) GetCacheLen() int {
 // We expect that the function calling Iterate might make updates to the entries by calling UpdateCacheEntry()
 // We therefore cannot take the lock at this point since it will conflict with the call in UpdateCacheEntry()
 // TODO: If the callback needs to update the cache, then we need a method to perform it without taking the lock again.
-func (tc *TimedCache) Iterate(f func(key string, value interface{})) {
+func (tc *TimedCache) Iterate(f func(key uint64, value interface{})) {
 	tc.mu.RLock()
 	defer tc.mu.RUnlock()
 	for k, v := range tc.cacheMap {

--- a/vendor/github.com/netobserv/netobserv-ebpf-agent/pkg/model/packet_record.go
+++ b/vendor/github.com/netobserv/netobserv-ebpf-agent/pkg/model/packet_record.go
@@ -18,12 +18,12 @@ type PacketRecord struct {
 // NewPacketRecord contains packet bytes
 func NewPacketRecord(
 	stream []byte,
-	len uint32,
+	length uint32,
 	ts time.Time,
 ) *PacketRecord {
 	pr := PacketRecord{}
 	pr.Time = ts
-	pr.Stream = make([]byte, len)
+	pr.Stream = make([]byte, length)
 	pr.Stream = stream
 	return &pr
 }

--- a/vendor/github.com/netobserv/netobserv-ebpf-agent/pkg/model/record.go
+++ b/vendor/github.com/netobserv/netobserv-ebpf-agent/pkg/model/record.go
@@ -39,11 +39,11 @@ type Direction uint8
 // (same behavior as Go's net.IP type)
 type IPAddr [net.IPv6len]uint8
 
-type InterfaceNamer func(ifIndex int) string
+type InterfaceNamer func(ifIndex int, mac MacAddr) string
 
 var (
 	agentIP        net.IP
-	interfaceNamer InterfaceNamer = func(ifIndex int) string { return fmt.Sprintf("[namer unset] %d", ifIndex) }
+	interfaceNamer InterfaceNamer = func(ifIndex int, _ MacAddr) string { return fmt.Sprintf("[namer unset] %d", ifIndex) }
 )
 
 func SetGlobals(ip net.IP, ifaceNamer InterfaceNamer) {
@@ -89,13 +89,17 @@ func NewRecord(
 		TimeFlowEnd:   currentTime.Add(-endDelta),
 		AgentIP:       agentIP,
 	}
-	record.Interfaces = []IntfDirUdn{NewIntfDirUdn(interfaceNamer(int(metrics.IfIndexFirstSeen)),
+	lMAC := metrics.SrcMac
+	if metrics.DirectionFirstSeen == 0 {
+		lMAC = metrics.DstMac
+	}
+	record.Interfaces = []IntfDirUdn{NewIntfDirUdn(interfaceNamer(int(metrics.IfIndexFirstSeen), lMAC),
 		int(metrics.DirectionFirstSeen),
 		udnsCache)}
 
 	for i := uint8(0); i < record.Metrics.NbObservedIntf; i++ {
 		record.Interfaces = append(record.Interfaces, NewIntfDirUdn(
-			interfaceNamer(int(metrics.ObservedIntf[i])),
+			interfaceNamer(int(metrics.ObservedIntf[i]), lMAC),
 			int(metrics.ObservedDirection[i]),
 			udnsCache,
 		))
@@ -185,7 +189,8 @@ func (ia *IPAddr) MarshalJSON() ([]byte, error) {
 }
 
 func (m *MacAddr) String() string {
-	return fmt.Sprintf("%02X:%02X:%02X:%02X:%02X:%02X", m[0], m[1], m[2], m[3], m[4], m[5])
+	t := net.HardwareAddr(m[:])
+	return t.String()
 }
 
 func (m *MacAddr) MarshalJSON() ([]byte, error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -317,7 +317,7 @@ github.com/netobserv/loki-client-go/pkg/labelutil
 github.com/netobserv/loki-client-go/pkg/logproto
 github.com/netobserv/loki-client-go/pkg/metric
 github.com/netobserv/loki-client-go/pkg/urlutil
-# github.com/netobserv/netobserv-ebpf-agent v1.9.0-crc0.0.20250528064221-6f34e5b85d2c
+# github.com/netobserv/netobserv-ebpf-agent v1.9.0-crc0.0.20250610144135-d64c5d99f2da
 ## explicit; go 1.23.0
 github.com/netobserv/netobserv-ebpf-agent/pkg/decode
 github.com/netobserv/netobserv-ebpf-agent/pkg/ebpf


### PR DESCRIPTION
In timed_cache, use uint64 hash (fnv 64a) instead of string builder
Uses the same implementation as in prom go client

Also:
- [Bump agent, with improved pb decode](https://github.com/netobserv/flowlogs-pipeline/pull/992/commits/a8e13410001541b7ab48dcab3dac4a0e8e313b20)

![image](https://github.com/user-attachments/assets/6b84ca39-e267-411a-a836-726f637061c4)


- [reduce allocations in metrics encode](https://github.com/netobserv/flowlogs-pipeline/pull/992/commits/da2f2679d60fab7c2cca388004928305e4a3f18f)

![image](https://github.com/user-attachments/assets/05dcaa1e-d051-4185-943b-8e3b01340ed0)
