### PR TITLE
NETOBSERV-2438: Metrics filters, allow OR on same key

### DIFF
--- a/pkg/pipeline/encode/metrics/filtering.go
+++ b/pkg/pipeline/encode/metrics/filtering.go
@@ -4,15 +4,32 @@ import "github.com/netobserv/flowlogs-pipeline/pkg/config"
 
 func (p *Preprocessed) ApplyFilters(flow config.GenericMap, flatParts []config.GenericMap) (bool, []config.GenericMap) {
 	filteredParts := flatParts
-	for _, filter := range p.filters {
-		if filter.useFlat {
-			filteredParts = filter.filterFlatParts(filteredParts)
-			if len(filteredParts) == 0 {
-				return false, nil
+	// For a given key, all related filters are OR'ed
+	for _, filtersPerKey := range p.filters {
+		allFailed := true
+		for _, filter := range filtersPerKey {
+			passed, nfp := applySingleFilter(flow, &filter, filteredParts)
+			if passed {
+				allFailed = false
+				filteredParts = nfp
+				break
 			}
-		} else if !filter.predicate(flow) {
+		}
+		if allFailed {
 			return false, nil
 		}
+	}
+	return true, filteredParts
+}
+
+func applySingleFilter(flow config.GenericMap, filter *preprocessedFilter, filteredParts []config.GenericMap) (bool, []config.GenericMap) {
+	if filter.useFlat {
+		filteredParts = filter.filterFlatParts(filteredParts)
+		if len(filteredParts) == 0 {
+			return false, nil
+		}
+	} else if !filter.predicate(flow) {
+		return false, nil
 	}
 	return true, filteredParts
 }

--- a/pkg/pipeline/encode/metrics/preprocess.go
+++ b/pkg/pipeline/encode/metrics/preprocess.go
@@ -10,7 +10,7 @@ import (
 
 type Preprocessed struct {
 	*api.MetricsItem
-	filters         []preprocessedFilter
+	filters         map[string][]preprocessedFilter
 	MappedLabels    []MappedLabel
 	FlattenedLabels []MappedLabel
 }
@@ -60,6 +60,7 @@ func filterToPredicate(filter api.MetricsFilter) filters.Predicate {
 func Preprocess(def *api.MetricsItem) *Preprocessed {
 	mi := Preprocessed{
 		MetricsItem: def,
+		filters:     make(map[string][]preprocessedFilter),
 	}
 	for _, l := range def.Labels {
 		ml := MappedLabel{Source: l, Target: l}
@@ -73,7 +74,7 @@ func Preprocess(def *api.MetricsItem) *Preprocessed {
 		}
 	}
 	for _, f := range def.Filters {
-		mi.filters = append(mi.filters, preprocessedFilter{
+		mi.filters[f.Key] = append(mi.filters[f.Key], preprocessedFilter{
 			predicate: filterToPredicate(f),
 			useFlat:   mi.isFlattened(f.Key),
 		})

--- a/pkg/pipeline/encode/metrics/preprocess_test.go
+++ b/pkg/pipeline/encode/metrics/preprocess_test.go
@@ -42,3 +42,24 @@ func Test_Flatten(t *testing.T) {
 		},
 	}, fl)
 }
+
+func Test_ORedFilters(t *testing.T) {
+	// Several filters on the same key are ORed
+	pp := Preprocess(&api.MetricsItem{Filters: []api.MetricsFilter{
+		{
+			Key:  "label",
+			Type: api.MetricFilterAbsence,
+		},
+		{
+			Key:   "label",
+			Type:  api.MetricFilterRegex,
+			Value: "^EXT-.*",
+		},
+	}})
+	keep, _ := pp.ApplyFilters(config.GenericMap{"namespace": "A", "bytes": 7, "label": "Something"}, nil)
+	assert.False(t, keep)
+	keep, _ = pp.ApplyFilters(config.GenericMap{"namespace": "A", "bytes": 7, "label": "EXT-Something"}, nil)
+	assert.True(t, keep)
+	keep, _ = pp.ApplyFilters(config.GenericMap{"namespace": "A", "bytes": 7}, nil)
+	assert.True(t, keep)
+}


### PR DESCRIPTION
## Description

Fix issue where several metrics filters targetting the same key would not be ORed, which should be an expected behaviour.

This is necessary for filters such as "SubnetLabel is absent OR starts with EXT-", which is a pattern that should become pretty common.


<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that.

* [ ] Will this change affect NetObserv / Network Observability operator? If not, you can ignore the rest of this checklist.
* [x] Is this PR backed with a JIRA ticket? If so, make sure it is written as a title prefix _(in general, PRs affecting the NetObserv/Network Observability product should be backed with a JIRA ticket - especially if they bring user facing changes)._
* [ ] Does this PR require product documentation?
  * [ ] If so, make sure the JIRA epic is labelled with "documentation" and provides a description relevant for doc writers, such as use cases or scenarios. Any required step to activate or configure the feature should be documented there, such as new CRD knobs.
* [ ] Does this PR require a product release notes entry?
  * [ ] If so, fill in "Release Note Text" in the JIRA.
* [ ] Is there anything else the QE team should know before testing? E.g: configuration changes, environment setup, etc.
  * [ ] If so, make sure it is described in the JIRA ticket.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test flp-node-density-heavy-25nodes`_
