### PR TITLE
NETOBSERV-2705: fix transform generic on missing keys

### DIFF
--- a/pkg/pipeline/transform/transform_generic.go
+++ b/pkg/pipeline/transform/transform_generic.go
@@ -33,7 +33,6 @@ type Generic struct {
 // Transform transforms a flow to a new set of keys
 func (g *Generic) Transform(entry config.GenericMap) (config.GenericMap, bool) {
 	var outputEntry config.GenericMap
-	ok := true
 	glog.Tracef("Transform input = %v", entry)
 	if g.policy != "replace_keys" {
 		outputEntry = entry.Copy()
@@ -41,23 +40,24 @@ func (g *Generic) Transform(entry config.GenericMap) (config.GenericMap, bool) {
 		outputEntry = config.GenericMap{}
 	}
 	for _, transformRule := range g.rules {
-		if transformRule.Multiplier != 0 {
-			ok = g.performMultiplier(entry, transformRule, outputEntry)
-		} else {
-			outputEntry[transformRule.Output] = entry[transformRule.Input]
+		if value, hasKey := entry[transformRule.Input]; hasKey {
+			if transformRule.Multiplier != 0 {
+				g.multiply(value, transformRule, outputEntry)
+			} else {
+				outputEntry[transformRule.Output] = value
+			}
 		}
 	}
 	glog.Tracef("Transform output = %v", outputEntry)
-	return outputEntry, ok
+	return outputEntry, true
 }
 
 func (g *Generic) Update(_ config.StageParam) {
 	log.Warn("Transform Generic, update not supported")
 }
 
-func (g *Generic) performMultiplier(entry config.GenericMap, transformRule api.GenericTransformRule, outputEntry config.GenericMap) bool {
-	ok := true
-	switch val := entry[transformRule.Input].(type) {
+func (g *Generic) multiply(value any, transformRule api.GenericTransformRule, outputEntry config.GenericMap) {
+	switch val := value.(type) {
 	case int:
 		outputEntry[transformRule.Output] = transformRule.Multiplier * val
 	case uint:
@@ -83,10 +83,9 @@ func (g *Generic) performMultiplier(entry config.GenericMap, transformRule api.G
 	case float64:
 		outputEntry[transformRule.Output] = float64(transformRule.Multiplier) * val
 	default:
-		ok = false
-		glog.Errorf("%s not of numerical type; cannot perform multiplication", transformRule.Output)
+		// Do not log an error in fast data path, downgrade severity to debug; ideally it should be counted in error metrics
+		glog.Debugf("%s not of numerical type; cannot perform multiplication", transformRule.Output)
 	}
-	return ok
 }
 
 // NewTransformGeneric create a new transform

--- a/pkg/pipeline/transform/transform_generic_test.go
+++ b/pkg/pipeline/transform/transform_generic_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -49,6 +50,8 @@ parameters:
           output: Protocol
         - input: srcIP
           output: srcIP
+        - input: unused_key
+          output: UnusedKey
 `
 
 const testConfigTransformGenericMaintainTrue = `---
@@ -74,21 +77,37 @@ parameters:
           output: Protocol
         - input: srcIP
           output: srcIP
+        - input: unused_key
+          output: UnusedKey
 `
 
-func getGenericExpectedOutputShort() config.GenericMap {
-	return config.GenericMap{
+func TestNewTransformGenericMaintainFalse(t *testing.T) {
+	newTransform := InitNewTransformGeneric(t, testConfigTransformGenericMaintainFalse)
+	transformGeneric := newTransform.(*Generic)
+	require.Len(t, transformGeneric.rules, 7)
+
+	input := test.GetIngestMockEntry(false)
+	output, ok := transformGeneric.Transform(input)
+	require.True(t, ok)
+	require.Equal(t, config.GenericMap{
 		"SrcAddr":  "10.0.0.1",
 		"srcIP":    "10.0.0.1",
 		"SrcPort":  11777,
 		"Protocol": "tcp",
 		"DstAddr":  "20.0.0.2",
 		"DstPort":  22,
-	}
+	}, output)
 }
 
-func getGenericExpectedOutputLong() config.GenericMap {
-	return config.GenericMap{
+func TestNewTransformGenericMaintainTrue(t *testing.T) {
+	newTransform := InitNewTransformGeneric(t, testConfigTransformGenericMaintainTrue)
+	transformGeneric := newTransform.(*Generic)
+	require.Len(t, transformGeneric.rules, 7)
+
+	input := test.GetIngestMockEntry(false)
+	output, ok := transformGeneric.Transform(input)
+	require.True(t, ok)
+	require.Equal(t, config.GenericMap{
 		"SrcAddr":      "10.0.0.1",
 		"SrcPort":      11777,
 		"Protocol":     "tcp",
@@ -105,31 +124,7 @@ func getGenericExpectedOutputLong() config.GenericMap {
 		"message":      "test message",
 		"dstIP":        "20.0.0.2",
 		"dstPort":      22,
-	}
-}
-
-func TestNewTransformGenericMaintainFalse(t *testing.T) {
-	newTransform := InitNewTransformGeneric(t, testConfigTransformGenericMaintainFalse)
-	transformGeneric := newTransform.(*Generic)
-	require.Len(t, transformGeneric.rules, 6)
-
-	input := test.GetIngestMockEntry(false)
-	output, ok := transformGeneric.Transform(input)
-	require.True(t, ok)
-	expectedOutput := getGenericExpectedOutputShort()
-	require.Equal(t, expectedOutput, output)
-}
-
-func TestNewTransformGenericMaintainTrue(t *testing.T) {
-	newTransform := InitNewTransformGeneric(t, testConfigTransformGenericMaintainTrue)
-	transformGeneric := newTransform.(*Generic)
-	require.Len(t, transformGeneric.rules, 6)
-
-	input := test.GetIngestMockEntry(false)
-	output, ok := transformGeneric.Transform(input)
-	require.True(t, ok)
-	expectedOutput := getGenericExpectedOutputLong()
-	require.Equal(t, expectedOutput, output)
+	}, output)
 }
 
 func InitNewTransformGeneric(t *testing.T, configFile string) Transformer {
@@ -151,6 +146,11 @@ func Test_Transform_Multiplier(t *testing.T) {
 				Output:     "output_var",
 				Multiplier: 10,
 			},
+			{
+				Input:      "unused_key",
+				Output:     "unused_multiplied",
+				Multiplier: 10,
+			},
 		},
 	}
 
@@ -161,27 +161,39 @@ func Test_Transform_Multiplier(t *testing.T) {
 	}
 	output, ok := newGenericTransform.Transform(entry)
 	require.True(t, ok)
-	require.Equal(t, 30, output["output_var"])
-	require.Equal(t, 7, output["other_var"])
+	assert.Equal(t, config.GenericMap{
+		"input_var":  3,
+		"output_var": 30,
+		"other_var":  7,
+	}, output)
 
 	entry = config.GenericMap{
 		"input_var": 4.0,
 	}
 	output, ok = newGenericTransform.Transform(entry)
 	require.True(t, ok)
-	require.Equal(t, 40.0, output["output_var"])
+	assert.Equal(t, config.GenericMap{
+		"input_var":  4.0,
+		"output_var": 40.0,
+	}, output)
 
 	entry = config.GenericMap{
 		"input_var": "not_a_number",
 	}
-	_, ok = newGenericTransform.Transform(entry)
-	require.False(t, ok)
+	output, ok = newGenericTransform.Transform(entry)
+	require.True(t, ok)
+	assert.Equal(t, config.GenericMap{
+		"input_var": "not_a_number",
+	}, output)
 
 	entry = config.GenericMap{
 		"input_var": true,
 	}
-	_, ok = newGenericTransform.Transform(entry)
-	require.False(t, ok)
+	output, ok = newGenericTransform.Transform(entry)
+	require.True(t, ok)
+	assert.Equal(t, config.GenericMap{
+		"input_var": true,
+	}, output)
 
 	entry = config.GenericMap{
 		"input_var": -4.0,


### PR DESCRIPTION

## Description

When an input key is missing in the flow, transform-generic should not add the transformed key to the output. E.g. if input has no "DnsName" output should not have "dns.name".

Additionnally, relax error handling with the multiplier feature (for info this feature is not used with the operator). Failing to multiply should not dismiss the whole flow like it's done currently.

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test flp-node-density-heavy-25nodes`_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of non-numeric input values during numeric multiplication transformations, ensuring operations complete successfully regardless of input type.
  * Enhanced diagnostic logging capabilities in the transformation pipeline for better troubleshooting and observability.

* **Refactor**
  * Streamlined internal transformation logic by removing unnecessary complexity in multiplier operation handling, improving code maintainability and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->