### PR TITLE
NETOBSERV-2783 Enrich ASN labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Usage:
   
 Flags:  
       --config string                   config file (default is $HOME/.flowlogs-pipeline)  
-      --dynamicParameters string        json of configmap location for dynamic parameters
-      --healthAddr string          Health server address such as ':8080' (default: disabled)  
+      --dynamicParameters string        json of configmap location for dynamic parameters  
+      --healthAddr string               Health server address such as ':8080' (default: disabled)  
   -h, --help                            help for flowlogs-pipeline  
       --k8scache.address string         K8s cache sync server address (default "0.0.0.0")  
       --k8scache.port int               K8s cache sync server port (default: disabled)  
@@ -62,8 +62,8 @@ Flags:
       --log-level string                Log level: debug, info, warning, error (default "error")  
       --metricsSettings string          json for global metrics settings  
       --parameters string               json of config file parameters field  
-      --pipeline string                 json of config file pipeline field
-      --pprofAddr string           Go pprof address such as '127.0.0.1:6060', used for profiling (default: disabled). Do not expose publicly.
+      --pipeline string                 json of config file pipeline field  
+      --pprofAddr string                Go pprof address such as '127.0.0.1:6060', used for profiling (default: disabled). Do not expose publicly.
 ```
 <!---END-AUTO-flowlogs-pipeline_help--->
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -253,6 +253,7 @@ Following is the supported API format for network transformations:
                     reinterpret_direction: reinterpret flow direction at the node level (instead of net interface), to ease the deduplication process
                     add_subnet_label: categorize IPs based on known subnets configuration
                     decode_tcp_flags: decode bitwise TCP flags into a string
+                    add_asn_label: add ASN from FRRConfiguration advertised prefixes (LPM)
                  kubernetes_infra: Kubernetes infra rule configuration
                      namespaceNameFields: entries for namespace and name input fields
                              name: name of the object
@@ -296,6 +297,9 @@ Following is the supported API format for network transformations:
                  decode_tcp_flags: Decode bitwise TCP flags into a string
                      input: entry input field
                      output: entry output field
+                 add_asn_label: Add ASN label rule configuration (from FRRConfiguration)
+                     input: entry IP input field
+                     output: entry output field for the ASN (stringified)
          kubeConfig: global configuration related to Kubernetes (optional)
              configPath: path to kubeconfig file (optional)
              secondaryNetworks: configuration for secondary networks

--- a/hack/examples/asn-enrich-config.yaml
+++ b/hack/examples/asn-enrich-config.yaml
@@ -1,0 +1,40 @@
+# Example: enrich flows with local ASN from FRRConfiguration
+#
+# Stage name "asns" matches the NetObserv Dynamic stage convention (operator
+# can hot-reload this stage later). ASN data itself comes from watching
+# FRRConfiguration CRs (routers[].prefixes / toAdvertise → routers[].asn),
+# matched with longest-prefix match on SrcAddr/DstAddr.
+log-level: info
+metricsSettings:
+  disableGlobalServer: true
+pipeline:
+  - name: ingest_file
+  - name: asns
+    follows: ingest_file
+  - name: write_stdout
+    follows: asns
+parameters:
+  - name: ingest_file
+    ingest:
+      type: file
+      file:
+        filename: /root/flowlogs-pipeline/hack/examples/asn-enrich-sample-flows.jsonl
+      decoder:
+        type: json
+  - name: asns
+    transform:
+      type: network
+      network:
+        rules:
+          - type: add_asn_label
+            add_asn_label:
+              input: SrcAddr
+              output: SrcASN
+          - type: add_asn_label
+            add_asn_label:
+              input: DstAddr
+              output: DstASN
+  - name: write_stdout
+    write:
+      type: stdout
+      stdout: {}

--- a/hack/examples/asn-enrich-sample-flows.jsonl
+++ b/hack/examples/asn-enrich-sample-flows.jsonl
@@ -1,0 +1,3 @@
+{"SrcAddr":"10.128.2.8","DstAddr":"172.20.1.10","SrcPort":34567,"DstPort":443,"Proto":6,"Bytes":3200,"Packets":20}
+{"SrcAddr":"10.129.0.12","DstAddr":"8.8.8.8","SrcPort":23456,"DstPort":53,"Proto":17,"Bytes":900,"Packets":5}
+{"SrcAddr":"192.0.2.1","DstAddr":"10.128.0.5","SrcPort":443,"DstPort":45678,"Proto":6,"Bytes":1500,"Packets":10}

--- a/pkg/api/transform_network.go
+++ b/pkg/api/transform_network.go
@@ -67,6 +67,7 @@ const (
 	NetworkReinterpretDirection TransformNetworkOperationEnum = "reinterpret_direction" // reinterpret flow direction at the node level (instead of net interface), to ease the deduplication process
 	NetworkAddSubnetLabel       TransformNetworkOperationEnum = "add_subnet_label"      // categorize IPs based on known subnets configuration
 	NetworkDecodeTCPFlags       TransformNetworkOperationEnum = "decode_tcp_flags"      // decode bitwise TCP flags into a string
+	NetworkAddASNLabel          TransformNetworkOperationEnum = "add_asn_label"         // add ASN from FRRConfiguration advertised prefixes (LPM)
 )
 
 type NetworkTransformRule struct {
@@ -78,6 +79,7 @@ type NetworkTransformRule struct {
 	AddSubnetLabel  *NetworkAddSubnetLabelRule    `yaml:"add_subnet_label,omitempty" json:"add_subnet_label,omitempty" doc:"Add subnet label rule configuration"`
 	AddService      *NetworkAddServiceRule        `yaml:"add_service,omitempty" json:"add_service,omitempty" doc:"Add service rule configuration"`
 	DecodeTCPFlags  *NetworkGenericRule           `yaml:"decode_tcp_flags,omitempty" json:"decode_tcp_flags,omitempty" doc:"Decode bitwise TCP flags into a string"`
+	AddASNLabel     *NetworkAddASNLabelRule       `yaml:"add_asn_label,omitempty" json:"add_asn_label,omitempty" doc:"Add ASN label rule configuration (from FRRConfiguration)"`
 }
 
 func (r *NetworkTransformRule) preprocess() {
@@ -200,6 +202,11 @@ type NetworkAddServiceRule struct {
 	Input    string `yaml:"input,omitempty" json:"input,omitempty" doc:"entry input field"`
 	Output   string `yaml:"output,omitempty" json:"output,omitempty" doc:"entry output field"`
 	Protocol string `yaml:"protocol,omitempty" json:"protocol,omitempty" doc:"entry protocol field"`
+}
+
+type NetworkAddASNLabelRule struct {
+	Input  string `yaml:"input,omitempty" json:"input,omitempty" doc:"entry IP input field"`
+	Output string `yaml:"output,omitempty" json:"output,omitempty" doc:"entry output field for the ASN (stringified)"`
 }
 
 type NetworkTransformDirectionInfo struct {

--- a/pkg/confgen/dedup.go
+++ b/pkg/confgen/dedup.go
@@ -32,7 +32,7 @@ func (cg *ConfGen) dedupe() {
 func dedupeNetworkTransformRules(rules api.NetworkTransformRules) api.NetworkTransformRules {
 	var dedupeSlice []api.NetworkTransformRule
 	for i, rule := range rules {
-		if containsNetworkTransformRule(dedupeSlice, rule) {
+		if containsNetworkTransformRule(dedupeSlice, &rule) {
 			// duplicate aggregateDefinition
 			log.Debugf("Remove duplicate transformation rule %v at index %v", rule, i)
 			continue
@@ -42,9 +42,9 @@ func dedupeNetworkTransformRules(rules api.NetworkTransformRules) api.NetworkTra
 	return dedupeSlice
 }
 
-func containsNetworkTransformRule(slice []api.NetworkTransformRule, rule api.NetworkTransformRule) bool {
+func containsNetworkTransformRule(slice []api.NetworkTransformRule, rule *api.NetworkTransformRule) bool {
 	for _, item := range slice {
-		if reflect.DeepEqual(item, rule) {
+		if reflect.DeepEqual(item, *rule) {
 			return true
 		}
 	}

--- a/pkg/pipeline/transform/frr/enrich.go
+++ b/pkg/pipeline/transform/frr/enrich.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package frr
+
+import (
+	"strconv"
+	"sync"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+)
+
+var (
+	storeMu sync.RWMutex
+	store   Store
+)
+
+// InitStore starts the FRRConfiguration informer. Safe to call once; subsequent
+// calls are no-ops while a store is already set.
+func InitStore(kubeConfigPath string) error {
+	storeMu.Lock()
+	defer storeMu.Unlock()
+	if store != nil {
+		return nil
+	}
+	s := NewInformerStore()
+	if err := s.Start(kubeConfigPath); err != nil {
+		return err
+	}
+	store = s
+	return nil
+}
+
+// SetStore injects a Store implementation (for tests).
+func SetStore(s Store) {
+	storeMu.Lock()
+	defer storeMu.Unlock()
+	store = s
+}
+
+// ResetStore clears the package-level store (for tests).
+func ResetStore() {
+	storeMu.Lock()
+	defer storeMu.Unlock()
+	if is, ok := store.(*InformerStore); ok && is != nil {
+		is.Stop()
+	}
+	store = nil
+}
+
+func getStore() Store {
+	storeMu.RLock()
+	defer storeMu.RUnlock()
+	return store
+}
+
+// Enrich looks up the IP in inputField via LPM against FRR advertised prefixes
+// and writes the matching local ASN (stringified) to outputField.
+func Enrich(outputEntry config.GenericMap, rule *api.NetworkAddASNLabelRule) {
+	if rule == nil || rule.Input == "" || rule.Output == "" {
+		log.Error("add_asn_label rule: missing input or output configuration")
+		return
+	}
+	ip, ok := outputEntry.LookupString(rule.Input)
+	if !ok || ip == "" {
+		return
+	}
+	s := getStore()
+	if s == nil {
+		return
+	}
+	asn, ok := s.Lookup(ip)
+	if !ok {
+		return
+	}
+	outputEntry[rule.Output] = strconv.FormatUint(uint64(asn), 10)
+}

--- a/pkg/pipeline/transform/frr/enrich_test.go
+++ b/pkg/pipeline/transform/frr/enrich_test.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package frr
+
+import (
+	"testing"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/api"
+	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type staticStore struct {
+	table *ASNTable
+}
+
+func (s *staticStore) Lookup(ipStr string) (uint32, bool) {
+	return s.table.LookupString(ipStr)
+}
+
+func TestEnrich_WritesStringASN(t *testing.T) {
+	t.Cleanup(ResetStore)
+	SetStore(&staticStore{table: BuildASNTable(map[string]uint32{
+		"10.128.0.0/14": 64512,
+		"10.128.2.0/24": 64513,
+	})})
+
+	entry := config.GenericMap{
+		"SrcAddr": "10.128.2.8",
+		"DstAddr": "8.8.8.8",
+	}
+	Enrich(entry, &api.NetworkAddASNLabelRule{Input: "SrcAddr", Output: "SrcASN"})
+	Enrich(entry, &api.NetworkAddASNLabelRule{Input: "DstAddr", Output: "DstASN"})
+
+	require.Equal(t, "64513", entry["SrcASN"])
+	_, hasDst := entry["DstASN"]
+	require.False(t, hasDst)
+}
+
+func TestEnrich_NoStoreNoOp(t *testing.T) {
+	t.Cleanup(ResetStore)
+	ResetStore()
+	entry := config.GenericMap{"SrcAddr": "10.128.2.8"}
+	Enrich(entry, &api.NetworkAddASNLabelRule{Input: "SrcAddr", Output: "SrcASN"})
+	_, ok := entry["SrcASN"]
+	require.False(t, ok)
+}
+
+func TestInformerStore_LoadConfigs(t *testing.T) {
+	s := NewInformerStore()
+	err := s.LoadConfigs(&unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "a", "namespace": "ns"},
+		"spec": map[string]interface{}{
+			"bgp": map[string]interface{}{
+				"routers": []interface{}{
+					map[string]interface{}{
+						"asn":      int64(64512),
+						"prefixes": []interface{}{"10.128.0.0/14"},
+					},
+				},
+			},
+		},
+	}})
+	require.NoError(t, err)
+	asn, ok := s.Lookup("10.129.0.1")
+	require.True(t, ok)
+	require.Equal(t, uint32(64512), asn)
+}

--- a/pkg/pipeline/transform/frr/extract.go
+++ b/pkg/pipeline/transform/frr/extract.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2026 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package frr
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// extractASNMappings parses an FRRConfiguration into CIDR → local ASN mappings.
+//
+// Source of truth for local ASN labeling:
+//   - routers[].asn with routers[].prefixes
+//   - routers[].asn with neighbors[].toAdvertise.allowed.prefixes
+//
+// Intentionally ignored (not ownership signals):
+//   - neighbors[].toReceive (accept allowlist, not peer-owned prefixes)
+//   - neighbors[].asn (peer ASN without reliable prefix ownership)
+func extractASNMappings(obj *unstructured.Unstructured) (map[string]uint32, error) {
+	if obj == nil {
+		return nil, fmt.Errorf("nil FRRConfiguration")
+	}
+
+	out := make(map[string]uint32)
+	routers, found, err := unstructured.NestedSlice(obj.Object, "spec", "bgp", "routers")
+	if err != nil {
+		return nil, fmt.Errorf("reading spec.bgp.routers: %w", err)
+	}
+	if !found {
+		return out, nil
+	}
+
+	for _, router := range routers {
+		routerMap, ok := router.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		asn, err := nestedUint32(routerMap, "asn")
+		if err != nil || asn == 0 {
+			continue
+		}
+
+		for _, prefix := range nestedStringSlice(routerMap, "prefixes") {
+			out[prefix] = asn
+		}
+
+		neighbors, _, err := unstructured.NestedSlice(routerMap, "neighbors")
+		if err != nil {
+			return nil, fmt.Errorf("reading neighbors: %w", err)
+		}
+		for _, neighbor := range neighbors {
+			neighborMap, ok := neighbor.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for _, prefix := range extractAdvertisePrefixes(neighborMap) {
+				out[prefix] = asn
+			}
+		}
+	}
+	return out, nil
+}
+
+func extractAdvertisePrefixes(neighbor map[string]interface{}) []string {
+	prefixes, found, err := unstructured.NestedSlice(neighbor, "toAdvertise", "allowed", "prefixes")
+	if err != nil || !found {
+		return nil
+	}
+	return coercePrefixList(prefixes)
+}
+
+func coercePrefixList(prefixes []interface{}) []string {
+	var result []string
+	for _, p := range prefixes {
+		switch v := p.(type) {
+		case string:
+			if v != "" {
+				result = append(result, v)
+			}
+		case map[string]interface{}:
+			if prefix, ok, _ := unstructured.NestedString(v, "prefix"); ok && prefix != "" {
+				result = append(result, prefix)
+			}
+		}
+	}
+	return result
+}
+
+func nestedStringSlice(obj map[string]interface{}, field string) []string {
+	raw, found, err := unstructured.NestedSlice(obj, field)
+	if err != nil || !found {
+		return nil
+	}
+	var out []string
+	for _, item := range raw {
+		if s, ok := item.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func nestedUint32(obj map[string]interface{}, field string) (uint32, error) {
+	v, found, err := unstructured.NestedFieldNoCopy(obj, field)
+	if err != nil {
+		return 0, err
+	}
+	if !found || v == nil {
+		return 0, fmt.Errorf("field %q not found", field)
+	}
+	switch n := v.(type) {
+	case int64:
+		return uint32(n), nil
+	case int32:
+		return uint32(n), nil
+	case int:
+		return uint32(n), nil
+	case float64:
+		return uint32(n), nil
+	default:
+		return 0, fmt.Errorf("field %q has unsupported type %T", field, v)
+	}
+}

--- a/pkg/pipeline/transform/frr/extract_test.go
+++ b/pkg/pipeline/transform/frr/extract_test.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2026 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package frr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestExtractASNMappings_LocalPrefixesAndAdvertise(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"apiVersion": "frrk8s.metallb.io/v1beta1",
+		"kind":       "FRRConfiguration",
+		"metadata": map[string]interface{}{
+			"name":      "ovnk-generated-ra",
+			"namespace": "openshift-frr-k8s",
+		},
+		"spec": map[string]interface{}{
+			"bgp": map[string]interface{}{
+				"routers": []interface{}{
+					map[string]interface{}{
+						"asn":      int64(64512),
+						"prefixes": []interface{}{"10.128.0.0/14", "10.128.2.0/24"},
+						"neighbors": []interface{}{
+							map[string]interface{}{
+								"address": "172.18.0.5",
+								"asn":     int64(65000),
+								"toAdvertise": map[string]interface{}{
+									"allowed": map[string]interface{}{
+										"prefixes": []interface{}{"10.128.2.0/24", "192.168.99.0/24"},
+									},
+								},
+								"toReceive": map[string]interface{}{
+									"allowed": map[string]interface{}{
+										"mode":     "filtered",
+										"prefixes": []interface{}{"203.0.113.0/24"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}}
+
+	got, err := extractASNMappings(obj)
+	require.NoError(t, err)
+	require.Equal(t, map[string]uint32{
+		"10.128.0.0/14":   64512,
+		"10.128.2.0/24":   64512,
+		"192.168.99.0/24": 64512, // from toAdvertise, still local ASN
+	}, got)
+	// toReceive must not contribute peer ASN ownership
+	_, hasRemote := got["203.0.113.0/24"]
+	require.False(t, hasRemote)
+}
+
+func TestExtractASNMappings_SkipsASNZero(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": map[string]interface{}{
+			"bgp": map[string]interface{}{
+				"routers": []interface{}{
+					map[string]interface{}{
+						"asn":      int64(0),
+						"prefixes": []interface{}{"10.0.0.0/8"},
+					},
+				},
+			},
+		},
+	}}
+	got, err := extractASNMappings(obj)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+func TestExtractASNMappings_MultiVRF(t *testing.T) {
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "multi", "namespace": "ns"},
+		"spec": map[string]interface{}{
+			"bgp": map[string]interface{}{
+				"routers": []interface{}{
+					map[string]interface{}{
+						"asn":      int64(64512),
+						"prefixes": []interface{}{"10.128.0.0/14"},
+					},
+					map[string]interface{}{
+						"asn":      int64(64513),
+						"vrf":      "blue",
+						"prefixes": []interface{}{"10.200.0.0/16"},
+					},
+				},
+			},
+		},
+	}}
+	got, err := extractASNMappings(obj)
+	require.NoError(t, err)
+	require.Equal(t, map[string]uint32{
+		"10.128.0.0/14": 64512,
+		"10.200.0.0/16": 64513,
+	}, got)
+}

--- a/pkg/pipeline/transform/frr/lpm.go
+++ b/pkg/pipeline/transform/frr/lpm.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package frr
+
+import (
+	"net"
+	"sort"
+)
+
+// prefixEntry maps a CIDR to an ASN. Entries are matched with longest-prefix match.
+type prefixEntry struct {
+	network *net.IPNet
+	bits    int
+	asn     uint32
+}
+
+// ASNTable is an immutable LPM table of CIDR → ASN. Safe for concurrent reads.
+type ASNTable struct {
+	entries []prefixEntry
+}
+
+// BuildASNTable builds a longest-prefix-match table from CIDR → ASN mappings.
+// Invalid CIDRs are skipped. ASN 0 entries are skipped (reserved / invalid for labeling).
+// On duplicate equal-length prefixes, the last write wins.
+func BuildASNTable(cidrs map[string]uint32) *ASNTable {
+	byCIDR := make(map[string]prefixEntry, len(cidrs))
+	for cidr, asn := range cidrs {
+		if asn == 0 {
+			continue
+		}
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil || ipNet == nil {
+			continue
+		}
+		ones, _ := ipNet.Mask.Size()
+		byCIDR[ipNet.String()] = prefixEntry{
+			network: ipNet,
+			bits:    ones,
+			asn:     asn,
+		}
+	}
+
+	entries := make([]prefixEntry, 0, len(byCIDR))
+	for _, e := range byCIDR {
+		entries = append(entries, e)
+	}
+	// Longest prefix first; stable order for equal lengths by CIDR string.
+	sort.SliceStable(entries, func(i, j int) bool {
+		if entries[i].bits != entries[j].bits {
+			return entries[i].bits > entries[j].bits
+		}
+		return entries[i].network.String() < entries[j].network.String()
+	})
+	return &ASNTable{entries: entries}
+}
+
+// Lookup returns the ASN for the longest matching prefix, or (0, false) if none.
+func (t *ASNTable) Lookup(ip net.IP) (uint32, bool) {
+	if t == nil || ip == nil {
+		return 0, false
+	}
+	for _, e := range t.entries {
+		if e.network.Contains(ip) {
+			return e.asn, true
+		}
+	}
+	return 0, false
+}
+
+// LookupString parses ip and looks up its ASN.
+func (t *ASNTable) LookupString(ipStr string) (uint32, bool) {
+	return t.Lookup(net.ParseIP(ipStr))
+}
+
+// Len returns the number of prefixes in the table.
+func (t *ASNTable) Len() int {
+	if t == nil {
+		return 0
+	}
+	return len(t.entries)
+}

--- a/pkg/pipeline/transform/frr/lpm_test.go
+++ b/pkg/pipeline/transform/frr/lpm_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package frr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildASNTable_LPM(t *testing.T) {
+	table := BuildASNTable(map[string]uint32{
+		"10.128.0.0/14":  64512,
+		"10.128.0.0/24":  64513,
+		"192.168.1.0/24": 65000,
+	})
+
+	asn, ok := table.LookupString("10.128.0.5")
+	require.True(t, ok)
+	require.Equal(t, uint32(64513), asn) // longest prefix wins
+
+	asn, ok = table.LookupString("10.129.1.1")
+	require.True(t, ok)
+	require.Equal(t, uint32(64512), asn)
+
+	asn, ok = table.LookupString("192.168.1.10")
+	require.True(t, ok)
+	require.Equal(t, uint32(65000), asn)
+
+	_, ok = table.LookupString("8.8.8.8")
+	require.False(t, ok)
+}
+
+func TestBuildASNTable_SkipsASNZeroAndInvalid(t *testing.T) {
+	table := BuildASNTable(map[string]uint32{
+		"10.0.0.0/8":     0,
+		"not-a-cidr":     64512,
+		"192.168.0.0/16": 64512,
+	})
+	require.Equal(t, 1, table.Len())
+	asn, ok := table.LookupString("192.168.1.1")
+	require.True(t, ok)
+	require.Equal(t, uint32(64512), asn)
+}

--- a/pkg/pipeline/transform/frr/store.go
+++ b/pkg/pipeline/transform/frr/store.go
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2026 IBM, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package frr
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/netobserv/flowlogs-pipeline/pkg/utils/k8sutils"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/cache"
+)
+
+const (
+	frrGroup    = "frrk8s.metallb.io"
+	frrVersion  = "v1beta1"
+	frrResource = "frrconfigurations"
+	syncPeriod  = 10 * time.Minute
+)
+
+var (
+	log = logrus.WithField("component", "transform.Network.FRR")
+	// Overridable in tests.
+	syncTimeout      = 30 * time.Second
+	probeListTimeout = 10 * time.Second
+)
+
+var frrGVR = schema.GroupVersionResource{
+	Group:    frrGroup,
+	Version:  frrVersion,
+	Resource: frrResource,
+}
+
+// Store indexes FRRConfiguration advertised prefixes into an LPM ASN table.
+type Store interface {
+	Lookup(ipStr string) (uint32, bool)
+}
+
+// InformerStore watches FRRConfiguration resources and maintains an ASN LPM table.
+type InformerStore struct {
+	mu    sync.RWMutex
+	raw   map[string]map[string]uint32 // object key → cidr→asn
+	table atomic.Pointer[ASNTable]
+
+	informer cache.SharedIndexInformer
+	stopCh   chan struct{}
+}
+
+func NewInformerStore() *InformerStore {
+	s := &InformerStore{
+		raw:    make(map[string]map[string]uint32),
+		stopCh: make(chan struct{}),
+	}
+	s.table.Store(BuildASNTable(nil))
+	return s
+}
+
+func (s *InformerStore) Lookup(ipStr string) (uint32, bool) {
+	return s.table.Load().LookupString(ipStr)
+}
+
+// Start watches FRRConfiguration resources cluster-wide.
+func (s *InformerStore) Start(kubeConfigPath string) error {
+	kconf, err := k8sutils.LoadK8sConfig(kubeConfigPath)
+	if err != nil {
+		return fmt.Errorf("loading kubeconfig for FRR informer: %w", err)
+	}
+	dynClient, err := dynamic.NewForConfig(kconf)
+	if err != nil {
+		return fmt.Errorf("creating dynamic client for FRR informer: %w", err)
+	}
+
+	probeCtx, probeCancel := context.WithTimeout(context.Background(), probeListTimeout)
+	defer probeCancel()
+	if _, err := dynClient.Resource(frrGVR).Namespace(metav1.NamespaceAll).List(probeCtx, metav1.ListOptions{Limit: 1}); err != nil {
+		return fmt.Errorf("listing FRRConfigurations (is the frr-k8s CRD installed?): %w", err)
+	}
+
+	lw := &cache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return dynClient.Resource(frrGVR).Namespace(metav1.NamespaceAll).List(context.Background(), options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return dynClient.Resource(frrGVR).Namespace(metav1.NamespaceAll).Watch(context.Background(), options)
+		},
+	}
+	return s.startInformer(lw)
+}
+
+func (s *InformerStore) startInformer(lw cache.ListerWatcher) error {
+	s.informer = cache.NewSharedIndexInformer(lw, &unstructured.Unstructured{}, syncPeriod, cache.Indexers{})
+	_, err := s.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			s.upsert(obj)
+		},
+		UpdateFunc: func(_, newObj interface{}) {
+			s.upsert(newObj)
+		},
+		DeleteFunc: func(obj interface{}) {
+			s.remove(obj)
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("adding FRR informer handlers: %w", err)
+	}
+
+	go s.informer.Run(s.stopCh)
+	syncCtx, syncCancel := context.WithTimeout(context.Background(), syncTimeout)
+	defer syncCancel()
+	if !cache.WaitForCacheSync(syncCtx.Done(), s.informer.HasSynced) {
+		s.Stop()
+		return fmt.Errorf("timed out waiting for FRRConfiguration informer sync")
+	}
+	log.Infof("FRRConfiguration informer started (%d prefixes indexed)", s.table.Load().Len())
+	return nil
+}
+
+func (s *InformerStore) Stop() {
+	select {
+	case <-s.stopCh:
+	default:
+		close(s.stopCh)
+	}
+}
+
+func (s *InformerStore) upsert(obj interface{}) {
+	u, ok := asUnstructured(obj)
+	if !ok {
+		return
+	}
+	mappings, err := extractASNMappings(u)
+	if err != nil {
+		log.WithError(err).Warnf("failed to extract FRRConfiguration %s/%s", u.GetNamespace(), u.GetName())
+		return
+	}
+	key := objectKey(u)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.raw[key] = mappings
+	s.rebuildLocked()
+}
+
+func (s *InformerStore) remove(obj interface{}) {
+	u, ok := asUnstructured(obj)
+	if !ok {
+		if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+			u, ok = asUnstructured(tombstone.Obj)
+			if !ok {
+				return
+			}
+		} else {
+			return
+		}
+	}
+	key := objectKey(u)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.raw, key)
+	s.rebuildLocked()
+}
+
+func (s *InformerStore) rebuildLocked() {
+	merged := make(map[string]uint32)
+	for _, mappings := range s.raw {
+		for cidr, asn := range mappings {
+			merged[cidr] = asn
+		}
+	}
+	s.table.Store(BuildASNTable(merged))
+}
+
+// LoadConfigs populates the store without a live API server (tests).
+func (s *InformerStore) LoadConfigs(configs ...*unstructured.Unstructured) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.raw = make(map[string]map[string]uint32)
+	for _, cfg := range configs {
+		mappings, err := extractASNMappings(cfg)
+		if err != nil {
+			return err
+		}
+		s.raw[objectKey(cfg)] = mappings
+	}
+	s.rebuildLocked()
+	return nil
+}
+
+func asUnstructured(obj interface{}) (*unstructured.Unstructured, bool) {
+	switch v := obj.(type) {
+	case *unstructured.Unstructured:
+		return v, true
+	case unstructured.Unstructured:
+		return &v, true
+	default:
+		return nil, false
+	}
+}
+
+func objectKey(u *unstructured.Unstructured) string {
+	return fmt.Sprintf("%s/%s", u.GetNamespace(), u.GetName())
+}

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -242,58 +242,65 @@ func initNetworkServices(cfg *api.TransformNetwork) (*netdb.ServiceNames, error)
 	return netdb.LoadServicesDB(protos, services)
 }
 
+type networkInitFlags struct {
+	locationDBConfig          *api.NetworkAddLocationRule
+	needToInitKubeData        bool
+	needToInitNetworkServices bool
+	needToInitFRR             bool
+}
+
+func inspectNetworkRules(cfg *api.TransformNetwork) (networkInitFlags, error) {
+	var flags networkInitFlags
+	for _, rule := range cfg.Rules {
+		switch rule.Type {
+		case api.NetworkAddLocation:
+			if rule.AddLocation == nil {
+				return flags, fmt.Errorf("missing configuration for '%s' rule", api.NetworkAddLocation)
+			}
+			flags.locationDBConfig = rule.AddLocation
+		case api.NetworkAddKubernetes, api.NetworkAddKubernetesInfra:
+			flags.needToInitKubeData = true
+		case api.NetworkAddService:
+			flags.needToInitNetworkServices = true
+		case api.NetworkReinterpretDirection:
+			if err := validateReinterpretDirectionConfig(&cfg.DirectionInfo); err != nil {
+				return flags, err
+			}
+		case api.NetworkAddASNLabel:
+			flags.needToInitFRR = true
+		case api.NetworkAddSubnetLabel, api.NetworkAddSubnet, api.NetworkDecodeTCPFlags:
+			// no init required
+		}
+	}
+	return flags, nil
+}
+
 // NewTransformNetwork create a new network transform
 func NewTransformNetwork(params config.StageParam, opMetrics *operational.Metrics) (Transformer, error) {
-	var locationDBConfig *api.NetworkAddLocationRule
-	var needToInitKubeData = false
-	var needToInitNetworkServices = false
-
 	jsonNetworkTransform := api.TransformNetwork{}
 	if params.Transform != nil && params.Transform.Network != nil {
 		jsonNetworkTransform = *params.Transform.Network
 	}
 	jsonNetworkTransform.Preprocess()
 
-	var needToInitFRR = false
-	for _, rule := range jsonNetworkTransform.Rules {
-		switch rule.Type {
-		case api.NetworkAddLocation:
-			if rule.AddLocation == nil {
-				return nil, fmt.Errorf("missing configuration for '%s' rule", api.NetworkAddLocation)
-			}
-			locationDBConfig = rule.AddLocation
-		case api.NetworkAddKubernetes:
-			needToInitKubeData = true
-		case api.NetworkAddKubernetesInfra:
-			needToInitKubeData = true
-		case api.NetworkAddService:
-			needToInitNetworkServices = true
-		case api.NetworkReinterpretDirection:
-			if err := validateReinterpretDirectionConfig(&jsonNetworkTransform.DirectionInfo); err != nil {
-				return nil, err
-			}
-		case api.NetworkAddASNLabel:
-			needToInitFRR = true
-		case api.NetworkAddSubnetLabel, api.NetworkAddSubnet, api.NetworkDecodeTCPFlags:
-			// nothing
-		}
+	flags, err := inspectNetworkRules(&jsonNetworkTransform)
+	if err != nil {
+		return nil, err
 	}
 
-	if locationDBConfig != nil {
-		err := location.InitLocationDB(locationDBConfig.FilePath)
-		if err != nil {
+	if flags.locationDBConfig != nil {
+		if err := location.InitLocationDB(flags.locationDBConfig.FilePath); err != nil {
 			log.Warnf("location.InitLocationDB error: %v", err)
 		}
 	}
 
-	if needToInitKubeData {
-		err := kubernetes.InitInformerDatasource(&jsonNetworkTransform.KubeConfig, opMetrics)
-		if err != nil {
+	if flags.needToInitKubeData {
+		if err := kubernetes.InitInformerDatasource(&jsonNetworkTransform.KubeConfig, opMetrics); err != nil {
 			return nil, err
 		}
 	}
 
-	if needToInitFRR {
+	if flags.needToInitFRR {
 		// Soft-fail: BGP/FRR is optional; enrichment simply no-ops without a store.
 		if err := frr.InitStore(jsonNetworkTransform.KubeConfig.ConfigPath); err != nil {
 			log.Warnf("FRR ASN enrichment disabled: %v", err)
@@ -301,7 +308,7 @@ func NewTransformNetwork(params config.StageParam, opMetrics *operational.Metric
 	}
 
 	var servicesDB *netdb.ServiceNames
-	if needToInitNetworkServices {
+	if flags.needToInitNetworkServices {
 		db, err := initNetworkServices(&jsonNetworkTransform)
 		if err != nil {
 			return nil, err

--- a/pkg/pipeline/transform/transform_network.go
+++ b/pkg/pipeline/transform/transform_network.go
@@ -29,6 +29,7 @@ import (
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
 	"github.com/netobserv/flowlogs-pipeline/pkg/operational"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/frr"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/kubernetes"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/location"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/netdb"
@@ -154,6 +155,8 @@ func (n *Network) Transform(inputEntry config.GenericMap) (config.GenericMap, bo
 					}
 				}
 			}
+		case api.NetworkAddASNLabel:
+			frr.Enrich(outputEntry, rule.AddASNLabel)
 
 		default:
 			log.Panicf("unknown type %s for transform.Network rule: %v", rule.Type, rule)
@@ -251,6 +254,7 @@ func NewTransformNetwork(params config.StageParam, opMetrics *operational.Metric
 	}
 	jsonNetworkTransform.Preprocess()
 
+	var needToInitFRR = false
 	for _, rule := range jsonNetworkTransform.Rules {
 		switch rule.Type {
 		case api.NetworkAddLocation:
@@ -268,6 +272,8 @@ func NewTransformNetwork(params config.StageParam, opMetrics *operational.Metric
 			if err := validateReinterpretDirectionConfig(&jsonNetworkTransform.DirectionInfo); err != nil {
 				return nil, err
 			}
+		case api.NetworkAddASNLabel:
+			needToInitFRR = true
 		case api.NetworkAddSubnetLabel, api.NetworkAddSubnet, api.NetworkDecodeTCPFlags:
 			// nothing
 		}
@@ -284,6 +290,13 @@ func NewTransformNetwork(params config.StageParam, opMetrics *operational.Metric
 		err := kubernetes.InitInformerDatasource(&jsonNetworkTransform.KubeConfig, opMetrics)
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	if needToInitFRR {
+		// Soft-fail: BGP/FRR is optional; enrichment simply no-ops without a store.
+		if err := frr.InitStore(jsonNetworkTransform.KubeConfig.ConfigPath); err != nil {
+			log.Warnf("FRR ASN enrichment disabled: %v", err)
 		}
 	}
 

--- a/pkg/pipeline/transform/transform_network_test.go
+++ b/pkg/pipeline/transform/transform_network_test.go
@@ -24,10 +24,12 @@ import (
 
 	"github.com/netobserv/flowlogs-pipeline/pkg/api"
 	"github.com/netobserv/flowlogs-pipeline/pkg/config"
+	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/frr"
 	"github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/location"
 	netdb "github.com/netobserv/flowlogs-pipeline/pkg/pipeline/transform/netdb"
 	"github.com/netobserv/flowlogs-pipeline/pkg/test"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func getMockNetworkTransformRules() api.NetworkTransformRules {
@@ -240,6 +242,54 @@ func InitNewTransformNetwork(t *testing.T, configFile string) Transformer {
 	newTransform, err := NewTransformNetwork(config, nil)
 	require.NoError(t, err)
 	return newTransform
+}
+
+func Test_AddASNLabel(t *testing.T) {
+	frr.ResetStore()
+	t.Cleanup(frr.ResetStore)
+
+	store := frr.NewInformerStore()
+	require.NoError(t, store.LoadConfigs(&unstructured.Unstructured{Object: map[string]interface{}{
+		"metadata": map[string]interface{}{"name": "test", "namespace": "ns"},
+		"spec": map[string]interface{}{
+			"bgp": map[string]interface{}{
+				"routers": []interface{}{
+					map[string]interface{}{
+						"asn":      int64(64512),
+						"prefixes": []interface{}{"10.128.0.0/14"},
+					},
+					map[string]interface{}{
+						"asn":      int64(64513),
+						"vrf":      "blue",
+						"prefixes": []interface{}{"10.128.2.0/24"},
+					},
+				},
+			},
+		},
+	}}))
+	frr.SetStore(store)
+
+	cfg := config.StageParam{
+		Transform: &config.Transform{
+			Network: &api.TransformNetwork{
+				Rules: []api.NetworkTransformRule{
+					{Type: api.NetworkAddASNLabel, AddASNLabel: &api.NetworkAddASNLabelRule{Input: "SrcAddr", Output: "SrcASN"}},
+					{Type: api.NetworkAddASNLabel, AddASNLabel: &api.NetworkAddASNLabelRule{Input: "DstAddr", Output: "DstASN"}},
+				},
+			},
+		},
+	}
+	// Store already injected; InitStore is a no-op when a store is set.
+	tr, err := NewTransformNetwork(cfg, nil)
+	require.NoError(t, err)
+
+	output, ok := tr.Transform(config.GenericMap{
+		"SrcAddr": "10.128.2.8",
+		"DstAddr": "10.129.0.1",
+	})
+	require.True(t, ok)
+	require.Equal(t, "64513", output["SrcASN"]) // LPM: /24 over /14
+	require.Equal(t, "64512", output["DstASN"])
 }
 
 func Test_Categorize(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `add_asn_label` network transform: LPM IP → local ASN from `FRRConfiguration` (`frrk8s.metallb.io/v1beta1`)
- Index `routers[].prefixes` and `toAdvertise` prefixes → `routers[].asn` (not `toReceive` / peer ASN)
- Soft-fail when FRR CRD is absent (cloud / no BGP); enrichment no-ops
- Separate stage name `asns` (ready for operator Dynamic wiring later)
- Unit tests for extract, LPM, enrich, and network transform wiring

## Usage
```yaml
name: asns
transform:
  type: network
  network:
    rules:
      - type: add_asn_label
        add_asn_label: { input: SrcAddr, output: SrcASN }
      - type: add_asn_label
        add_asn_label: { input: DstAddr, output: DstASN }
```

## Out of scope (follow-ups)
- FlowCollector admin `asnLabels` maps
- Operator pipeline / Dynamic CM wiring
- Remote/peer ASN from RIB/BMP

## Test plan
- [x] Unit tests (`pkg/pipeline/transform/frr`, `Test_AddASNLabel`)
- [x] `make lint` / build clean
- [x] Manual: BM cluster with FRR + `FRRConfiguration`; assert `SrcASN`/`DstASN` on flows matching advertised CIDRs
- [ ] Manual: cluster without FRR CRD; pipeline starts, no ASN fields

@luisjira PTAL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added network transform support for enriching flow records with source and destination ASN labels.
  - ASN resolution uses the most specific matching network prefix and updates automatically from FRR configuration data.
  - Added an example configuration and sample flow records demonstrating ASN enrichment.

- **Bug Fixes**
  - ASN resolution now handles overlapping or duplicate prefixes deterministically.

- **Documentation**
  - Reformatted CLI help text in the README for improved alignment and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->