### PR TITLE
NETOBSERV-1565: review & fix some nolints; mostly renaming things for…

### DIFF
--- a/pkg/confgen/confgen_test.go
+++ b/pkg/confgen/confgen_test.go
@@ -98,7 +98,7 @@ func Test_RunShortConfGen(t *testing.T) {
 	// Unmarshal output
 	destCfgBytes, err := os.ReadFile(configOut)
 	require.NoError(t, err)
-	var out config.ConfigFileStruct
+	var out config.Root
 	err = yaml.UnmarshalStrict(destCfgBytes, &out)
 	require.NoError(t, err)
 	require.Len(t, out.Pipeline, 4)
@@ -191,7 +191,7 @@ func Test_RunConfGenNoAgg(t *testing.T) {
 	// Unmarshal output
 	destCfgBytes, err := os.ReadFile(configOut)
 	require.NoError(t, err)
-	var out config.ConfigFileStruct
+	var out config.Root
 	err = yaml.Unmarshal(destCfgBytes, &out)
 	require.NoError(t, err)
 	require.Len(t, out.Pipeline, 3)
@@ -276,7 +276,7 @@ func Test_RunLongConfGen(t *testing.T) {
 	// Unmarshal output
 	destCfgBytes, err := os.ReadFile(configOut)
 	require.NoError(t, err)
-	var out config.ConfigFileStruct
+	var out config.Root
 	err = yaml.UnmarshalStrict(destCfgBytes, &out)
 	require.NoError(t, err)
 	require.Len(t, out.Parameters, 6)

--- a/pkg/confgen/flowlogs2metrics_config.go
+++ b/pkg/confgen/flowlogs2metrics_config.go
@@ -27,7 +27,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func (cg *ConfGen) GenerateFlowlogs2PipelineConfig() *config.ConfigFileStruct {
+func (cg *ConfGen) GenerateFlowlogs2PipelineConfig() *config.Root {
 	pipeline, _ := config.NewPipeline("ingest_collector", &cg.config.Ingest)
 	forkedNode := pipeline
 	if cg.config.Transform.Generic != nil {
@@ -63,7 +63,7 @@ func (cg *ConfGen) GenerateFlowlogs2PipelineConfig() *config.ConfigFileStruct {
 	if cg.config.Write.Loki != nil {
 		forkedNode.WriteLoki("write_loki", *cg.config.Write.Loki)
 	}
-	return pipeline.IntoConfigFileStruct(&config.ConfigFileStruct{
+	return pipeline.IntoRootConfig(&config.Root{
 		LogLevel: "error",
 		MetricsSettings: config.MetricsSettings{
 			PromConnectionInfo: api.PromConnectionInfo{Port: 9102},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,10 +35,7 @@ type Options struct {
 	Profile           Profile
 }
 
-// (nolint => needs refactoring)
-//
-//nolint:revive
-type ConfigFileStruct struct {
+type Root struct {
 	LogLevel          string            `yaml:"log-level,omitempty" json:"log-level,omitempty"`
 	MetricsSettings   MetricsSettings   `yaml:"metricsSettings,omitempty" json:"metricsSettings,omitempty"`
 	Pipeline          []Stage           `yaml:"pipeline,omitempty" json:"pipeline,omitempty"`
@@ -150,8 +147,8 @@ type Write struct {
 }
 
 // ParseConfig creates the internal unmarshalled representation from the Pipeline and Parameters json
-func ParseConfig(opts *Options) (ConfigFileStruct, error) {
-	out := ConfigFileStruct{}
+func ParseConfig(opts *Options) (Root, error) {
+	out := Root{}
 
 	logrus.Debugf("opts.PipeLine = %v ", opts.PipeLine)
 	err := JSONUnmarshalStrict([]byte(opts.PipeLine), &out.Pipeline)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -47,7 +47,7 @@ func TestJSONUnmarshalStrict(t *testing.T) {
 
 func TestUnmarshalInline(t *testing.T) {
 	cfg := `{"metricsSettings":{"port":9102,"prefix":"netobserv_"}}`
-	var cfs ConfigFileStruct
+	var cfs Root
 	err := yaml.Unmarshal([]byte(cfg), &cfs)
 	require.NoError(t, err)
 	require.Equal(t, "netobserv_", cfs.MetricsSettings.Prefix)

--- a/pkg/config/pipeline_builder.go
+++ b/pkg/config/pipeline_builder.go
@@ -235,14 +235,14 @@ func (b *PipelineBuilderStage) GetDynamicStageParams() []StageParam {
 	return res
 }
 
-// IntoConfigFileStruct injects the current pipeline and params in the provided ConfigFileStruct object.
-func (b *PipelineBuilderStage) IntoConfigFileStruct(cfs *ConfigFileStruct) *ConfigFileStruct {
+// IntoRootConfig injects the current pipeline and params in the provided config.Root object.
+func (b *PipelineBuilderStage) IntoRootConfig(cfs *Root) *Root {
 	cfs.Pipeline = b.GetStages()
 	cfs.Parameters = b.GetStageParams()
 	return cfs
 }
 
-// ToConfigFileStruct returns the current pipeline and params as a new ConfigFileStruct object.
-func (b *PipelineBuilderStage) ToConfigFileStruct() *ConfigFileStruct {
-	return b.IntoConfigFileStruct(&ConfigFileStruct{})
+// ToRootConfig returns the current pipeline and params as a new config.Root object.
+func (b *PipelineBuilderStage) ToRootConfig() *Root {
+	return b.IntoRootConfig(&Root{})
 }

--- a/pkg/pipeline/aggregate_prom_test.go
+++ b/pkg/pipeline/aggregate_prom_test.go
@@ -177,7 +177,7 @@ parameters:
 			for _, aa := range actualAggs {
 				promEncode.Encode(aa)
 			}
-			exposed := test.ReadExposedMetrics(t, promEncode.(*encode.EncodeProm).Gatherer())
+			exposed := test.ReadExposedMetrics(t, promEncode.(*encode.Prometheus).Gatherer())
 
 			for _, expected := range tt.expectedEncode {
 				require.Contains(t, exposed, expected)

--- a/pkg/pipeline/conntrack_integ_test.go
+++ b/pkg/pipeline/conntrack_integ_test.go
@@ -167,7 +167,7 @@ func ingestFile(t *testing.T, in chan<- config.GenericMap, filepath string) int 
 		lines = append(lines, []byte(text))
 	}
 	submittedLines := 0
-	decoder, err := decode.NewDecodeJSON()
+	decoder, err := decode.NewJSON()
 	require.NoError(t, err)
 	for _, line := range lines {
 		line, err := decoder.Decode(line)

--- a/pkg/pipeline/decode/decode.go
+++ b/pkg/pipeline/decode/decode.go
@@ -32,7 +32,7 @@ type Decoder interface {
 func GetDecoder(params api.Decoder) (Decoder, error) {
 	switch params.Type {
 	case api.DecoderJSON:
-		return NewDecodeJSON()
+		return NewJSON()
 	case api.DecoderProtobuf:
 		return decode.NewProtobuf()
 	}

--- a/pkg/pipeline/decode/decode_json.go
+++ b/pkg/pipeline/decode/decode_json.go
@@ -25,12 +25,11 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-//nolint:revive
-type DecodeJSON struct {
+type JSON struct {
 }
 
 // Decode decodes input strings to a list of flow entries
-func (c *DecodeJSON) Decode(line []byte) (config.GenericMap, error) {
+func (c *JSON) Decode(line []byte) (config.GenericMap, error) {
 
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Debugf("decodeJSON: line = %v", string(line))
@@ -52,8 +51,8 @@ func (c *DecodeJSON) Decode(line []byte) (config.GenericMap, error) {
 	return decodedLine2, nil
 }
 
-// NewDecodeJSON create a new decode
-func NewDecodeJSON() (Decoder, error) {
-	log.Debugf("entering NewDecodeJSON")
-	return &DecodeJSON{}, nil
+// NewJSON create a new JSON decoder
+func NewJSON() (Decoder, error) {
+	log.Debugf("entering decode.NewJSON")
+	return &JSON{}, nil
 }

--- a/pkg/pipeline/decode/decode_json_test.go
+++ b/pkg/pipeline/decode/decode_json_test.go
@@ -24,14 +24,14 @@ import (
 )
 
 func initNewDecodeJSON(t *testing.T) Decoder {
-	newDecode, err := NewDecodeJSON()
+	newDecode, err := NewJSON()
 	require.Equal(t, nil, err)
 	return newDecode
 }
 
 func TestDecodeJSON(t *testing.T) {
 	newDecode := initNewDecodeJSON(t)
-	decodeJSON := newDecode.(*DecodeJSON)
+	decodeJSON := newDecode.(*JSON)
 
 	out, err := decodeJSON.Decode([]byte(
 		"{\"varInt\": 12, \"varString\":\"testString\", \"varBool\":false}"))
@@ -53,7 +53,7 @@ func TestDecodeJSON(t *testing.T) {
 
 func TestDecodeJSONTimestamps(t *testing.T) {
 	newDecode := initNewDecodeJSON(t)
-	decodeJSON := newDecode.(*DecodeJSON)
+	decodeJSON := newDecode.(*JSON)
 	out, err := decodeJSON.Decode([]byte("{\"unixTime\": 1645104030 }"))
 	require.NoError(t, err)
 	require.Equal(t, float64(1645104030), out["unixTime"])

--- a/pkg/pipeline/encode/encode_prom_test.go
+++ b/pkg/pipeline/encode/encode_prom_test.go
@@ -70,7 +70,7 @@ parameters:
             labels:
 `
 
-func initProm(params *api.PromEncode) (*EncodeProm, error) {
+func initProm(params *api.PromEncode) (*Prometheus, error) {
 	// We need to re-instanciate globals used here and there, to avoid errors such as:
 	//  "panic: http: multiple registrations for /metrics"
 	//  TODO: remove use of default globals.
@@ -83,7 +83,7 @@ func initProm(params *api.PromEncode) (*EncodeProm, error) {
 	if err != nil {
 		return nil, err
 	}
-	prom := enc.(*EncodeProm)
+	prom := enc.(*Prometheus)
 	return prom, nil
 }
 

--- a/pkg/pipeline/encode/opentelemetry/encode_otlp_test.go
+++ b/pkg/pipeline/encode/opentelemetry/encode_otlp_test.go
@@ -48,11 +48,12 @@ parameters:
 type fakeOltpLoggerProvider struct {
 }
 type fakeOltpLogger struct {
+	logs.Logger
 }
 
 var otlpReceivedData []logs.LogRecord
 
-// nolint:gocritic
+// nolint:gocritic // no choice here, this is agoda interface signature
 func (f *fakeOltpLogger) Emit(msg logs.LogRecord) {
 	otlpReceivedData = append(otlpReceivedData, msg)
 }

--- a/pkg/pipeline/encode/prom_cache_test.go
+++ b/pkg/pipeline/encode/prom_cache_test.go
@@ -93,7 +93,7 @@ parameters:
 `
 )
 
-func encodeEntries(promEncode *EncodeProm, entries []config.GenericMap) {
+func encodeEntries(promEncode *Prometheus, entries []config.GenericMap) {
 	for _, entry := range entries {
 		promEncode.Encode(entry)
 	}

--- a/pkg/pipeline/ingest/ingest_kafka.go
+++ b/pkg/pipeline/ingest/ingest_kafka.go
@@ -167,7 +167,6 @@ func (k *ingestKafka) reportStats() {
 }
 
 // NewIngestKafka create a new ingester
-// nolint:cyclop
 func NewIngestKafka(opMetrics *operational.Metrics, params config.StageParam) (Ingester, error) {
 	config := &api.IngestKafka{}
 	var ingestType string

--- a/pkg/pipeline/inprocess.go
+++ b/pkg/pipeline/inprocess.go
@@ -10,7 +10,7 @@ import (
 )
 
 // StartFLPInProcess is an entry point to start the whole FLP / pipeline processing from imported code
-func StartFLPInProcess(cfg *config.ConfigFileStruct, in chan config.GenericMap) error {
+func StartFLPInProcess(cfg *config.Root, in chan config.GenericMap) error {
 	promServer := prometheus.InitializePrometheus(&cfg.MetricsSettings)
 
 	// Create new flows pipeline

--- a/pkg/pipeline/inprocess_test.go
+++ b/pkg/pipeline/inprocess_test.go
@@ -18,7 +18,7 @@ func TestInProcessFLP(t *testing.T) {
 	pipeline = pipeline.WriteStdout("writer", api.WriteStdout{Format: "json"})
 	in := make(chan config.GenericMap, 100)
 	defer close(in)
-	err := StartFLPInProcess(pipeline.ToConfigFileStruct(), in)
+	err := StartFLPInProcess(pipeline.ToRootConfig(), in)
 	require.NoError(t, err)
 
 	capturedOut, w, _ := os.Pipe()

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -50,12 +50,12 @@ type Pipeline struct {
 }
 
 // NewPipeline defines the pipeline elements
-func NewPipeline(cfg *config.ConfigFileStruct) (*Pipeline, error) {
+func NewPipeline(cfg *config.Root) (*Pipeline, error) {
 	return newPipelineFromIngester(cfg, nil)
 }
 
 // newPipelineFromIngester defines the pipeline elements from a preset ingester (e.g. for in-process receiver)
-func newPipelineFromIngester(cfg *config.ConfigFileStruct, ing ingest.Ingester) (*Pipeline, error) {
+func newPipelineFromIngester(cfg *config.Root, ing ingest.Ingester) (*Pipeline, error) {
 	log.Debugf("entering newPipelineFromIngester")
 
 	log.Debugf("stages = %v ", cfg.Pipeline)

--- a/pkg/pipeline/pipeline_builder.go
+++ b/pkg/pipeline/pipeline_builder.go
@@ -74,7 +74,7 @@ type pipelineEntry struct {
 	Writer      write.Writer
 }
 
-func getDynConfig(cfg *config.ConfigFileStruct) ([]config.StageParam, error) {
+func getDynConfig(cfg *config.Root) ([]config.StageParam, error) {
 	k8sconfig, err := k8sutils.LoadK8sConfig(cfg.DynamicParameters.KubeConfigPath)
 	if err != nil {
 		log.Errorf("Cannot get k8s config: %v", err)
@@ -105,7 +105,7 @@ func getDynConfig(cfg *config.ConfigFileStruct) ([]config.StageParam, error) {
 	return dynConfig.Parameters, nil
 }
 
-func newBuilder(cfg *config.ConfigFileStruct) *builder {
+func newBuilder(cfg *config.Root) *builder {
 	// Get global metrics settings
 	opMetrics := operational.NewMetrics(&cfg.MetricsSettings)
 	stageDuration := opMetrics.GetOrCreateStageDurationHisto()

--- a/pkg/pipeline/pipeline_watcher.go
+++ b/pkg/pipeline/pipeline_watcher.go
@@ -22,7 +22,7 @@ type pipelineConfigWatcher struct {
 	pipelineEntryMap map[string]*pipelineEntry
 }
 
-func newPipelineConfigWatcher(cfg *config.ConfigFileStruct, pipelineEntryMap map[string]*pipelineEntry) (*pipelineConfigWatcher, error) {
+func newPipelineConfigWatcher(cfg *config.Root, pipelineEntryMap map[string]*pipelineEntry) (*pipelineConfigWatcher, error) {
 	if cfg.DynamicParameters.Name == "" ||
 		cfg.DynamicParameters.Namespace == "" ||
 		cfg.DynamicParameters.FileName == "" {

--- a/pkg/pipeline/transform/kubernetes/datasource/datasource.go
+++ b/pkg/pipeline/transform/kubernetes/datasource/datasource.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Datasource struct {
-	Informers informers.InformersInterface
+	Informers informers.Interface
 }
 
 func NewInformerDatasource(kubeconfig string, infConfig informers.Config, opMetrics *operational.Metrics) (*Datasource, error) {

--- a/pkg/pipeline/transform/kubernetes/informers/informers-mock.go
+++ b/pkg/pipeline/transform/kubernetes/informers/informers-mock.go
@@ -27,7 +27,7 @@ var (
 
 type Mock struct {
 	mock.Mock
-	InformersInterface
+	Interface
 }
 
 func NewInformersMock() *Mock {
@@ -164,7 +164,7 @@ func SetupIndexerMocks(kd *Informers) (pods, nodes, svc, rs *IndexerMock) {
 }
 
 type FakeInformers struct {
-	InformersInterface
+	Interface
 	ipInfo         map[string]*model.ResourceMetaData
 	customKeysInfo map[string]*model.ResourceMetaData
 	nodes          map[string]*model.ResourceMetaData

--- a/pkg/pipeline/transform/kubernetes/informers/informers.go
+++ b/pkg/pipeline/transform/kubernetes/informers/informers.go
@@ -52,15 +52,14 @@ var (
 	log = logrus.WithField("component", "transform.Network.Kubernetes")
 )
 
-//nolint:revive
-type InformersInterface interface {
+type Interface interface {
 	IndexLookup([]cni.SecondaryNetKey, string) *model.ResourceMetaData
 	GetNodeByName(string) (*model.ResourceMetaData, error)
 	InitFromConfig(string, Config, *operational.Metrics) error
 }
 
 type Informers struct {
-	InformersInterface
+	Interface
 	// pods, nodes and services cache the different object types as *Info pointers
 	pods     cache.SharedIndexInformer
 	nodes    cache.SharedIndexInformer

--- a/pkg/pipeline/write/testnorace/write_ipfix_test.go
+++ b/pkg/pipeline/write/testnorace/write_ipfix_test.go
@@ -377,7 +377,6 @@ func TestICMPIPFIXFlow(t *testing.T) {
 	}
 }
 
-//nolint:cyclop
 func matchElement(t *testing.T, element entities.InfoElementWithValue, flow config.GenericMap) {
 	name := element.GetName()
 	mapping, ok := write.MapIPFIXKeys[name]

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -57,7 +57,7 @@ func GetIngestMockEntry(missingKey bool) config.GenericMap {
 	return entry
 }
 
-func InitConfig(t *testing.T, conf string) (*viper.Viper, *config.ConfigFileStruct) {
+func InitConfig(t *testing.T, conf string) (*viper.Viper, *config.Root) {
 	ResetPromRegistry()
 	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	yamlConfig := []byte(conf)


### PR DESCRIPTION
… revive

(no QE needed)

**Breaking change for Go consumers**

`config.ConfigFileStruct` was renamed to `config.Root`
