### PR TITLE
Fix S3 access key secret not being redacted in logs

### DIFF
--- a/pkg/api/encode_s3.go
+++ b/pkg/api/encode_s3.go
@@ -21,7 +21,7 @@ type EncodeS3 struct {
 	Account                string                 `yaml:"account" json:"account" doc:"tenant id for this flow collector"`
 	Endpoint               string                 `yaml:"endpoint" json:"endpoint" doc:"address of s3 server"`
 	AccessKeyID            string                 `yaml:"accessKeyId" json:"accessKeyId" doc:"username to connect to server"`
-	SecretAccessKey        string                 `yaml:"secretAccessKey" json:"secretAccessKey" doc:"password to connect to server"`
+	SecretAccessKey        RedactedText           `yaml:"secretAccessKey" json:"secretAccessKey" doc:"password to connect to server"`
 	Bucket                 string                 `yaml:"bucket" json:"bucket" doc:"bucket into which to store objects"`
 	WriteTimeout           Duration               `yaml:"writeTimeout,omitempty" json:"writeTimeout,omitempty" doc:"timeout (in seconds) for write operation"`
 	BatchSize              int                    `yaml:"batchSize,omitempty" json:"batchSize,omitempty" doc:"limit on how many flows will be buffered before being sent to an object"`

--- a/pkg/api/redacted.go
+++ b/pkg/api/redacted.go
@@ -1,0 +1,16 @@
+package api
+
+import (
+	"fmt"
+	"log/slog"
+)
+
+type RedactedText string
+
+func (RedactedText) Format(f fmt.State, _ rune) {
+	_, _ = f.Write([]byte("[REDACTED]"))
+}
+
+func (RedactedText) LogValue() slog.Value {
+	return slog.StringValue("[REDACTED]")
+}

--- a/pkg/pipeline/encode/encode_s3.go
+++ b/pkg/pipeline/encode/encode_s3.go
@@ -32,7 +32,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"github.com/prometheus/client_golang/prometheus"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -42,6 +42,7 @@ const (
 
 var (
 	defaultTimeOut = api.Duration{Duration: 60 * time.Second}
+	s3log          = logrus.WithField("component", "encode.S3")
 )
 
 type encodeS3 struct {
@@ -80,8 +81,8 @@ func (s *encodeS3) writeObject() error {
 	hour := fmt.Sprintf("%02d", now.Hour())
 	seq := fmt.Sprintf("%08d", s.sequenceNumber)
 	objectName := s.s3Params.Account + "/year=" + year + "/month=" + month + "/day=" + day + "/hour=" + hour + "/stream-id=" + s.streamID + "/" + seq
-	log.Debugf("S3 writeObject: objectName = %s", objectName)
-	log.Debugf("S3 writeObject: object = %v", object)
+	s3log.Tracef("S3 writeObject: objectName = %s", objectName)
+	s3log.Tracef("S3 writeObject: object = %v", object)
 	s.pendingEntries = s.pendingEntries[nLogs:]
 	s.intervalStartTime = now
 	s.expiryTime = now.Add(s.s3Params.WriteTimeout.Duration)
@@ -89,7 +90,7 @@ func (s *encodeS3) writeObject() error {
 	// send object to object store
 	err := s.s3Writer.putObject(s.s3Params.Bucket, objectName, object)
 	if err != nil {
-		log.Errorf("error in writing object: %v", err)
+		s3log.Errorf("error in writing object: %v", err)
 	}
 	return err
 }
@@ -110,20 +111,19 @@ func (s *encodeS3) GenerateStoreHeader(flows []config.GenericMap, startTime time
 }
 
 func (s *encodeS3) Update(_ config.StageParam) {
-	log.Warn("Encode S3 Writer, update not supported")
+	s3log.Warn("Encode S3 Writer, update not supported")
 }
 
 func (s *encodeS3) createObjectTimeoutLoop() {
-	log.Debugf("entering createObjectTimeoutLoop")
 	ticker := time.NewTicker(s.s3Params.WriteTimeout.Duration)
 	for {
 		select {
 		case <-s.exitChan:
-			log.Debugf("exiting createObjectTimeoutLoop because of signal")
+			s3log.Debugf("exiting createObjectTimeoutLoop because of signal")
 			return
 		case <-ticker.C:
 			now := time.Now()
-			log.Debugf("time now = %v, expiryTime = %v", now, s.expiryTime)
+			s3log.Debugf("time now = %v, expiryTime = %v", now, s.expiryTime)
 			s.mutex.Lock()
 			_ = s.writeObject()
 			s.mutex.Unlock()
@@ -133,7 +133,6 @@ func (s *encodeS3) createObjectTimeoutLoop() {
 
 // Encode queues entries to be sent to object store
 func (s *encodeS3) Encode(entry config.GenericMap) {
-	log.Debugf("Encode S3, entry = %v", entry)
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	s.pendingEntries = append(s.pendingEntries, entry)
@@ -149,7 +148,7 @@ func NewEncodeS3(opMetrics *operational.Metrics, params config.StageParam) (Enco
 	if params.Encode != nil && params.Encode.S3 != nil {
 		configParams = *params.Encode.S3
 	}
-	log.Debugf("NewEncodeS3, config = %v", configParams)
+	s3log.Debugf("NewEncodeS3, config = %v", configParams)
 	s3Writer := &encodeS3Writer{
 		s3Params: &configParams,
 	}
@@ -183,19 +182,18 @@ func (e *encodeS3Writer) connectS3(config *api.EncodeS3) (*minio.Client, error) 
 	}
 	s3Client, err := minio.New(config.Endpoint, &minioOptions)
 	if err != nil {
-		log.Errorf("Error when creating S3 client: %v", err)
+		s3log.Errorf("Error when creating S3 client: %v", err)
 		return nil, err
 	}
 
 	found, err := s3Client.BucketExists(context.Background(), config.Bucket)
 	if err != nil {
-		log.Errorf("Error accessing S3 bucket: %v", err)
+		s3log.Errorf("Error accessing S3 bucket: %v", err)
 		return nil, err
 	}
 	if found {
-		log.Infof("S3 Bucket %s found", config.Bucket)
+		s3log.Infof("S3 Bucket %s found", config.Bucket)
 	}
-	log.Debugf("s3Client = %#v", s3Client) // s3Client is now setup
 	return s3Client, nil
 }
 
@@ -210,16 +208,14 @@ func (e *encodeS3Writer) putObject(bucket string, objectName string, object map[
 	b := new(bytes.Buffer)
 	err := json.NewEncoder(b).Encode(object)
 	if err != nil {
-		log.Errorf("error encoding object: %v", err)
+		s3log.Errorf("error encoding object: %v", err)
 		return err
 	}
-	log.Debugf("encoded object = %v", b)
 	// TBD: add necessary headers such as authorization (token), gzip, md5, etc
-	uploadInfo, err := e.s3Client.PutObject(context.Background(), bucket, objectName, b, int64(b.Len()), minio.PutObjectOptions{ContentType: "application/octet-stream"})
-	log.Debugf("uploadInfo = %v", uploadInfo)
+	_, err = e.s3Client.PutObject(context.Background(), bucket, objectName, b, int64(b.Len()), minio.PutObjectOptions{ContentType: "application/octet-stream"})
 	return err
 }
 
 func (e *encodeS3Writer) Update(_ config.StageParam) {
-	log.Warn("Encode S3 Writer, update not supported")
+	s3log.Warn("Encode S3 Writer, update not supported")
 }

--- a/pkg/pipeline/encode/encode_s3.go
+++ b/pkg/pipeline/encode/encode_s3.go
@@ -178,7 +178,7 @@ func NewEncodeS3(opMetrics *operational.Metrics, params config.StageParam) (Enco
 func (e *encodeS3Writer) connectS3(config *api.EncodeS3) (*minio.Client, error) {
 	// Initialize s3 client object.
 	minioOptions := minio.Options{
-		Creds:  credentials.NewStaticV4(config.AccessKeyID, config.SecretAccessKey, ""),
+		Creds:  credentials.NewStaticV4(config.AccessKeyID, string(config.SecretAccessKey), ""),
 		Secure: config.Secure,
 	}
 	s3Client, err := minio.New(config.Endpoint, &minioOptions)

--- a/pkg/pipeline/encode/encode_s3_test.go
+++ b/pkg/pipeline/encode/encode_s3_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,6 +91,14 @@ func initNewEncodeS3(t *testing.T, configString string) *encodeS3 {
 	return encodeS3
 }
 
+func Test_RedactedKey(t *testing.T) {
+	v, cfg := test.InitConfig(t, testS3Config1)
+	require.NotNil(t, v)
+
+	asString := fmt.Sprintf("%v", *cfg.Parameters[0].Encode.S3)
+	assert.Equal(t, "{account1 1.2.3.4:9000 accessKey1 [REDACTED] bucket1 1s 3 false map[key1:val1 key2:val2 key3:val3 key4:val4]}", asString)
+}
+
 func Test_EncodeS3(t *testing.T) {
 	utils.InitExitChannel()
 	encodeS3 := initNewEncodeS3(t, testS3Config1)
@@ -97,7 +106,7 @@ func Test_EncodeS3(t *testing.T) {
 	require.Equal(t, "bucket1", encodeS3.s3Params.Bucket)
 	require.Equal(t, "account1", encodeS3.s3Params.Account)
 	require.Equal(t, "accessKey1", encodeS3.s3Params.AccessKeyID)
-	require.Equal(t, "secretAccessKey1", encodeS3.s3Params.SecretAccessKey)
+	require.Equal(t, "secretAccessKey1", string(encodeS3.s3Params.SecretAccessKey))
 
 	entries := test.GetExtractMockEntries2()
 	for i := range entries {


### PR DESCRIPTION
## Description

Configured S3 access key was potentially exposed when running flowlogs-pipeline with "debug" log level.

This only affects users who configured S3 exports with overridden log level (default being "error"). NetObserv operator users are not affected, as the S3 exporting API is not exposed there.

<!-- Fill-in description here -->

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test flp-node-density-heavy-25nodes`_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3 secret credentials are now consistently redacted in displayed output and structured logs, showing `"[REDACTED]"` instead of sensitive values.

* **Bug Fixes**
  * Improved S3 logging to use a dedicated component logger, reducing exposure of verbose internal details.

* **Tests**
  * Added coverage to verify that the configured S3 secret access key is redacted while other S3 parameters remain visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->