### PR TITLE
NETOBSERV-2705: Filter null values from OTEL log Body

### DIFF
--- a/pkg/pipeline/encode/opentelemetry/opentelemetry.go
+++ b/pkg/pipeline/encode/opentelemetry/opentelemetry.go
@@ -245,7 +245,9 @@ func (e *EncodeOtlpLogs) LogWrite(entry config.GenericMap) {
 	now := time.Now()
 	sn := logs.INFO
 	st := "INFO"
-	msgByteArray, _ := json.Marshal(entry)
+	// Filter out null values before marshaling for Body
+	filteredEntry := filterNullValues(entry)
+	msgByteArray, _ := json.Marshal(filteredEntry)
 	msg := string(msgByteArray)
 	// TODO: Decide whether the content should be delivered as Body or as Attributes
 	lrc := logs.LogRecordConfig{
@@ -264,6 +266,16 @@ func (e *EncodeOtlpLogs) LogWrite(entry config.GenericMap) {
 		logs.WithSchemaURL(semconv.SchemaURL),
 	)
 	logger.Emit(logRecord)
+}
+
+func filterNullValues(entry config.GenericMap) config.GenericMap {
+	filtered := make(config.GenericMap, len(entry))
+	for k, v := range entry {
+		if v != nil {
+			filtered[k] = v
+		}
+	}
+	return filtered
 }
 
 func obtainAttributesFromEntry(entry config.GenericMap) *[]attribute.KeyValue {


### PR DESCRIPTION
## Summary

Companion PR to netobserv-operator#2706 for [NETOBSERV-2705](https://redhat.atlassian.net/browse/NETOBSERV-2705).

Filters out null values when marshaling flow entries to JSON for OpenTelemetry log record Body field. This prevents exporting fields for disabled agent features as null.

## Problem

Currently, the `LogWrite` function marshals the entire flow entry map (including null values) for the Body field:
```go
msgByteArray, _ := json.Marshal(entry)  // Line 248 - includes nulls
msg := string(msgByteArray)
```

While `obtainAttributesFromEntry` correctly skips null values for Attributes:
```go
case nil:
    continue  // Line 313-315
```

This inconsistency results in:
- **Body**: Contains fields like `"dns.errno":null,"drops.bytes":null` for disabled features
- **Attributes**: Clean, only contains fields with actual values

## Solution

Added `filterNullValues()` helper function to remove null entries before marshaling for the Body field.

### Changes
- `pkg/pipeline/encode/opentelemetry/opentelemetry.go`:
  - New `filterNullValues()` function to filter out null map entries
  - Updated `LogWrite()` to apply filter before `json.Marshal()`

## Testing

- All existing tests pass
- Verified with OTEL test (test_exporters.go:74977) after deploying operator with field filtering

## Related

- Operator PR: https://github.com/netobserv/netobserv-operator/pull/2706
- JIRA: [NETOBSERV-2705](https://redhat.atlassian.net/browse/NETOBSERV-2705)

**Note**: Both PRs need to be merged for the complete fix.