### PR TITLE
NETOBSERV-2355: Rename sampling ratio/rate -> interval

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -191,7 +191,7 @@ Following is the supported API format for filter transformations:
                              value: specified value of input field:
                              castInt: set true to cast the value field as an int (numeric values are float64 otherwise)
                  keepEntryQuery: configuration for keep_entry rule
-                 keepEntrySampling: sampling value for keep_entry type: 1 flow on <sampling> is kept
+                 keepEntrySampling: sampling interval for keep_entry type: 1 flow on <sampling> is kept
                  addField: configuration for add_field rule
                      input: entry input field
                      value: specified value of input field:
@@ -220,7 +220,7 @@ Following is the supported API format for filter transformations:
                      parameters: parameters specific to type
                      assignee: value needs to assign to output field
                  conditionalSampling: sampling configuration rules
-                         value: sampling value: 1 flow on <sampling> is kept
+                         value: sampling interval: 1 flow on <sampling> is kept
                          rules: rules to be satisfied for this sampling configuration
                                  type: (enum) one of the following:
                                     remove_entry_if_exists: removes the entry if the field exists

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -34,7 +34,7 @@ The language is currently integrated in the "keep_entry" transform/filtering API
         rules:
         - type: keep_entry_query
           keepEntryQuery: (namespace="A" and with(workload)) or service=~"abc.+"
-          keepEntrySampling: 10 # Optionally, a sampling ratio can be associated with the filter
+          keepEntrySampling: 10 # Optionally, a sampling interval can be associated with the filter
 ```
 
 ## Integration with the NetObserv operator
@@ -48,7 +48,7 @@ spec:
       - query: |
           (SrcK8S_Namespace="netobserv" OR (SrcK8S_Namespace="openshift-ingress" AND DstK8S_Namespace="netobserv"))
         outputTarget: Loki  # The filter can target a specific output (such as Loki logs or exported data), or all outputs.
-        sampling: 10        # Optionally, a sampling ratio can be associated with the filter
+        sampling: 10        # Optionally, a sampling interval can be associated with the filter
 ```
 
 See also the [list of field names](https://github.com/netobserv/network-observability-operator/blob/main/docs/flows-format.adoc) that are available for queries, and the [API documentation](https://github.com/netobserv/network-observability-operator/blob/main/docs/FlowCollector.md#flowcollectorspecprocessorfiltersindex-1).

--- a/pkg/api/transform_filter.go
+++ b/pkg/api/transform_filter.go
@@ -63,7 +63,7 @@ type TransformFilterRule struct {
 	RemoveEntry             *TransformFilterGenericRule      `yaml:"removeEntry,omitempty" json:"removeEntry,omitempty" doc:"configuration for remove_entry_* rules"`
 	RemoveEntryAllSatisfied []*RemoveEntryRule               `yaml:"removeEntryAllSatisfied,omitempty" json:"removeEntryAllSatisfied,omitempty" doc:"configuration for remove_entry_all_satisfied rule"`
 	KeepEntryQuery          string                           `yaml:"keepEntryQuery,omitempty" json:"keepEntryQuery,omitempty" doc:"configuration for keep_entry rule"`
-	KeepEntrySampling       uint16                           `yaml:"keepEntrySampling,omitempty" json:"keepEntrySampling,omitempty" doc:"sampling value for keep_entry type: 1 flow on <sampling> is kept"`
+	KeepEntrySampling       uint16                           `yaml:"keepEntrySampling,omitempty" json:"keepEntrySampling,omitempty" doc:"sampling interval for keep_entry type: 1 flow on <sampling> is kept"`
 	AddField                *TransformFilterGenericRule      `yaml:"addField,omitempty" json:"addField,omitempty" doc:"configuration for add_field rule"`
 	AddFieldIfDoesntExist   *TransformFilterGenericRule      `yaml:"addFieldIfDoesntExist,omitempty" json:"addFieldIfDoesntExist,omitempty" doc:"configuration for add_field_if_doesnt_exist rule"`
 	AddFieldIf              *TransformFilterRuleWithAssignee `yaml:"addFieldIf,omitempty" json:"addFieldIf,omitempty" doc:"configuration for add_field_if rule"`
@@ -115,7 +115,7 @@ type RemoveEntryRule struct {
 }
 
 type SamplingCondition struct {
-	Value uint16             `yaml:"value,omitempty" json:"value,omitempty" doc:"sampling value: 1 flow on <sampling> is kept"`
+	Value uint16             `yaml:"value,omitempty" json:"value,omitempty" doc:"sampling interval: 1 flow on <sampling> is kept"`
 	Rules []*RemoveEntryRule `yaml:"rules,omitempty" json:"rules,omitempty" doc:"rules to be satisfied for this sampling configuration"`
 }
 


### PR DESCRIPTION
## Description

Just doc/text renamings...

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test flp-node-density-heavy-25nodes`_
