### PR TITLE
Minor security hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,15 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: ".github"
+    schedule:
+      interval: "monthly"
+  - package-ecosystem: "docker"
+    directory: "contrib/docker"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/workflows/build_image_pr.yml
+++ b/.github/workflows/build_image_pr.yml
@@ -16,7 +16,7 @@ jobs:
     name: Build PR image and upload artifact
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: Install make
@@ -24,7 +24,7 @@ jobs:
       - name: build and save image
         run: OCI_BUILD_OPTS="--label quay.expires-after=2w" IMAGE=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:tmp CLEAN_BUILD=1 make tar-image
       - name: upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pr
           path: out/

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,11 +16,11 @@ jobs:
     - name: install make
       run: sudo apt-get install make
     - name: set up go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '1.26'
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: run build

--- a/.github/workflows/pull_request_e2e.yml
+++ b/.github/workflows/pull_request_e2e.yml
@@ -16,11 +16,11 @@ jobs:
     - name: install make
       run: sudo apt-get install make
     - name: set up go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '1.26'
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: run build

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -20,7 +20,7 @@ jobs:
       - name: install make
         run: sudo apt-get install make
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
       - name: docker login to quay.io
@@ -46,11 +46,12 @@ jobs:
     - name: install make
       run: sudo apt-get install make
     - name: set up go 1.x
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version: '1.26'
+        cache: false
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         persist-credentials: false
     - name: Test

--- a/.github/workflows/push_image_pr.yml
+++ b/.github/workflows/push_image_pr.yml
@@ -41,7 +41,7 @@ jobs:
           echo "short_sha=$(echo ${head_sha::8})" >> $GITHUB_ENV
           echo "main_image=${{ env.WF_REGISTRY }}/${{ env.WF_IMAGE }}:${head_sha::8}" >> $GITHUB_ENV
       - name: download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: pr
           run-id: ${{github.event.workflow_run.id }}
@@ -59,7 +59,7 @@ jobs:
       - name: push images
         run: |
           DOCKER_BUILDKIT=1 docker push ${{ env.main_image }}
-      - uses: actions/github-script@v9
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -50,66 +50,32 @@ jobs:
           registry: ${{ env.WF_REGISTRY_NAME }}
 
       - name: build and push manifest with images
-        run: |
-          MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" \
-          IMAGE_ORG=${{ env.WF_ORG }} \
-          VERSION=${{ env.tag }} \
-          CLEAN_BUILD=1 make images
-
-      - name: capture image digest
-        id: image_digest
-        run: |
-          digest=$(docker buildx imagetools inspect \
-            ${{ env.WF_IMAGE_NAME }}:${{ env.tag }} \
-            --format '{{json .Manifest.Digest}}' | tr -d '"')
-
-          echo "digest=$digest" >> "$GITHUB_ENV"
+        run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} CLEAN_BUILD=1 make images
 
       - name: extract binaries
         run: MULTIARCH_TARGETS="${{ env.WF_MULTIARCH_TARGETS }}" IMAGE_ORG=${{ env.WF_ORG }} VERSION=${{ env.tag }} make extract-binaries
 
-      - name: create draft release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.tag }}
-          release_name: ${{ env.tag }}
-          draft: true
-          prerelease: false
-
-      - name: upload binaries
-        uses: actions/github-script@v9
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            const fs = require('fs').promises;
-            const upload_url = '${{ steps.create_release.outputs.upload_url }}';
-            for (let file of await fs.readdir('./release-assets')) {
-              console.log('uploading', file);
-              await github.rest.repos.uploadReleaseAsset({
-                url: upload_url,
-                name: file,
-                data: await fs.readFile(`./release-assets/${file}`)
-              });
-            }
+      - name: capture image digest
+        id: image_digest
+        run: |
+          digest=$(docker buildx imagetools inspect ${{ env.WF_IMAGE_NAME }}:${{ env.tag }} \
+            --format '{{json .Manifest.Digest}}' | tr -d '"')
+          echo "digest=$digest" >> "$GITHUB_ENV"
+          echo "${{ env.WF_IMAGE_NAME }}@$digest" >> ./release-assets/images
 
       - name: cosign-installer
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003
 
       - name: Sign and verify the image with GitHub OIDC Token
         run: |
