### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for flowlogs-pipeline-zstream

### DIFF
--- a/contrib/docker/Dockerfile.downstream
+++ b/contrib/docker/Dockerfile.downstream
@@ -28,7 +28,8 @@ USER 65532:65532
 ENTRYPOINT ["/flowlogs-pipeline"]
 
 LABEL com.redhat.component="network-observability-flowlogs-pipeline-container"
-LABEL name="network-observability-flowlogs-pipeline"
+LABEL name="network-observability/network-observability-flowlogs-pipeline-rhel9"
+LABEL cpe="cpe:/a:redhat:network_observ_optr:1.9::el9"
 LABEL io.k8s.display-name="Network Observability Flow-Logs Pipeline"
 LABEL io.k8s.description="Network Observability Flow-Logs Pipeline"
 LABEL summary="Network Observability Flow-Logs Pipeline"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
