### PR TITLE
NETOBSERV-2288: Fix MAC enrichment

### DIFF
--- a/pkg/pipeline/transform/kubernetes/cni/multus.go
+++ b/pkg/pipeline/transform/kubernetes/cni/multus.go
@@ -75,7 +75,7 @@ func (m *MultusHandler) buildSNKeys(flow config.GenericMap, rule *api.K8sRule, s
 		return nil
 	}
 
-	macIP := "~" + ip + "~" + mac
+	macIP := "~" + ip + "~" + strings.ToLower(mac)
 	if interfaces == nil {
 		return []SecondaryNetKey{{NetworkName: sn.Name, Key: macIP}}
 	}
@@ -137,5 +137,5 @@ func (n *NetStatItem) Keys(snConfig api.SecondaryNetwork) []string {
 }
 
 func key(intf, ip, mac string) string {
-	return intf + "~" + ip + "~" + strings.ToUpper(mac)
+	return intf + "~" + ip + "~" + strings.ToLower(mac)
 }

--- a/pkg/pipeline/transform/kubernetes/cni/multus_test.go
+++ b/pkg/pipeline/transform/kubernetes/cni/multus_test.go
@@ -57,11 +57,11 @@ func TestExtractNetStatusKeys(t *testing.T) {
 	}
 	keys, err = multusHandler.GetPodUniqueKeys(&pod, secondaryNetConfig)
 	require.NoError(t, err)
-	require.Equal(t, []string{"~~86:1D:96:FF:55:0D"}, keys)
+	require.Equal(t, []string{"~~86:1d:96:ff:55:0d"}, keys)
 
 	// Composed key
 	secondaryNetConfig[0].Index = map[string]any{"mac": nil, "ip": nil, "interface": nil}
 	keys, err = multusHandler.GetPodUniqueKeys(&pod, secondaryNetConfig)
 	require.NoError(t, err)
-	require.Equal(t, []string{"net1~192.168.1.205~86:1D:96:FF:55:0D"}, keys)
+	require.Equal(t, []string{"net1~192.168.1.205~86:1d:96:ff:55:0d"}, keys)
 }

--- a/pkg/pipeline/transform/kubernetes/enrich_test.go
+++ b/pkg/pipeline/transform/kubernetes/enrich_test.go
@@ -46,7 +46,7 @@ var ipInfo = map[string]*model.ResourceMetaData{
 }
 
 var customKeysInfo = map[string]*model.ResourceMetaData{
-	"~~AA:BB:CC:DD:EE:FF": {
+	"~~aa:bb:cc:dd:ee:ff": {
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "pod-1",
 			Namespace: "ns-1",
@@ -456,7 +456,7 @@ func TestEnrichUsingMac(t *testing.T) {
 	// Pod to unknown using MAC
 	entry := config.GenericMap{
 		"SrcAddr": "8.8.8.8",
-		"SrcMAC":  "AA:BB:CC:DD:EE:FF", // pod-1
+		"SrcMAC":  "aa:bb:cc:dd:ee:ff", // pod-1
 		"DstAddr": "9.9.9.9",
 		"DstMAC":  "GG:HH:II:JJ:KK:LL", // unknown
 	}
@@ -465,7 +465,7 @@ func TestEnrichUsingMac(t *testing.T) {
 	}
 	assert.Equal(t, config.GenericMap{
 		"SrcAddr":            "8.8.8.8",
-		"SrcMAC":             "AA:BB:CC:DD:EE:FF",
+		"SrcMAC":             "aa:bb:cc:dd:ee:ff",
 		"DstAddr":            "9.9.9.9",
 		"DstMAC":             "GG:HH:II:JJ:KK:LL",
 		"SrcK8s_HostIP":      "100.0.0.1",
@@ -481,7 +481,7 @@ func TestEnrichUsingMac(t *testing.T) {
 
 	// remove the MAC rules and retry
 	entry = config.GenericMap{
-		"SrcMAC": "AA:BB:CC:DD:EE:FF", // pod-1
+		"SrcMAC": "aa:bb:cc:dd:ee:ff", // pod-1
 		"DstMAC": "GG:HH:II:JJ:KK:LL", // unknown
 	}
 	for _, r := range nt.Rules {
@@ -490,7 +490,7 @@ func TestEnrichUsingMac(t *testing.T) {
 	}
 	assert.Equal(t, config.GenericMap{
 		"DstMAC": "GG:HH:II:JJ:KK:LL",
-		"SrcMAC": "AA:BB:CC:DD:EE:FF",
+		"SrcMAC": "aa:bb:cc:dd:ee:ff",
 	}, entry)
 }
 
@@ -520,7 +520,7 @@ func TestEnrichUsingUDN(t *testing.T) {
 		},
 	}
 	customIndexes := map[string]*model.ResourceMetaData{
-		"~~AA:BB:CC:DD:EE:FF": {
+		"~~aa:bb:cc:dd:ee:ff": {
 			ObjectMeta: v1.ObjectMeta{
 				Name:      "pod-1",
 				Namespace: "ns-1",

--- a/pkg/pipeline/transform/kubernetes/informers/informers_test.go
+++ b/pkg/pipeline/transform/kubernetes/informers/informers_test.go
@@ -58,12 +58,12 @@ func TestGetInfo(t *testing.T) {
 		OwnerKind:        "Pod",
 		NetworkName:      "primary",
 		IPs:              []string{"1.2.3.4"},
-		SecondaryNetKeys: []string{"~~AA:BB:CC:DD:EE:FF"},
+		SecondaryNetKeys: []string{"~~aa:bb:cc:dd:ee:ff"},
 	}
 	require.Equal(t, pod1, *info)
 
 	// Test get same pod by mac
-	info = kubeData.IndexLookup([]cni.SecondaryNetKey{{NetworkName: "custom-network", Key: "~~AA:BB:CC:DD:EE:FF"}}, "")
+	info = kubeData.IndexLookup([]cni.SecondaryNetKey{{NetworkName: "custom-network", Key: "~~aa:bb:cc:dd:ee:ff"}}, "")
 	require.NotNil(t, info)
 	pod1.NetworkName = "custom-network"
 	require.Equal(t, pod1, *info)


### PR DESCRIPTION
## Description

mac is now lower case in flows - make sure both key and lookup input are lower-cased

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [x] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test flp-node-density-heavy-25nodes`_