-          cosign sign --yes \
-            ${{ env.WF_IMAGE_NAME }}@${{ env.digest }}
+          cosign sign --yes ${{ env.WF_IMAGE_NAME }}@${{ env.digest }}
 
-          cosign verify \
-            ${{ env.WF_IMAGE_NAME }}@${{ env.digest }} \
+          cosign verify ${{ env.WF_IMAGE_NAME }}@${{ env.digest }} \
             --certificate-identity=https://github.com/netobserv/flowlogs-pipeline/.github/workflows/release.yml@refs/tags/${{ env.tag }} \
             --certificate-oidc-issuer=https://token.actions.githubusercontent.com
 
       - name: Attest Provenance attestations
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
         with:
           subject-name: ${{ env.WF_IMAGE_NAME }}
           subject-digest: ${{ env.digest }}
@@ -119,16 +85,22 @@ jobs:
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ${{ env.WF_IMAGE_NAME }}@${{ env.digest }}
-          registry-username: ${{ env.WF_REGISTRY_USER }}
-          registry-password: ${{ secrets.QUAY_SECRET }}
           format: 'spdx-json'
-          output-file: 'sbom.spdx.json'
+          output-file: './release-assets/sbom.spdx.json'
 
       - name: Attest SBOM
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4
-        id: attest
         with:
           subject-name: ${{ env.WF_IMAGE_NAME }}
           subject-digest: ${{ env.digest }}
-          sbom-path: 'sbom.spdx.json'
+          sbom-path: './release-assets/sbom.spdx.json'
           push-to-registry: true
+
+      - name: create draft release and upload binaries
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        with:
+          tag_name: ${{ env.tag }}
+          name: ${{ env.tag }}
+          draft: true
+          prerelease: false
+          files: ./release-assets/*

--- a/contrib/kubernetes/deployment.yaml
+++ b/contrib/kubernetes/deployment.yaml
@@ -23,12 +23,16 @@ spec:
             - containerPort: 6343
             - containerPort: 2055
             - containerPort: 2056
-          # When deployed on KinD, the image is pre-pushed to KinD from the local registry.
-          # When deployed on OCP, OCP will pull the image from quay.io.
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: configuration
               mountPath: "/etc/flowlogs-pipeline/"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: [ALL]
       volumes:
         - name: configuration
           configMap:
@@ -82,9 +86,25 @@ kind: ClusterRole
 metadata:
   name: flowlogs-pipeline
 rules:
-  - apiGroups: ["*"]
-    resources: ["*"]
-    verbs: ["*"]
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - replicasets
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/api/tls.go
+++ b/pkg/api/tls.go
@@ -34,6 +34,7 @@ type ClientTLS struct {
 func (c *ClientTLS) Build() (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: c.InsecureSkipVerify,
+		MinVersion:         tls.VersionTLS13,
 	}
 	if c.CACertPath != "" {
 		caCert, err := os.ReadFile(c.CACertPath)


### PR DESCRIPTION
## Description

Same as https://github.com/netobserv/netobserv-operator/pull/2815 

- sha pinning of the remaining github-owned actions
- dependabot setting for docker & actions
- force tls client minversion
- remove bad practice promoted in sample file (wildcard permissions)

## Dependencies

<!-- List here any related PRs with links, that need to be pulled also for testing -->
n/a

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test flp-node-density-heavy-25nodes`_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated update checks for GitHub Actions and Docker-related content.
* **Bug Fixes**
  * Improved workflow reliability by pinning GitHub Actions steps and dependencies to fixed revisions across build, PR, and image workflows.
  * Streamlined draft release creation and asset uploading, and updated SBOM output/attestation references.
  * Enforced stronger TLS requirements by requiring TLS 1.3 for client connections.
* **Chores**
  * Hardened Kubernetes deployment security settings and tightened RBAC permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->