### PR TITLE
Optimize replicaset informers - DNM

### DIFF
--- a/pkg/pipeline/transform/kubernetes/informers/informers.go
+++ b/pkg/pipeline/transform/kubernetes/informers/informers.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	inf "k8s.io/client-go/informers"
@@ -412,7 +413,9 @@ func (k *Informers) InitFromConfig(kubeconfig string, infConfig Config, opMetric
 
 func (k *Informers) initInformers(client kubernetes.Interface, metaClient metadata.Interface, dynClient *dynamic.DynamicClient, cfg Config) error {
 	informerFactory := inf.NewSharedInformerFactory(client, syncTime)
-	metadataInformerFactory := metadatainformer.NewSharedInformerFactory(metaClient, syncTime)
+	metadataInformerFactory := metadatainformer.NewFilteredSharedInformerFactory(metaClient, syncTime, metav1.NamespaceAll, func(options *metav1.ListOptions) {
+		options.FieldSelector = fields.OneTermNotEqualSelector("status.replicas", "0").String()
+	})
 	err := k.initNodeInformer(informerFactory, cfg)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Ignores all inactive replicasets; potentially improving a lot memory usage on large clusters

**do not merge yet** , see dependencies
We need to see if the upstream fix will be backported or not. If not, we should perhaps introduce a flag or a mechanism to turn on/off this optimization, so that it doesn't break the replicasets informer when running against a non-patched cluster.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
- https://github.com/kubernetes/kubernetes/issues/135136


## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [ ] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test flp-node-density-heavy-25nodes`_
