### PR TITLE
Enhance release workflow with SBOM and signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,22 +5,28 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
+  artifact-metadata: write
 
 env:
   WF_REGISTRY_USER: netobserv+github_ci
   WF_ORG: netobserv
   WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le s390x
   WF_REGISTRY_NAME: quay.io
+  WF_IMAGE_NAME: quay.io/netobserv/flowlogs-pipeline
 
 jobs:
   push-image:
     name: build and push release
     runs-on: ubuntu-latest
+
     steps:
       - name: checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+
       - name: validate tag
         run: |
           tag=`git describe --exact-match --tags 2> /dev/null`
@@ -32,18 +38,36 @@ jobs:
               echo "$tag is NOT a valid release tag"
               exit 1
           fi
+
       - name: install make
         run: sudo apt-get install make
+
       - name: docker login to quay.io
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ env.WF_REGISTRY_USER }}
           password: ${{ secrets.QUAY_SECRET }}
           registry: ${{ env.WF_REGISTRY_NAME }}
+
       - name: build and push manifest with images
-        run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} CLEAN_BUILD=1 make images
+        run: |
+          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" \
+          IMAGE_ORG=${{ env.WF_ORG }} \
+          VERSION=${{ env.tag }} \
+          CLEAN_BUILD=1 make images
+
+      - name: capture image digest
+        id: image_digest
+        run: |
+          digest=$(docker buildx imagetools inspect \
+            ${{ env.WF_IMAGE_NAME }}:${{ env.tag }} \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
       - name: extract binaries
         run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} make extract-binaries
+
       - name: create draft release
         id: create_release
         uses: actions/create-release@v1
@@ -54,6 +78,7 @@ jobs:
           release_name: ${{ env.tag }}
           draft: true
           prerelease: false
+
       - name: upload binaries
         uses: actions/github-script@v9
         with:
@@ -67,39 +92,33 @@ jobs:
                 url: upload_url,
                 name: file,
                 data: await fs.readFile(`./release-assets/${file}`)
-              }); 
+              });
             }
+
       - name: cosign-installer
-        # You may pin to the exact commit or the version.
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003
-        #uses: sigstore/cosign-installer@v4.1.1
-        #with:
-        # cosign release version to be installed
-        #cosign-release: # optional, default is v3.0.5
-        # Where to install the cosign binary
-        #install-dir: # optional, default is $HOME/.cosign
-        # set to true if install-dir location requires sudo privs
-        # use-sudo: # optional, default is false
-                
+
       - name: Sign and verify the image with GitHub OIDC Token
         run: |
-          cosign sign --yes ${{ env.WF_REGISTRY_NAME }}/${{ env.WF_MULTIARCH_TARGETS }}/${{ env.WF_ORG }}/${{ env.tag }}@${{ steps.create_release.outputs.digest }}
+          cosign sign --yes \
+            ${{ env.WF_IMAGE_NAME }}@${{ steps.image_digest.outputs.digest }}
 
-          cosign verify ${{ env.WF_REGISTRY_NAME }}/${{ env.WF_MULTIARCH_TARGETS }}/${{ env.WF_ORG }}/${{ env.tag }}@${{ steps.create_release.outputs.digest }} \
-          --certificate-identity=https://github.com/netobserv/flowlogs-pipeline/blob/main/.github/workflows/release.yml@refs/heads/main \
-          --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+          cosign verify \
+            ${{ env.WF_IMAGE_NAME }}@${{ steps.image_digest.outputs.digest }} \
+            --certificate-identity=https://github.com/netobserv/flowlogs-pipeline/blob/main/.github/workflows/release.yml@refs/heads/main \
+            --certificate-oidc-issuer=https://token.actions.githubusercontent.com
 
       - name: Attest Provenance attestations
         uses: actions/attest-build-provenance@v3
         with:
