### PR TITLE
Expose prometheus HELP information

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -17,6 +17,7 @@ Following is the supported API format for prometheus encode:
                     counter: monotonically increasing counter whose value can only increase
                     histogram: counts samples in configurable buckets
                     agg_histogram: counts samples in configurable buckets, pre-aggregated via an Aggregate stage
+                 help: the metric help text
                  filters: a list of criteria to filter entries by
                          key: the key to match and filter by
                          value: the value to match and filter by
@@ -457,6 +458,7 @@ Following is the supported API format for writing metrics to an OpenTelemetry co
                     counter: monotonically increasing counter whose value can only increase
                     histogram: counts samples in configurable buckets
                     agg_histogram: counts samples in configurable buckets, pre-aggregated via an Aggregate stage
+                 help: the metric help text
                  filters: a list of criteria to filter entries by
                          key: the key to match and filter by
                          value: the value to match and filter by

--- a/pkg/api/encode_prom.go
+++ b/pkg/api/encode_prom.go
@@ -49,6 +49,7 @@ type PromConnectionInfo struct {
 type MetricsItem struct {
 	Name       string                    `yaml:"name" json:"name" doc:"the metric name"`
 	Type       MetricEncodeOperationEnum `yaml:"type" json:"type" doc:"(enum) one of the following:"`
+	Help       string                    `yaml:"help,omitempty" json:"help,omitempty" doc:"the metric help text"`
 	Filters    []MetricsFilter           `yaml:"filters" json:"filters" doc:"a list of criteria to filter entries by"`
 	ValueKey   string                    `yaml:"valueKey" json:"valueKey" doc:"entry key from which to resolve metric value"`
 	Labels     []string                  `yaml:"labels" json:"labels" doc:"labels to be associated with the metric"`

--- a/pkg/pipeline/encode/encode_prom.go
+++ b/pkg/pipeline/encode/encode_prom.go
@@ -116,25 +116,25 @@ func (e *Prometheus) Cleanup(cleanupFunc interface{}) {
 }
 
 func (e *Prometheus) addCounter(fullMetricName string, mInfo *metrics.Preprocessed) prometheus.Collector {
-	counter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: fullMetricName, Help: ""}, mInfo.TargetLabels())
+	counter := prometheus.NewCounterVec(prometheus.CounterOpts{Name: fullMetricName, Help: mInfo.Help}, mInfo.TargetLabels())
 	e.metricCommon.AddCounter(fullMetricName, counter, mInfo)
 	return counter
 }
 
 func (e *Prometheus) addGauge(fullMetricName string, mInfo *metrics.Preprocessed) prometheus.Collector {
-	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: fullMetricName, Help: ""}, mInfo.TargetLabels())
+	gauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: fullMetricName, Help: mInfo.Help}, mInfo.TargetLabels())
 	e.metricCommon.AddGauge(fullMetricName, gauge, mInfo)
 	return gauge
 }
 
 func (e *Prometheus) addHistogram(fullMetricName string, mInfo *metrics.Preprocessed) prometheus.Collector {
-	histogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: fullMetricName, Help: ""}, mInfo.TargetLabels())
+	histogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: fullMetricName, Help: mInfo.Help}, mInfo.TargetLabels())
 	e.metricCommon.AddHist(fullMetricName, histogram, mInfo)
 	return histogram
 }
 
 func (e *Prometheus) addAgghistogram(fullMetricName string, mInfo *metrics.Preprocessed) prometheus.Collector {
-	agghistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: fullMetricName, Help: ""}, mInfo.TargetLabels())
+	agghistogram := prometheus.NewHistogramVec(prometheus.HistogramOpts{Name: fullMetricName, Help: mInfo.Help}, mInfo.TargetLabels())
 	e.metricCommon.AddAggHist(fullMetricName, agghistogram, mInfo)
 	return agghistogram
 }

--- a/pkg/pipeline/encode/opentelemetry/encode_otlpmetrics.go
+++ b/pkg/pipeline/encode/opentelemetry/encode_otlpmetrics.go
@@ -152,7 +152,7 @@ func NewEncodeOtlpMetrics(opMetrics *operational.Metrics, params config.StagePar
 		mInfo := metrics.Preprocess(mCfg)
 		switch mCfg.Type {
 		case api.MetricCounter:
-			counter, err := meter.Float64Counter(fullMetricName)
+			counter, err := meter.Float64Counter(fullMetricName, metric.WithDescription(mCfg.Help))
 			if err != nil {
 				log.Errorf("error during counter creation: %v", err)
 				return nil, err
@@ -163,6 +163,7 @@ func NewEncodeOtlpMetrics(opMetrics *operational.Metrics, params config.StagePar
 			obs := Float64Gauge{observations: make(map[string]Float64GaugeEntry)}
 			gauge, err := meterFactory.Float64ObservableGauge(
 				fullMetricName,
+				metric.WithDescription(mCfg.Help),
 				metric.WithFloat64Callback(obs.Callback),
 			)
 			if err != nil {
@@ -173,12 +174,12 @@ func NewEncodeOtlpMetrics(opMetrics *operational.Metrics, params config.StagePar
 		case api.MetricHistogram:
 			var histo metric.Float64Histogram
 			if len(mCfg.Buckets) == 0 {
-				histo, err = meter.Float64Histogram(fullMetricName)
+				histo, err = meter.Float64Histogram(fullMetricName, metric.WithDescription(mCfg.Help))
 			} else {
 				histo, err = meter.Float64Histogram(fullMetricName,
+					metric.WithDescription(mCfg.Help),
 					metric.WithExplicitBucketBoundaries(mCfg.Buckets...),
 				)
-
 			}
 			if err != nil {
 				log.Errorf("error during histogram creation: %v", err)


### PR DESCRIPTION
## Description

Expose prometheus HELP information to API `MetricsItem`.

## Dependencies

n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).
