### PR TITLE
NETOBSERV-2515: Use TLS environment variables for TLS config if present

### DIFF
--- a/cmd/flowlogs-pipeline/main.go
+++ b/cmd/flowlogs-pipeline/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/k8scache"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"github.com/netobserv/flowlogs-pipeline/pkg/prometheus"
+	"github.com/netobserv/flowlogs-pipeline/pkg/tlsprofile"
 	"github.com/netobserv/flowlogs-pipeline/pkg/server"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -351,9 +352,10 @@ func createServerTLSConfig(cfg *config.K8sCacheServer) (credentials.TransportCre
 
 	tlsConfig := &tls.Config{
 		Certificates: []tls.Certificate{cert},
-		ClientAuth:   tls.NoClientCert, // Default: no client cert required
-		MinVersion:   tls.VersionTLS13, // Enforce TLS 1.3+ to prevent downgrade attacks
+		ClientAuth:   tls.NoClientCert,
+		MinVersion:   tls.VersionTLS13,
 	}
+	tlsprofile.Apply(tlsConfig)
 
 	// If CA is provided, require and verify client certificates
 	if cfg.TLSCAPath != "" {

--- a/cmd/flowlogs-pipeline/main.go
+++ b/cmd/flowlogs-pipeline/main.go
@@ -41,8 +41,8 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/k8scache"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
 	"github.com/netobserv/flowlogs-pipeline/pkg/prometheus"
-	"github.com/netobserv/flowlogs-pipeline/pkg/tlsprofile"
 	"github.com/netobserv/flowlogs-pipeline/pkg/server"
+	"github.com/netobserv/flowlogs-pipeline/pkg/tlsprofile"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -355,7 +355,9 @@ func createServerTLSConfig(cfg *config.K8sCacheServer) (credentials.TransportCre
 		ClientAuth:   tls.NoClientCert,
 		MinVersion:   tls.VersionTLS13,
 	}
-	tlsprofile.Apply(tlsConfig)
+	if _, err := tlsprofile.Apply(tlsConfig); err != nil {
+		return nil, fmt.Errorf("invalid TLS profile override: %w", err)
+	}
 
 	// If CA is provided, require and verify client certificates
 	if cfg.TLSCAPath != "" {

--- a/pkg/api/tls.go
+++ b/pkg/api/tls.go
@@ -22,8 +22,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"os"
-
-	"github.com/netobserv/flowlogs-pipeline/pkg/tlsprofile"
 )
 
 type ClientTLS struct {
@@ -38,7 +36,6 @@ func (c *ClientTLS) Build() (*tls.Config, error) {
 		InsecureSkipVerify: c.InsecureSkipVerify,
 		MinVersion:         tls.VersionTLS13,
 	}
-	tlsprofile.Apply(tlsConfig)
 	if c.CACertPath != "" {
 		caCert, err := os.ReadFile(c.CACertPath)
 		if err != nil {

--- a/pkg/api/tls.go
+++ b/pkg/api/tls.go
@@ -22,6 +22,8 @@ import (
 	"crypto/x509"
 	"errors"
 	"os"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/tlsprofile"
 )
 
 type ClientTLS struct {
@@ -36,6 +38,7 @@ func (c *ClientTLS) Build() (*tls.Config, error) {
 		InsecureSkipVerify: c.InsecureSkipVerify,
 		MinVersion:         tls.VersionTLS13,
 	}
+	tlsprofile.Apply(tlsConfig)
 	if c.CACertPath != "" {
 		caCert, err := os.ReadFile(c.CACertPath)
 		if err != nil {

--- a/pkg/api/write_grpc.go
+++ b/pkg/api/write_grpc.go
@@ -3,8 +3,9 @@ package api
 import "errors"
 
 type WriteGRPC struct {
-	TargetHost string `yaml:"targetHost,omitempty" json:"targetHost,omitempty" doc:"the host name or IP of the target Flow collector"`
-	TargetPort int    `yaml:"targetPort,omitempty" json:"targetPort,omitempty" doc:"the port of the target Flow collector"`
+	TargetHost string     `yaml:"targetHost,omitempty" json:"targetHost,omitempty" doc:"the host name or IP of the target Flow collector"`
+	TargetPort int        `yaml:"targetPort,omitempty" json:"targetPort,omitempty" doc:"the port of the target Flow collector"`
+	TLS        *ClientTLS `yaml:"tls,omitempty" json:"tls,omitempty" doc:"TLS client configuration"`
 }
 
 func (w *WriteGRPC) Validate() error {

--- a/pkg/pipeline/ingest/ingest_grpc.go
+++ b/pkg/pipeline/ingest/ingest_grpc.go
@@ -12,6 +12,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
 	pUtils "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/utils"
+	"github.com/netobserv/flowlogs-pipeline/pkg/tlsprofile"
 	"github.com/netobserv/flowlogs-pipeline/pkg/utils"
 	"github.com/netobserv/netobserv-ebpf-agent/pkg/decode"
 	grpc "github.com/netobserv/netobserv-ebpf-agent/pkg/grpc/flow"
@@ -74,6 +75,7 @@ func NewGRPCProtobuf(opMetrics *operational.Metrics, params config.StageParam) (
 			ClientAuth:   tls.NoClientCert,
 			MinVersion:   tls.VersionTLS13,
 		}
+		tlsprofile.Apply(tlsCfg)
 		if cfg.ClientCAPath != "" {
 			// mTLS
 			caCert, err := os.ReadFile(cfg.ClientCAPath)

--- a/pkg/pipeline/ingest/ingest_grpc.go
+++ b/pkg/pipeline/ingest/ingest_grpc.go
@@ -75,7 +75,9 @@ func NewGRPCProtobuf(opMetrics *operational.Metrics, params config.StageParam) (
 			ClientAuth:   tls.NoClientCert,
 			MinVersion:   tls.VersionTLS13,
 		}
-		tlsprofile.Apply(tlsCfg)
+		if _, err := tlsprofile.Apply(tlsCfg); err != nil {
+			return nil, fmt.Errorf("invalid TLS profile override: %w", err)
+		}
 		if cfg.ClientCAPath != "" {
 			// mTLS
 			caCert, err := os.ReadFile(cfg.ClientCAPath)

--- a/pkg/pipeline/transform/kubernetes/k8scache/client.go
+++ b/pkg/pipeline/transform/kubernetes/k8scache/client.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/metrics"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/model"
-	"github.com/netobserv/flowlogs-pipeline/pkg/tlsprofile"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -178,7 +177,6 @@ func (c *Client) getTransportCredentials() (credentials.TransportCredentials, er
 		InsecureSkipVerify: c.tlsConfig.InsecureSkipVerify,
 		MinVersion:         tls.VersionTLS13,
 	}
-	tlsprofile.Apply(tlsConfig)
 
 	// Set ServerName if provided (allows connecting by IP while validating against DNS name in certificate)
 	if c.tlsConfig.TLSServerName != "" {

--- a/pkg/pipeline/transform/kubernetes/k8scache/client.go
+++ b/pkg/pipeline/transform/kubernetes/k8scache/client.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/metrics"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes/model"
+	"github.com/netobserv/flowlogs-pipeline/pkg/tlsprofile"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -175,8 +176,9 @@ func (c *Client) getTransportCredentials() (credentials.TransportCredentials, er
 
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: c.tlsConfig.InsecureSkipVerify,
-		MinVersion:         tls.VersionTLS13, // Match server MinVersion to prevent downgrade attacks
+		MinVersion:         tls.VersionTLS13,
 	}
+	tlsprofile.Apply(tlsConfig)
 
 	// Set ServerName if provided (allows connecting by IP while validating against DNS name in certificate)
 	if c.tlsConfig.TLSServerName != "" {

--- a/pkg/pipeline/write/write_grpc.go
+++ b/pkg/pipeline/write/write_grpc.go
@@ -2,6 +2,7 @@ package write
 
 import (
 	"context"
+	cryptotls "crypto/tls"
 	"encoding/json"
 	"fmt"
 
@@ -46,7 +47,15 @@ func NewWriteGRPC(params config.StageParam) (Writer, error) {
 		return nil, fmt.Errorf("write.grpc param is mandatory: %v", params.Write)
 	}
 	logrus.Debugf("NewWriteGRPC ConnectClient %s:%d...", writeGRPC.hostIP, writeGRPC.hostPort)
-	clientConn, err := grpc.ConnectClient(writeGRPC.hostIP, writeGRPC.hostPort, nil)
+	var tlsCfg *cryptotls.Config
+	if params.Write.GRPC.TLS != nil {
+		var err error
+		tlsCfg, err = params.Write.GRPC.TLS.Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build TLS config: %w", err)
+		}
+	}
+	clientConn, err := grpc.ConnectClient(writeGRPC.hostIP, writeGRPC.hostPort, tlsCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pipeline/write/write_grpc.go
+++ b/pkg/pipeline/write/write_grpc.go
@@ -65,19 +65,28 @@ func NewWriteGRPC(params config.StageParam) (Writer, error) {
 // If cfg is set, it is used to build the explicit TLS configuration, which is
 // then extended with any TLS-profile environment overrides (TLS_MIN_VERSION,
 // TLS_CIPHER_SUITES, TLS_CURVE_PREFERENCES).
-// If cfg is nil, nil is returned and the connection remains insecure: profile
-// env vars only constrain TLS when TLS is already configured, they must not
-// enable it on a previously plaintext writer.
+// If cfg is nil, a TLS configuration is only created when the environment
+// yields at least one valid override; otherwise nil is returned and the
+// connection remains insecure, preserving prior behavior.
 func resolveTLSConfig(cfg *api.ClientTLS) (*cryptotls.Config, error) {
-	if cfg == nil {
-		return nil, nil
+	if cfg != nil {
+		tlsCfg, err := cfg.Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build TLS config: %w", err)
+		}
+		if _, err := tlsprofile.Apply(tlsCfg); err != nil {
+			return nil, fmt.Errorf("invalid TLS profile override: %w", err)
+		}
+		return tlsCfg, nil
 	}
-	tlsCfg, err := cfg.Build()
+
+	envCfg := &cryptotls.Config{MinVersion: cryptotls.VersionTLS13}
+	applied, err := tlsprofile.Apply(envCfg)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build TLS config: %w", err)
-	}
-	if _, err := tlsprofile.Apply(tlsCfg); err != nil {
 		return nil, fmt.Errorf("invalid TLS profile override: %w", err)
 	}
-	return tlsCfg, nil
+	if !applied {
+		return nil, nil
+	}
+	return envCfg, nil
 }

--- a/pkg/pipeline/write/write_grpc.go
+++ b/pkg/pipeline/write/write_grpc.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/write/grpc"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/write/grpc/genericmap"
+	"github.com/netobserv/flowlogs-pipeline/pkg/tlsprofile"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -47,13 +49,9 @@ func NewWriteGRPC(params config.StageParam) (Writer, error) {
 		return nil, fmt.Errorf("write.grpc param is mandatory: %v", params.Write)
 	}
 	logrus.Debugf("NewWriteGRPC ConnectClient %s:%d...", writeGRPC.hostIP, writeGRPC.hostPort)
-	var tlsCfg *cryptotls.Config
-	if params.Write.GRPC.TLS != nil {
-		var err error
-		tlsCfg, err = params.Write.GRPC.TLS.Build()
-		if err != nil {
-			return nil, fmt.Errorf("failed to build TLS config: %w", err)
-		}
+	tlsCfg, err := resolveTLSConfig(params.Write.GRPC.TLS)
+	if err != nil {
+		return nil, err
 	}
 	clientConn, err := grpc.ConnectClient(writeGRPC.hostIP, writeGRPC.hostPort, tlsCfg)
 	if err != nil {
@@ -61,4 +59,34 @@ func NewWriteGRPC(params config.StageParam) (Writer, error) {
 	}
 	writeGRPC.clientConn = clientConn
 	return writeGRPC, nil
+}
+
+// resolveTLSConfig builds the gRPC client TLS configuration for the writer.
+// If cfg is set, it is used to build the explicit TLS configuration, which is
+// then extended with any TLS-profile environment overrides (TLS_MIN_VERSION,
+// TLS_CIPHER_SUITES, TLS_CURVE_PREFERENCES).
+// If cfg is nil, a TLS configuration is only created when the environment
+// yields at least one valid override; otherwise nil is returned and the
+// connection remains insecure, preserving prior behavior.
+func resolveTLSConfig(cfg *api.ClientTLS) (*cryptotls.Config, error) {
+	if cfg != nil {
+		tlsCfg, err := cfg.Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build TLS config: %w", err)
+		}
+		if _, err := tlsprofile.Apply(tlsCfg); err != nil {
+			return nil, fmt.Errorf("invalid TLS profile override: %w", err)
+		}
+		return tlsCfg, nil
+	}
+
+	envCfg := &cryptotls.Config{MinVersion: cryptotls.VersionTLS13}
+	applied, err := tlsprofile.Apply(envCfg)
+	if err != nil {
+		return nil, fmt.Errorf("invalid TLS profile override: %w", err)
+	}
+	if !applied {
+		return nil, nil
+	}
+	return envCfg, nil
 }

--- a/pkg/pipeline/write/write_grpc.go
+++ b/pkg/pipeline/write/write_grpc.go
@@ -65,28 +65,19 @@ func NewWriteGRPC(params config.StageParam) (Writer, error) {
 // If cfg is set, it is used to build the explicit TLS configuration, which is
 // then extended with any TLS-profile environment overrides (TLS_MIN_VERSION,
 // TLS_CIPHER_SUITES, TLS_CURVE_PREFERENCES).
-// If cfg is nil, a TLS configuration is only created when the environment
-// yields at least one valid override; otherwise nil is returned and the
-// connection remains insecure, preserving prior behavior.
+// If cfg is nil, nil is returned and the connection remains insecure: profile
+// env vars only constrain TLS when TLS is already configured, they must not
+// enable it on a previously plaintext writer.
 func resolveTLSConfig(cfg *api.ClientTLS) (*cryptotls.Config, error) {
-	if cfg != nil {
-		tlsCfg, err := cfg.Build()
-		if err != nil {
-			return nil, fmt.Errorf("failed to build TLS config: %w", err)
-		}
-		if _, err := tlsprofile.Apply(tlsCfg); err != nil {
-			return nil, fmt.Errorf("invalid TLS profile override: %w", err)
-		}
-		return tlsCfg, nil
-	}
-
-	envCfg := &cryptotls.Config{MinVersion: cryptotls.VersionTLS13}
-	applied, err := tlsprofile.Apply(envCfg)
-	if err != nil {
-		return nil, fmt.Errorf("invalid TLS profile override: %w", err)
-	}
-	if !applied {
+	if cfg == nil {
 		return nil, nil
 	}
-	return envCfg, nil
+	tlsCfg, err := cfg.Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build TLS config: %w", err)
+	}
+	if _, err := tlsprofile.Apply(tlsCfg); err != nil {
+		return nil, fmt.Errorf("invalid TLS profile override: %w", err)
+	}
+	return tlsCfg, nil
 }

--- a/pkg/pipeline/write/write_grpc_test.go
+++ b/pkg/pipeline/write/write_grpc_test.go
@@ -66,6 +66,18 @@ func Test_ResolveTLSConfig_EnvironmentOnlyTLS(t *testing.T) {
 	require.Equal(t, []uint16{49199, 49200}, tlsCfg.CipherSuites)
 }
 
+func Test_ResolveTLSConfig_EnvironmentOnlyAllTLS13CipherSuites(t *testing.T) {
+	// No TLS_MIN_VERSION: the base env-only config already defaults to TLS 1.3,
+	// and TLS_CIPHER_SUITES only contains TLS 1.3 suite IDs, which are never
+	// applied to CipherSuites. With nothing actually applied, TLS is not
+	// turned on, same as if no env override had been set at all.
+	t.Setenv(tlsprofile.EnvCipherSuites, "4865,4866,4867")
+
+	tlsCfg, err := resolveTLSConfig(nil)
+	require.NoError(t, err)
+	require.Nil(t, tlsCfg, "an all-TLS-1.3 cipher list has nothing to apply, so TLS should stay off")
+}
+
 func Test_ResolveTLSConfig_ExplicitTLSWithOverride(t *testing.T) {
 	t.Setenv(tlsprofile.EnvMinVersion, "771")
 

--- a/pkg/pipeline/write/write_grpc_test.go
+++ b/pkg/pipeline/write/write_grpc_test.go
@@ -1,12 +1,14 @@
 package write
 
 import (
+	cryptotls "crypto/tls"
 	"testing"
 
 	"github.com/mariomac/guara/pkg/test"
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/write/grpc"
+	"github.com/netobserv/flowlogs-pipeline/pkg/tlsprofile"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,4 +41,52 @@ func Test_NewWriteGRPC(t *testing.T) {
 	})
 	require.Nil(t, err)
 	require.NotNil(t, writer)
+}
+
+func Test_ResolveTLSConfig_NoTLSConfiguration(t *testing.T) {
+	// Explicitly clear all three vars: a TLS_* value inherited from the
+	// parent environment must not make this test nondeterministic.
+	t.Setenv(tlsprofile.EnvMinVersion, "")
+	t.Setenv(tlsprofile.EnvCipherSuites, "")
+	t.Setenv(tlsprofile.EnvCurvePreferences, "")
+
+	tlsCfg, err := resolveTLSConfig(nil)
+	require.NoError(t, err)
+	require.Nil(t, tlsCfg, "no explicit TLS and no env override should keep the connection insecure")
+}
+
+func Test_ResolveTLSConfig_EnvironmentOnlyTLS(t *testing.T) {
+	t.Setenv(tlsprofile.EnvMinVersion, "771")
+	t.Setenv(tlsprofile.EnvCipherSuites, "49199,49200")
+
+	tlsCfg, err := resolveTLSConfig(nil)
+	require.NoError(t, err)
+	require.NotNil(t, tlsCfg, "a valid env override alone should turn on TLS")
+	require.Equal(t, uint16(cryptotls.VersionTLS12), tlsCfg.MinVersion)
+	require.Equal(t, []uint16{49199, 49200}, tlsCfg.CipherSuites)
+}
+
+func Test_ResolveTLSConfig_ExplicitTLSWithOverride(t *testing.T) {
+	t.Setenv(tlsprofile.EnvMinVersion, "771")
+
+	tlsCfg, err := resolveTLSConfig(&api.ClientTLS{InsecureSkipVerify: true})
+	require.NoError(t, err)
+	require.NotNil(t, tlsCfg)
+	require.True(t, tlsCfg.InsecureSkipVerify, "explicit TLS config should still be honored")
+	require.Equal(t, uint16(cryptotls.VersionTLS12), tlsCfg.MinVersion, "env override should apply on top of the explicit TLS config")
+}
+
+func Test_ResolveTLSConfig_MalformedEnvironmentValue(t *testing.T) {
+	t.Setenv(tlsprofile.EnvMinVersion, "not-a-number")
+
+	// Malformed env value with no explicit TLS config.
+	tlsCfg, err := resolveTLSConfig(nil)
+	require.Error(t, err)
+	require.Nil(t, tlsCfg)
+
+	// Malformed env value with an explicit TLS config: the invalid override
+	// must not be silently dropped in favor of the explicit config.
+	tlsCfg, err = resolveTLSConfig(&api.ClientTLS{})
+	require.Error(t, err)
+	require.Nil(t, tlsCfg)
 }

--- a/pkg/prometheus/prom_server.go
+++ b/pkg/prometheus/prom_server.go
@@ -19,7 +19,6 @@ package prometheus
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -97,10 +96,6 @@ func StartServerAsync(conn *api.PromConnectionInfo, regName string, registry pro
 
 	httpServer := http.Server{
 		Addr: addr,
-		// TLS clients must use TLS 1.2 or higher
-		TLSConfig: &tls.Config{
-			MinVersion: tls.VersionTLS12,
-		},
 	}
 	// The Handler function provides a default handler to expose metrics
 	// via an HTTP server. "/metrics" is the usual endpoint for that.

--- a/pkg/server/common.go
+++ b/pkg/server/common.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/netobserv/flowlogs-pipeline/pkg/tlsprofile"
 	"github.com/sirupsen/logrus"
 )
 
@@ -39,6 +40,7 @@ func Default(srv *http.Server) *http.Server {
 	if srv.TLSConfig.MinVersion == 0 {
 		srv.TLSConfig.MinVersion = tls.VersionTLS13
 	}
+	tlsprofile.Apply(srv.TLSConfig)
 	// Disable http/2
 	srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0)
 

--- a/pkg/server/common.go
+++ b/pkg/server/common.go
@@ -40,7 +40,9 @@ func Default(srv *http.Server) *http.Server {
 	if srv.TLSConfig.MinVersion == 0 {
 		srv.TLSConfig.MinVersion = tls.VersionTLS13
 	}
-	tlsprofile.Apply(srv.TLSConfig)
+	if _, err := tlsprofile.Apply(srv.TLSConfig); err != nil {
+		slog.Errorf("invalid TLS profile override, keeping secure defaults: %v", err)
+	}
 	// Disable http/2
 	srv.TLSNextProto = make(map[string]func(*http.Server, *tls.Conn, http.Handler), 0)
 

--- a/pkg/server/common_test.go
+++ b/pkg/server/common_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/tlsprofile"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefault_AppliesTLSProfileOverrides(t *testing.T) {
+	t.Setenv(tlsprofile.EnvMinVersion, "771")
+	t.Setenv(tlsprofile.EnvCipherSuites, "49199,49200")
+	t.Setenv(tlsprofile.EnvCurvePreferences, "23,24")
+
+	srv := Default(&http.Server{})
+
+	assert.Equal(t, uint16(tls.VersionTLS12), srv.TLSConfig.MinVersion)
+	assert.Equal(t, []uint16{49199, 49200}, srv.TLSConfig.CipherSuites)
+	assert.Equal(t, []tls.CurveID{tls.CurveP256, tls.CurveP384}, srv.TLSConfig.CurvePreferences)
+}
+
+func TestDefault_NoOverridesKeepsSecureDefaultMinVersion(t *testing.T) {
+	// Explicitly clear all three vars: a TLS_* value inherited from the
+	// parent environment must not make this test nondeterministic.
+	t.Setenv(tlsprofile.EnvMinVersion, "")
+	t.Setenv(tlsprofile.EnvCipherSuites, "")
+	t.Setenv(tlsprofile.EnvCurvePreferences, "")
+
+	srv := Default(&http.Server{})
+
+	assert.Equal(t, uint16(tls.VersionTLS13), srv.TLSConfig.MinVersion)
+	assert.Empty(t, srv.TLSConfig.CipherSuites)
+	assert.Empty(t, srv.TLSConfig.CurvePreferences)
+}
+
+func TestDefault_InvalidOverrideKeepsSecureDefaults(t *testing.T) {
+	// One invalid value among an otherwise valid profile must not result in
+	// a partially-applied TLS config: the secure defaults should be kept as-is.
+	t.Setenv(tlsprofile.EnvMinVersion, "not-a-number")
+	t.Setenv(tlsprofile.EnvCipherSuites, "49199,49200")
+
+	srv := Default(&http.Server{})
+
+	assert.Equal(t, uint16(tls.VersionTLS13), srv.TLSConfig.MinVersion)
+	assert.Empty(t, srv.TLSConfig.CipherSuites)
+	assert.Empty(t, srv.TLSConfig.CurvePreferences)
+}

--- a/pkg/tlsprofile/tlsprofile.go
+++ b/pkg/tlsprofile/tlsprofile.go
@@ -1,0 +1,89 @@
+package tlsprofile
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	EnvMinVersion       = "TLS_MIN_VERSION"
+	EnvCipherSuites     = "TLS_CIPHER_SUITES"
+	EnvCurvePreferences = "TLS_CURVE_PREFERENCES"
+)
+
+// Apply overrides fields in c using values from TLS_MIN_VERSION, TLS_CIPHER_SUITES
+// and TLS_CURVE_PREFERENCES environment variables, when those are set.
+// Values are decimal uint16 strings (e.g. "771" for TLS 1.2).
+// Fields whose env var is absent are left unchanged.
+func Apply(c *tls.Config) {
+	if c == nil {
+		return
+	}
+	if v := minVersionFromEnv(); v != 0 {
+		c.MinVersion = v
+	}
+	if suites := cipherSuitesFromEnv(); len(suites) > 0 {
+		c.CipherSuites = suites
+	}
+	if curves := curvePrefsFromEnv(); len(curves) > 0 {
+		c.CurvePreferences = curves
+	}
+}
+
+func minVersionFromEnv() uint16 {
+	s := strings.TrimSpace(os.Getenv(EnvMinVersion))
+	if s == "" {
+		return 0
+	}
+	v, err := strconv.ParseUint(s, 10, 16)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tlsprofile: invalid %s value %q, ignoring: %v\n", EnvMinVersion, s, err)
+		return 0
+	}
+	return uint16(v)
+}
+
+func cipherSuitesFromEnv() []uint16 {
+	s := strings.TrimSpace(os.Getenv(EnvCipherSuites))
+	if s == "" {
+		return nil
+	}
+	var ids []uint16
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		v, err := strconv.ParseUint(part, 10, 16)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "tlsprofile: invalid cipher suite %q in %s, skipping: %v\n", part, EnvCipherSuites, err)
+			continue
+		}
+		ids = append(ids, uint16(v))
+	}
+	return ids
+}
+
+func curvePrefsFromEnv() []tls.CurveID {
+	s := strings.TrimSpace(os.Getenv(EnvCurvePreferences))
+	if s == "" {
+		return nil
+	}
+	var curves []tls.CurveID
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		v, err := strconv.ParseUint(part, 10, 16)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "tlsprofile: invalid curve %q in %s, skipping: %v\n", part, EnvCurvePreferences, err)
+			continue
+		}
+		curves = append(curves, tls.CurveID(v))
+	}
+	return curves
+}

--- a/pkg/tlsprofile/tlsprofile.go
+++ b/pkg/tlsprofile/tlsprofile.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -16,40 +18,83 @@ const (
 
 // Apply overrides fields in c using values from TLS_MIN_VERSION, TLS_CIPHER_SUITES
 // and TLS_CURVE_PREFERENCES environment variables, when those are set.
-// Values are decimal uint16 strings (e.g. "771" for TLS 1.2).
-// Fields whose env var is absent are left unchanged.
-func Apply(c *tls.Config) {
+// Values are decimal uint16 strings (e.g. "771" for TLS 1.2, "772" for TLS 1.3),
+// or, for cipher suites/curves, the corresponding IANA TLS registry IDs.
+// Env vars that are absent leave the corresponding field unchanged.
+// If any set env var holds a value that isn't a valid uint16, c is left
+// entirely unmodified and an error describing the first invalid value is
+// returned; no further validation (e.g. against known curve IDs) is
+// performed, so it is the caller's responsibility to supply correct IDs.
+// TLS_CIPHER_SUITES silently filters out the fixed TLS 1.3 suite IDs
+// (4865, 4866, 4867): crypto/tls.Config.CipherSuites only affects TLS 1.0-1.2
+// negotiation, so those IDs would never do anything there, and standard TLS
+// profiles (e.g. OpenShift's Intermediate/Modern) legitimately include them
+// alongside real TLS 1.0-1.2 suite IDs.
+// If TLS_CIPHER_SUITES is set but the effective MinVersion is TLS 1.3, a
+// warning is logged: Go's crypto/tls does not allow customizing the (fixed,
+// already secure) TLS 1.3 cipher suite list, so the override has no effect
+// unless a lower TLS version ends up being negotiated.
+// It returns whether at least one override was applied.
+func Apply(c *tls.Config) (bool, error) {
 	if c == nil {
-		return
+		return false, nil
 	}
-	if v := minVersionFromEnv(); v != 0 {
-		c.MinVersion = v
+	minVersion, hasMinVersion, err := minVersionFromEnv()
+	if err != nil {
+		return false, err
 	}
-	if suites := cipherSuitesFromEnv(); len(suites) > 0 {
+	suites, err := cipherSuitesFromEnv()
+	if err != nil {
+		return false, err
+	}
+	curves, err := curvePrefsFromEnv()
+	if err != nil {
+		return false, err
+	}
+
+	if hasMinVersion {
+		c.MinVersion = minVersion
+	}
+	if suites != nil {
+		if c.MinVersion >= tls.VersionTLS13 {
+			logrus.Warnf("tlsprofile: %s is set but has no effect because the effective minimum TLS version is 1.3 (TLS 1.3 cipher suites are not configurable)", EnvCipherSuites)
+		}
 		c.CipherSuites = suites
 	}
-	if curves := curvePrefsFromEnv(); len(curves) > 0 {
+	if curves != nil {
 		c.CurvePreferences = curves
 	}
+	return hasMinVersion || suites != nil || curves != nil, nil
 }
 
-func minVersionFromEnv() uint16 {
+func minVersionFromEnv() (value uint16, set bool, err error) {
 	s := strings.TrimSpace(os.Getenv(EnvMinVersion))
 	if s == "" {
-		return 0
+		return 0, false, nil
 	}
 	v, err := strconv.ParseUint(s, 10, 16)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "tlsprofile: invalid %s value %q, ignoring: %v\n", EnvMinVersion, s, err)
-		return 0
+		return 0, false, fmt.Errorf("tlsprofile: invalid %s value %q: %w", EnvMinVersion, s, err)
 	}
-	return uint16(v)
+	return uint16(v), true, nil
 }
 
-func cipherSuitesFromEnv() []uint16 {
+// tls13CipherSuiteIDs are the fixed suite IDs Go's crypto/tls negotiates
+// automatically for TLS 1.3 connections. tls.Config.CipherSuites only affects
+// TLS 1.0-1.2 negotiation, so these IDs have no effect there; they are
+// silently filtered out rather than rejected because standard TLS profile
+// definitions (e.g. OpenShift's Intermediate/Modern TLSSecurityProfile)
+// legitimately list them alongside real TLS 1.0-1.2 suite IDs.
+var tls13CipherSuiteIDs = map[uint16]struct{}{
+	4865: {}, // TLS_AES_128_GCM_SHA256
+	4866: {}, // TLS_AES_256_GCM_SHA384
+	4867: {}, // TLS_CHACHA20_POLY1305_SHA256
+}
+
+func cipherSuitesFromEnv() ([]uint16, error) {
 	s := strings.TrimSpace(os.Getenv(EnvCipherSuites))
 	if s == "" {
-		return nil
+		return nil, nil
 	}
 	var ids []uint16
 	for _, part := range strings.Split(s, ",") {
@@ -59,18 +104,21 @@ func cipherSuitesFromEnv() []uint16 {
 		}
 		v, err := strconv.ParseUint(part, 10, 16)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "tlsprofile: invalid cipher suite %q in %s, skipping: %v\n", part, EnvCipherSuites, err)
+			return nil, fmt.Errorf("tlsprofile: invalid cipher suite %q in %s: %w", part, EnvCipherSuites, err)
+		}
+		id := uint16(v)
+		if _, ok := tls13CipherSuiteIDs[id]; ok {
 			continue
 		}
-		ids = append(ids, uint16(v))
+		ids = append(ids, id)
 	}
-	return ids
+	return ids, nil
 }
 
-func curvePrefsFromEnv() []tls.CurveID {
+func curvePrefsFromEnv() ([]tls.CurveID, error) {
 	s := strings.TrimSpace(os.Getenv(EnvCurvePreferences))
 	if s == "" {
-		return nil
+		return nil, nil
 	}
 	var curves []tls.CurveID
 	for _, part := range strings.Split(s, ",") {
@@ -80,10 +128,9 @@ func curvePrefsFromEnv() []tls.CurveID {
 		}
 		v, err := strconv.ParseUint(part, 10, 16)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "tlsprofile: invalid curve %q in %s, skipping: %v\n", part, EnvCurvePreferences, err)
-			continue
+			return nil, fmt.Errorf("tlsprofile: invalid curve %q in %s: %w", part, EnvCurvePreferences, err)
 		}
 		curves = append(curves, tls.CurveID(v))
 	}
-	return curves
+	return curves, nil
 }

--- a/pkg/tlsprofile/tlsprofile.go
+++ b/pkg/tlsprofile/tlsprofile.go
@@ -30,10 +30,12 @@ const (
 // negotiation, so those IDs would never do anything there, and standard TLS
 // profiles (e.g. OpenShift's Intermediate/Modern) legitimately include them
 // alongside real TLS 1.0-1.2 suite IDs.
-// If TLS_CIPHER_SUITES is set but the effective MinVersion is TLS 1.3, a
-// warning is logged: Go's crypto/tls does not allow customizing the (fixed,
-// already secure) TLS 1.3 cipher suite list, so the override has no effect
-// unless a lower TLS version ends up being negotiated.
+// If the effective MinVersion is TLS 1.3 (regardless of whether that came
+// from TLS_MIN_VERSION or from c's own prior value), TLS_CIPHER_SUITES is not
+// applied at all: Go's crypto/tls does not allow customizing the (fixed,
+// already secure) TLS 1.3 cipher suite list, so the override could never have
+// any effect. In that case, an info line is logged if TLS_CIPHER_SUITES was
+// actually provided, since there's nothing to fix, just nothing to do.
 // It returns whether at least one override was applied.
 func Apply(c *tls.Config) (bool, error) {
 	if c == nil {
@@ -55,16 +57,19 @@ func Apply(c *tls.Config) (bool, error) {
 	if hasMinVersion {
 		c.MinVersion = minVersion
 	}
-	if suites != nil {
-		if c.MinVersion >= tls.VersionTLS13 {
-			logrus.Warnf("tlsprofile: %s is set but has no effect because the effective minimum TLS version is 1.3 (TLS 1.3 cipher suites are not configurable)", EnvCipherSuites)
+	appliedSuites := false
+	if c.MinVersion >= tls.VersionTLS13 {
+		if strings.TrimSpace(os.Getenv(EnvCipherSuites)) != "" {
+			logrus.Infof("tlsprofile: %s is set but has no effect because the effective minimum TLS version is 1.3 (TLS 1.3 cipher suites are not configurable)", EnvCipherSuites)
 		}
+	} else if suites != nil {
 		c.CipherSuites = suites
+		appliedSuites = true
 	}
 	if curves != nil {
 		c.CurvePreferences = curves
 	}
-	return hasMinVersion || suites != nil || curves != nil, nil
+	return hasMinVersion || appliedSuites || curves != nil, nil
 }
 
 func minVersionFromEnv() (value uint16, set bool, err error) {

--- a/pkg/tlsprofile/tlsprofile_test.go
+++ b/pkg/tlsprofile/tlsprofile_test.go
@@ -181,8 +181,14 @@ func TestApply_MalformedCipherSuiteLeavesConfigUntouched(t *testing.T) {
 // by openshift/library-go, even though Go's crypto/tls never reads them from
 // CipherSuites). This must not fail the whole profile application.
 func TestApply_OpenShiftModernProfile(t *testing.T) {
+	var buf bytes.Buffer
+	orig := logrus.StandardLogger().Out
+	logrus.SetOutput(&buf)
+	t.Cleanup(func() { logrus.SetOutput(orig) })
+
 	t.Setenv(EnvMinVersion, "772")
 	t.Setenv(EnvCipherSuites, "4865,4866,4867")
+	t.Setenv(EnvCurvePreferences, "")
 
 	c := &tls.Config{}
 	applied, err := Apply(c)
@@ -191,6 +197,7 @@ func TestApply_OpenShiftModernProfile(t *testing.T) {
 	assert.True(t, applied, "MinVersion was still applied")
 	assert.Equal(t, uint16(tls.VersionTLS13), c.MinVersion)
 	assert.Empty(t, c.CipherSuites, "an all-TLS-1.3 cipher list has nothing to apply")
+	assert.Contains(t, buf.String(), EnvCipherSuites, "the (harmless) TLS_CIPHER_SUITES override should still be noted")
 }
 
 // TestApply_OpenShiftIntermediateProfile reproduces OpenShift's "Intermediate"
@@ -200,6 +207,7 @@ func TestApply_OpenShiftModernProfile(t *testing.T) {
 func TestApply_OpenShiftIntermediateProfile(t *testing.T) {
 	t.Setenv(EnvMinVersion, "771")
 	t.Setenv(EnvCipherSuites, "4865,4866,4867,49199,49200")
+	t.Setenv(EnvCurvePreferences, "")
 
 	c := &tls.Config{}
 	applied, err := Apply(c)
@@ -216,14 +224,16 @@ func TestApply_WarnsWhenCipherSuitesInertUnderTLS13(t *testing.T) {
 	logrus.SetOutput(&buf)
 	t.Cleanup(func() { logrus.SetOutput(orig) })
 
+	t.Setenv(EnvMinVersion, "")
 	t.Setenv(EnvCipherSuites, "49199,49200")
+	t.Setenv(EnvCurvePreferences, "")
 
 	c := &tls.Config{MinVersion: tls.VersionTLS13}
 	applied, err := Apply(c)
 
 	assert.NoError(t, err)
-	assert.True(t, applied)
-	assert.Equal(t, []uint16{49199, 49200}, c.CipherSuites, "the override is still applied even though it has no effect")
+	assert.False(t, applied, "cipher suites are not applied at all when the effective TLS version is already 1.3")
+	assert.Empty(t, c.CipherSuites)
 	assert.Contains(t, buf.String(), EnvCipherSuites)
 	assert.Contains(t, buf.String(), "no effect")
 }
@@ -236,6 +246,7 @@ func TestApply_NoWarningWhenEffectiveVersionAllowsTLS12(t *testing.T) {
 
 	t.Setenv(EnvMinVersion, "771") // TLS 1.2: cipher suites remain meaningful
 	t.Setenv(EnvCipherSuites, "49199")
+	t.Setenv(EnvCurvePreferences, "")
 
 	c := &tls.Config{MinVersion: tls.VersionTLS13}
 	_, err := Apply(c)

--- a/pkg/tlsprofile/tlsprofile_test.go
+++ b/pkg/tlsprofile/tlsprofile_test.go
@@ -1,0 +1,245 @@
+package tlsprofile
+
+import (
+	"bytes"
+	"crypto/tls"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinVersionFromEnv(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		expected    uint16
+		expectedSet bool
+		expectErr   bool
+	}{
+		{name: "absent", value: "", expected: 0, expectedSet: false},
+		{name: "valid TLS1.2", value: "771", expected: tls.VersionTLS12, expectedSet: true},
+		{name: "valid TLS1.3", value: "772", expected: tls.VersionTLS13, expectedSet: true},
+		{name: "malformed", value: "not-a-number", expectErr: true},
+		{name: "out of uint16 range", value: "99999999", expectErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Always set (even to "", which the code treats the same as absent)
+			// so a TLS_MIN_VERSION inherited from the parent environment can't
+			// make this test nondeterministic.
+			t.Setenv(EnvMinVersion, tt.value)
+			v, set, err := minVersionFromEnv()
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, v)
+			assert.Equal(t, tt.expectedSet, set)
+		})
+	}
+}
+
+func TestCipherSuitesFromEnv(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		expected  []uint16
+		expectErr bool
+	}{
+		{name: "absent", value: "", expected: nil},
+		{name: "single valid", value: "49199", expected: []uint16{49199}},
+		{name: "multiple valid with spaces", value: " 49199 , 49200 ", expected: []uint16{49199, 49200}},
+		{name: "one malformed entry fails the whole list", value: "49199,not-a-number,49200", expectErr: true},
+		{name: "all malformed", value: "abc,def", expectErr: true},
+		{name: "empty entries ignored", value: "49199,,49200", expected: []uint16{49199, 49200}},
+		{name: "TLS 1.3 suite IDs filtered out", value: "4865,49199,4866,4867", expected: []uint16{49199}},
+		{name: "TLS 1.3-only suite IDs yield nil", value: "4865,4866,4867", expected: nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Always set, so a TLS_CIPHER_SUITES inherited from the parent
+			// environment can't make this test nondeterministic.
+			t.Setenv(EnvCipherSuites, tt.value)
+			suites, err := cipherSuitesFromEnv()
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, suites)
+		})
+	}
+}
+
+func TestCurvePrefsFromEnv(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		expected  []tls.CurveID
+		expectErr bool
+	}{
+		{name: "absent", value: "", expected: nil},
+		{name: "single valid", value: "23", expected: []tls.CurveID{tls.CurveP256}},
+		{name: "multiple valid", value: "23,24", expected: []tls.CurveID{tls.CurveP256, tls.CurveP384}},
+		{name: "one malformed entry fails the whole list", value: "23,bogus,24", expectErr: true},
+		{name: "all malformed", value: "bogus,also-bogus", expectErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Always set, so a TLS_CURVE_PREFERENCES inherited from the
+			// parent environment can't make this test nondeterministic.
+			t.Setenv(EnvCurvePreferences, tt.value)
+			curves, err := curvePrefsFromEnv()
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, curves)
+		})
+	}
+}
+
+func TestApply_NilConfig(t *testing.T) {
+	applied, err := Apply(nil)
+	assert.NoError(t, err)
+	assert.False(t, applied)
+}
+
+func TestApply_NoEnvLeavesConfigUnchanged(t *testing.T) {
+	// Explicitly clear all three vars: a TLS_* value inherited from the
+	// parent environment must not make this test nondeterministic.
+	t.Setenv(EnvMinVersion, "")
+	t.Setenv(EnvCipherSuites, "")
+	t.Setenv(EnvCurvePreferences, "")
+
+	c := &tls.Config{
+		MinVersion:       tls.VersionTLS13,
+		CipherSuites:     []uint16{49199},
+		CurvePreferences: []tls.CurveID{tls.CurveP256},
+	}
+	applied, err := Apply(c)
+	assert.NoError(t, err)
+	assert.False(t, applied)
+	assert.Equal(t, uint16(tls.VersionTLS13), c.MinVersion)
+	assert.Equal(t, []uint16{49199}, c.CipherSuites)
+	assert.Equal(t, []tls.CurveID{tls.CurveP256}, c.CurvePreferences)
+}
+
+func TestApply_ValidOverrides(t *testing.T) {
+	t.Setenv(EnvMinVersion, "771")
+	t.Setenv(EnvCipherSuites, "49199,49200")
+	t.Setenv(EnvCurvePreferences, "23,24")
+
+	c := &tls.Config{MinVersion: tls.VersionTLS13}
+	applied, err := Apply(c)
+	assert.NoError(t, err)
+	assert.True(t, applied)
+
+	assert.Equal(t, uint16(tls.VersionTLS12), c.MinVersion)
+	assert.Equal(t, []uint16{49199, 49200}, c.CipherSuites)
+	assert.Equal(t, []tls.CurveID{tls.CurveP256, tls.CurveP384}, c.CurvePreferences)
+}
+
+func TestApply_InvalidOverrideLeavesConfigUntouched(t *testing.T) {
+	// MinVersion malformed; cipher suites otherwise valid; curve preferences absent.
+	// Because one field is invalid, none of the fields should be applied.
+	t.Setenv(EnvMinVersion, "not-a-number")
+	t.Setenv(EnvCipherSuites, "49199,49200")
+
+	c := &tls.Config{
+		MinVersion:       tls.VersionTLS13,
+		CipherSuites:     []uint16{9999},
+		CurvePreferences: []tls.CurveID{tls.CurveP384},
+	}
+	applied, err := Apply(c)
+
+	assert.Error(t, err)
+	assert.False(t, applied)
+	assert.Equal(t, uint16(tls.VersionTLS13), c.MinVersion, "no field should be overridden when any override is invalid")
+	assert.Equal(t, []uint16{9999}, c.CipherSuites, "no field should be overridden when any override is invalid")
+	assert.Equal(t, []tls.CurveID{tls.CurveP384}, c.CurvePreferences, "no field should be overridden when any override is invalid")
+}
+
+func TestApply_MalformedCipherSuiteLeavesConfigUntouched(t *testing.T) {
+	t.Setenv(EnvMinVersion, "771")
+	t.Setenv(EnvCipherSuites, "49199,garbage")
+
+	c := &tls.Config{MinVersion: tls.VersionTLS13}
+	applied, err := Apply(c)
+
+	assert.Error(t, err)
+	assert.False(t, applied)
+	assert.Equal(t, uint16(tls.VersionTLS13), c.MinVersion, "valid min version should not be applied when cipher suites are invalid")
+}
+
+// TestApply_OpenShiftModernProfile reproduces the env vars netobserv-operator
+// derives from OpenShift's "Modern" TLSSecurityProfile, whose Ciphers list is
+// exactly the three TLS 1.3 suite names (they're included there deliberately
+// by openshift/library-go, even though Go's crypto/tls never reads them from
+// CipherSuites). This must not fail the whole profile application.
+func TestApply_OpenShiftModernProfile(t *testing.T) {
+	t.Setenv(EnvMinVersion, "772")
+	t.Setenv(EnvCipherSuites, "4865,4866,4867")
+
+	c := &tls.Config{}
+	applied, err := Apply(c)
+
+	assert.NoError(t, err)
+	assert.True(t, applied, "MinVersion was still applied")
+	assert.Equal(t, uint16(tls.VersionTLS13), c.MinVersion)
+	assert.Empty(t, c.CipherSuites, "an all-TLS-1.3 cipher list has nothing to apply")
+}
+
+// TestApply_OpenShiftIntermediateProfile reproduces OpenShift's "Intermediate"
+// TLSSecurityProfile, whose Ciphers list mixes the three TLS 1.3 suite names
+// with real TLS 1.2 suites: the TLS 1.3 ones must be filtered out, and the
+// TLS 1.2 ones applied.
+func TestApply_OpenShiftIntermediateProfile(t *testing.T) {
+	t.Setenv(EnvMinVersion, "771")
+	t.Setenv(EnvCipherSuites, "4865,4866,4867,49199,49200")
+
+	c := &tls.Config{}
+	applied, err := Apply(c)
+
+	assert.NoError(t, err)
+	assert.True(t, applied)
+	assert.Equal(t, uint16(tls.VersionTLS12), c.MinVersion)
+	assert.Equal(t, []uint16{49199, 49200}, c.CipherSuites)
+}
+
+func TestApply_WarnsWhenCipherSuitesInertUnderTLS13(t *testing.T) {
+	var buf bytes.Buffer
+	orig := logrus.StandardLogger().Out
+	logrus.SetOutput(&buf)
+	t.Cleanup(func() { logrus.SetOutput(orig) })
+
+	t.Setenv(EnvCipherSuites, "49199,49200")
+
+	c := &tls.Config{MinVersion: tls.VersionTLS13}
+	applied, err := Apply(c)
+
+	assert.NoError(t, err)
+	assert.True(t, applied)
+	assert.Equal(t, []uint16{49199, 49200}, c.CipherSuites, "the override is still applied even though it has no effect")
+	assert.Contains(t, buf.String(), EnvCipherSuites)
+	assert.Contains(t, buf.String(), "no effect")
+}
+
+func TestApply_NoWarningWhenEffectiveVersionAllowsTLS12(t *testing.T) {
+	var buf bytes.Buffer
+	orig := logrus.StandardLogger().Out
+	logrus.SetOutput(&buf)
+	t.Cleanup(func() { logrus.SetOutput(orig) })
+
+	t.Setenv(EnvMinVersion, "771") // TLS 1.2: cipher suites remain meaningful
+	t.Setenv(EnvCipherSuites, "49199")
+
+	c := &tls.Config{MinVersion: tls.VersionTLS13}
+	_, err := Apply(c)
+
+	assert.NoError(t, err)
+	assert.NotContains(t, buf.String(), EnvCipherSuites)
+}


### PR DESCRIPTION
## Description

Use TLS environment variables for TLS config if present

## Dependencies

https://github.com/netobserv/netobserv-operator/pull/2823

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [x] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [ ] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test flp-node-density-heavy-25nodes`_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment-driven TLS profile overrides for minimum TLS version, cipher suites, and curve preferences.
  * Added optional TLS configuration for gRPC write connections.
* **Bug Fixes**
  * Invalid TLS settings now fail safely without partially applying changes.
  * Ineffective cipher-suite overrides are ignored under TLS 1.3.
* **Tests**
  * Expanded coverage for TLS profiles, gRPC connections, and secure server defaults.
* **Refactor**
  * Simplified Prometheus TLS handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->