-          subject-name: ${{ env.WF_REGISTRY_NAME }}/${{ env.WF_MULTIARCH_TARGETS }}/${{ env.WF_ORG }}/${{ env.tag }}
-          subject-digest: ${{ steps.create_release.outputs.digest }}
+          subject-name: ${{ env.WF_IMAGE_NAME }}
+          subject-digest: ${{ steps.image_digest.outputs.digest }}
           push-to-registry: true
 
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ env.WF_REGISTRY_NAME }}/${{ env.WF_MULTIARCH_TARGETS }}/${{ env.WF_ORG }}/${{ env.tag }}
+          image: ${{ env.WF_IMAGE_NAME }}:${{ env.tag }}
           registry-username: ${{ env.WF_REGISTRY_USER }}
           registry-password: ${{ secrets.QUAY_SECRET }}
           format: 'spdx-json'
@@ -109,7 +128,7 @@ jobs:
         uses: actions/attest-sbom@v3
         id: attest
         with:
-          subject-name: ${{ env.WF_REGISTRY_NAME }}/${{ env.WF_MULTIARCH_TARGETS }}/${{ env.WF_ORG }}/${{ env.tag }}
-          subject-digest: ${{ steps.create_release.outputs.digest }}
+          subject-name: ${{ env.WF_IMAGE_NAME }}
+          subject-digest: ${{ steps.image_digest.outputs.digest }}
           sbom-path: 'sbom.spdx.json'
           push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
             ${{ env.WF_IMAGE_NAME }}:${{ env.tag }} \
             --format '{{json .Manifest.Digest}}' | tr -d '"')
 
-          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "digest=$digest" >> "$GITHUB_ENV"
 
       - name: extract binaries
         run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} make extract-binaries
@@ -101,22 +101,22 @@ jobs:
       - name: Sign and verify the image with GitHub OIDC Token
         run: |
           cosign sign --yes \
-            ${{ env.WF_IMAGE_NAME }}@${{ steps.image_digest.outputs.digest }}
+            ${{ env.WF_IMAGE_NAME }}@${{ env.digest }}
 
           cosign verify \
-            ${{ env.WF_IMAGE_NAME }}@${{ steps.image_digest.outputs.digest }} \
-            --certificate-identity=https://github.com/netobserv/flowlogs-pipeline/blob/main/.github/workflows/release.yml@refs/heads/main \
+            ${{ env.WF_IMAGE_NAME }}@${{ env.digest }} \
+            --certificate-identity=https://github.com/netobserv/flowlogs-pipeline/.github/workflows/release.yml@refs/tags/${{ env.tag }} \
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com
 
       - name: Attest Provenance attestations
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
         with:
           subject-name: ${{ env.WF_IMAGE_NAME }}
-          subject-digest: ${{ steps.image_digest.outputs.digest }}
+          subject-digest: ${{ env.digest }}
           push-to-registry: true
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.WF_IMAGE_NAME }}:${{ env.tag }}
           registry-username: ${{ env.WF_REGISTRY_USER }}
@@ -125,10 +125,10 @@ jobs:
           output-file: 'sbom.spdx.json'
 
       - name: Attest SBOM
-        uses: actions/attest-sbom@v3
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4
         id: attest
         with:
           subject-name: ${{ env.WF_IMAGE_NAME }}
-          subject-digest: ${{ steps.image_digest.outputs.digest }}
+          subject-digest: ${{ env.digest }}
           sbom-path: 'sbom.spdx.json'
           push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release to quay.io, attaching sbom and signing image
+name: release to quay.io
 on:
   push:
     tags: [v*]
@@ -125,7 +125,7 @@ jobs:
           output-file: 'sbom.spdx.json'
 
       - name: Attest SBOM
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         id: attest
         with:
           subject-name: ${{ env.WF_IMAGE_NAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: ${{ env.WF_IMAGE_NAME }}:${{ env.tag }}
+          image: ${{ env.WF_IMAGE_NAME }}@${{ env.digest }}
           registry-username: ${{ env.WF_REGISTRY_USER }}
           registry-password: ${{ secrets.QUAY_SECRET }}
           format: 'spdx-json'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release to quay.io
+name: release to quay.io, attaching sbom and signing image
 on:
   push:
     tags: [v*]
@@ -10,6 +10,7 @@ env:
   WF_REGISTRY_USER: netobserv+github_ci
   WF_ORG: netobserv
   WF_MULTIARCH_TARGETS: amd64 arm64 ppc64le s390x
+  WF_REGISTRY_NAME: quay.io
 
 jobs:
   push-image:
@@ -38,7 +39,7 @@ jobs:
         with:
           username: ${{ env.WF_REGISTRY_USER }}
           password: ${{ secrets.QUAY_SECRET }}
-          registry: quay.io
+          registry: ${{ env.WF_REGISTRY_NAME }}
       - name: build and push manifest with images
         run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} CLEAN_BUILD=1 make images
       - name: extract binaries
@@ -68,3 +69,47 @@ jobs:
                 data: await fs.readFile(`./release-assets/${file}`)
               }); 
             }
