### PR TITLE
Fix pprof broad exposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,13 @@ Usage:
 Flags:  
       --config string              config file (default is $HOME/.flowlogs-pipeline)  
       --dynamicParameters string   json of configmap location for dynamic parameters  
-      --health.address string      Health server address (default "0.0.0.0")  
-      --health.port int            Health server port (default: disable health server)   
+      --healthAddr string          Health server address such as ':8080' (default: disabled)  
   -h, --help                       help for flowlogs-pipeline  
       --log-level string           Log level: debug, info, warning, error (default "error")  
       --metricsSettings string     json for global metrics settings  
       --parameters string          json of config file parameters field  
       --pipeline string            json of config file pipeline field  
-      --profile.port int           Go pprof tool port (default: disabled)
+      --pprofAddr string           Go pprof address such as '127.0.0.1:6060', used for profiling (default: disabled). Do not expose publicly.
 ```
 <!---END-AUTO-flowlogs-pipeline_help--->
 

--- a/cmd/flowlogs-pipeline/main.go
+++ b/cmd/flowlogs-pipeline/main.go
@@ -193,7 +193,7 @@ func run() {
 	if opts.PprofAddr != "" {
 		go func() {
 			log.WithField("addr", opts.PprofAddr).Info("starting PProf HTTP listener")
-			srv := server.Default(&http.Server{Addr: opts.PprofAddr})
+			srv := server.Default(&http.Server{Addr: opts.PprofAddr, Handler: http.DefaultServeMux})
 			log.WithError(srv.ListenAndServe()).
 				Error("PProf HTTP listener stopped working")
 		}()

--- a/cmd/flowlogs-pipeline/main.go
+++ b/cmd/flowlogs-pipeline/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"github.com/netobserv/flowlogs-pipeline/pkg/prometheus"
+	"github.com/netobserv/flowlogs-pipeline/pkg/server"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -142,9 +143,8 @@ func initFlags() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", fmt.Sprintf("config file (default is $HOME/%s)", defaultLogFileName))
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "error", "Log level: debug, info, warning, error")
-	rootCmd.PersistentFlags().StringVar(&opts.Health.Address, "health.address", "0.0.0.0", "Health server address")
-	rootCmd.PersistentFlags().IntVar(&opts.Health.Port, "health.port", 0, "Health server port (default: disable health server) ")
-	rootCmd.PersistentFlags().IntVar(&opts.Profile.Port, "profile.port", 0, "Go pprof tool port (default: disabled)")
+	rootCmd.PersistentFlags().StringVar(&opts.HealthAddr, "healthAddr", "", "Health server address such as ':8080' (default: disabled)")
+	rootCmd.PersistentFlags().StringVar(&opts.PprofAddr, "pprofAddr", "", "Go pprof address such as '127.0.0.1:6060', used for profiling (default: disabled). Do not expose publicly.")
 	rootCmd.PersistentFlags().StringVar(&opts.PipeLine, "pipeline", "", "json of config file pipeline field")
 	rootCmd.PersistentFlags().StringVar(&opts.Parameters, "parameters", "", "json of config file parameters field")
 	rootCmd.PersistentFlags().StringVar(&opts.DynamicParameters, "dynamicParameters", "", "json of configmap location for dynamic parameters")
@@ -190,17 +190,18 @@ func run() {
 		os.Exit(1)
 	}
 
-	if opts.Profile.Port != 0 {
+	if opts.PprofAddr != "" {
 		go func() {
-			log.WithField("port", opts.Profile.Port).Info("starting PProf HTTP listener")
-			log.WithError(http.ListenAndServe(fmt.Sprintf(":%d", opts.Profile.Port), nil)).
+			log.WithField("addr", opts.PprofAddr).Info("starting PProf HTTP listener")
+			srv := server.Default(&http.Server{Addr: opts.PprofAddr})
+			log.WithError(srv.ListenAndServe()).
 				Error("PProf HTTP listener stopped working")
 		}()
 	}
 
 	// Start health report server
 	var healthServer *http.Server
-	if opts.Health.Port > 0 {
+	if opts.HealthAddr != "" {
 		healthServer = operational.NewHealthServer(&opts, mainPipeline.IsAlive, mainPipeline.IsReady)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -31,8 +31,8 @@ type Options struct {
 	Parameters        string
 	DynamicParameters string
 	MetricsSettings   string
-	Health            Health
-	Profile           Profile
+	HealthAddr        string
+	PprofAddr         string
 }
 
 type Root struct {
@@ -53,15 +53,6 @@ type DynamicParameters struct {
 
 type HotReloadStruct struct {
 	Parameters []StageParam `yaml:"parameters,omitempty" json:"parameters,omitempty"`
-}
-
-type Health struct {
-	Address string
-	Port    int
-}
-
-type Profile struct {
-	Port int
 }
 
 // MetricsSettings is similar to api.PromEncode, but is global to the application, ie. it also works with operational metrics.

--- a/pkg/operational/health.go
+++ b/pkg/operational/health.go
@@ -18,7 +18,6 @@
 package operational
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -30,19 +29,18 @@ import (
 
 func NewHealthServer(opts *config.Options, isAlive healthcheck.Check, isReady healthcheck.Check) *http.Server {
 	handler := healthcheck.NewHandler()
-	address := fmt.Sprintf("%s:%d", opts.Health.Address, opts.Health.Port)
 	handler.AddLivenessCheck("PipelineCheck", isAlive)
 	handler.AddReadinessCheck("PipelineCheck", isReady)
 
 	server := server.Default(&http.Server{
 		Handler: handler,
-		Addr:    address,
+		Addr:    opts.HealthAddr,
 	})
 
 	go func() {
 		for {
 			err := server.ListenAndServe()
-			log.Errorf("http.ListenAndServe error %v", err)
+			log.Errorf("Health server ListenAndServe error: %v", err)
 			time.Sleep(60 * time.Second)
 		}
 	}()

--- a/pkg/pipeline/health_test.go
+++ b/pkg/pipeline/health_test.go
@@ -18,7 +18,6 @@
 package pipeline
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -35,7 +34,6 @@ func TestNewHealthServer(t *testing.T) {
 
 	type args struct {
 		pipeline Pipeline
-		port     int
 		address  string
 	}
 	type want struct {
@@ -47,28 +45,26 @@ func TestNewHealthServer(t *testing.T) {
 		args args
 		want want
 	}{
-		{name: "pipeline running", args: args{pipeline: Pipeline{IsRunning: true}, port: 7000, address: "0.0.0.0"}, want: want{statusCode: 200}},
-		{name: "pipeline not running", args: args{pipeline: Pipeline{IsRunning: false}, port: 7001, address: "0.0.0.0"}, want: want{statusCode: 503}},
+		{name: "pipeline running", args: args{pipeline: Pipeline{IsRunning: true}, address: "0.0.0.0:7000"}, want: want{statusCode: 200}},
+		{name: "pipeline not running", args: args{pipeline: Pipeline{IsRunning: false}, address: "0.0.0.0:7001"}, want: want{statusCode: 503}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			opts := config.Options{Health: config.Health{Port: tt.args.port, Address: tt.args.address}}
-			expectedAddr := fmt.Sprintf("%s:%d", opts.Health.Address, opts.Health.Port)
+			opts := config.Options{HealthAddr: tt.args.address}
 			server := operational.NewHealthServer(&opts, tt.args.pipeline.IsAlive, tt.args.pipeline.IsReady)
 			require.NotNil(t, server)
-			require.Equal(t, expectedAddr, server.Addr)
 
 			client := &http.Client{}
 
 			time.Sleep(time.Second)
-			readyURL := url.URL{Scheme: "http", Host: expectedAddr, Path: readyPath}
+			readyURL := url.URL{Scheme: "http", Host: tt.args.address, Path: readyPath}
 			var resp, err = client.Get(readyURL.String())
 			require.NoError(t, err)
 			require.Equal(t, tt.want.statusCode, resp.StatusCode)
 
-			liveURL := url.URL{Scheme: "http", Host: expectedAddr, Path: livePath}
+			liveURL := url.URL{Scheme: "http", Host: tt.args.address, Path: livePath}
 			resp, err = client.Get(liveURL.String())
 			require.NoError(t, err)
 			require.Equal(t, tt.want.statusCode, resp.StatusCode)

--- a/pkg/prometheus/prom_server.go
+++ b/pkg/prometheus/prom_server.go
@@ -116,7 +116,7 @@ func StartServerAsync(conn *api.PromConnectionInfo, regName string, registry pro
 			err = httpServer.ListenAndServe()
 		}
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			maybePanic("error in http.ListenAndServe: %v", err)
+			maybePanic("Prometheus server error in ListenAndServe: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
## Description

When pprof was enabled, it was exposed on ":(port)" which stands for all net interfaces.

Settings are changed so the user controls what address to use. For example, they can configure it with "127.0.0.1:6060" to restrict to the local loop (more secured), or keep ":6060" or "0.0.0.0:6060" for a broader exposition.

In netobserv, this is managed by the operator, which will force using the local loop.

Additionally, the pprof server now uses the common safeguards against resource exhaustion attacks

*Breaking changes*:
- config for pprof changed from "--profile.port" (or in json "profile: { port: ...}") to "--pprofAddr" (or in json "pprofAddr: ...")
- for consistency, same change is applied to the health server config: "--health.port" and "--health.address" are merged as "--healthAddr", or in json, the health nested structure is now a flat "healthAddr: ''".

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
- operator: https://github.com/netobserv/netobserv-operator/pull/2821
- agent: https://github.com/netobserv/netobserv-ebpf-agent/pull/996

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test flp-node-density-heavy-25nodes`_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced separate health and profiling server configuration flags with address-based options (`--healthAddr`, `--pprofAddr`), which are disabled by default when empty.
  * Health and profiling listeners now start based on whether an address is provided.
* **Documentation**
  * Updated README CLI help text to reflect the new flag names.
* **Tests**
  * Updated health server tests to use the new address-based configuration.
* **Bug Fixes**
  * Improved Prometheus server error message wording when the listener fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->