+      - name: cosign-installer
+        # You may pin to the exact commit or the version.
+        # uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003
+        uses: sigstore/cosign-installer@v4.1.1
+        #with:
+        # cosign release version to be installed
+        #cosign-release: # optional, default is v3.0.5
+        # Where to install the cosign binary
+        #install-dir: # optional, default is $HOME/.cosign
+        # set to true if install-dir location requires sudo privs
+        # use-sudo: # optional, default is false
+                
+      - name: Sign and verify the image with GitHub OIDC Token
+        run: |
+          cosign sign --yes ${{ env.WF_REGISTRY_NAME }}/${{ env.WF_MULTIARCH_TARGETS }}/${{ env.WF_ORG }}/${{ env.tag }}@${{ steps.create_release.outputs.digest }}
+
+          cosign verify ${{ env.WF_REGISTRY_NAME }}/${{ env.WF_MULTIARCH_TARGETS }}/${{ env.WF_ORG }}/${{ env.tag }}@${{ steps.create_release.outputs.digest }} \
+          --certificate-identity=https://github.com/netobserv/flowlogs-pipeline/blob/main/.github/workflows/release.yml@refs/heads/main \
+          --certificate-oidc-issuer=https://token.actions.githubusercontent.com
+
+      - name: Attest Provenance attestations
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ${{ env.WF_REGISTRY_NAME }}/${{ env.WF_MULTIARCH_TARGETS }}/${{ env.WF_ORG }}/${{ env.tag }}
+          subject-digest: ${{ steps.create_release.outputs.digest }}
+          push-to-registry: true
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.WF_REGISTRY_NAME }}/${{ env.WF_MULTIARCH_TARGETS }}/${{ env.WF_ORG }}/${{ env.tag }}
+          registry-username: ${{ env.WF_REGISTRY_USER }}
+          registry-password: ${{ secrets.QUAY_SECRET }}
+          format: 'spdx-json'
+          output-file: 'sbom.spdx.json'
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@v3
+        id: attest
+        with:
+          subject-name: ${{ env.WF_REGISTRY_NAME }}/${{ env.WF_MULTIARCH_TARGETS }}/${{ env.WF_ORG }}/${{ env.tag }}
+          subject-digest: ${{ steps.create_release.outputs.digest }}
+          sbom-path: 'sbom.spdx.json'
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,8 +71,8 @@ jobs:
             }
       - name: cosign-installer
         # You may pin to the exact commit or the version.
-        # uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003
+        #uses: sigstore/cosign-installer@v4.1.1
         #with:
         # cosign release version to be installed
         #cosign-release: # optional, default is v3.0.5


### PR DESCRIPTION
Updated the release workflow to include SBOM generation and image signing.

## Description
Added new jobs in ```release.yml``` workflow,
1. cosign-installer
2. Sign and verify the image with GitHub OIDC Token
3. Attest Provenance attestations
4. Generate SBOM
5. Attest SBOM

Solves: https://github.com/netobserv/netobserv-operator/issues/2490#issuecomment-4167949613
<!-- Fill-in description here -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores / Release Hardening**
  * Hardened the release pipeline with automated container image signing and verification using OIDC-based authentication.
  * Automatically generate and publish build provenance attestations and an SPDX SBOM for each release, and publish these security artifacts to the registry.
  * Improved release reliability by capturing the multi-architecture image digest during the build and using it for signing and attestation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->