### PR TITLE
NETOBSERV-2916: Fix secondary-networks enrichment with informers

### DIFF
--- a/cmd/flp-informers/main.go
+++ b/cmd/flp-informers/main.go
@@ -205,38 +205,7 @@ func run(_ *cobra.Command, _ []string) {
 	cancel()
 }
 
-func runInformers(ctx context.Context, healthServer *informers.HealthServer) {
-	log.Info("Starting informers and gRPC client")
-
-	// Create gRPC client
-	clientConfig := k8scache.ClientConfig{
-		TLSEnabled:         opts.TLSEnabled,
-		TLSCertPath:        opts.TLSCertPath,
-		TLSKeyPath:         opts.TLSKeyPath,
-		TLSCAPath:          opts.TLSCAPath,
-		TLSServerName:      opts.TLSServerName,
-		InsecureSkipVerify: opts.InsecureSkipVerify,
-		UpdateBufferSize:   opts.UpdateBufferSize,
-		SendTimeout:        time.Duration(opts.SendTimeoutSec) * time.Second,
-		BatchSize:          opts.BatchSize,
-	}
-	grpcClient := k8scache.NewClient(&clientConfig)
-
-	if opts.TLSEnabled {
-		log.Info("TLS enabled for gRPC connections to processors")
-		// Warn if neither TLSServerName nor ProcessorServiceName is set (may cause TLS verification issues)
-		if opts.TLSServerName == "" && opts.ProcessorServiceName == "" {
-			log.Warn("TLS enabled but neither --tls-server-name nor --processor-service-name is set. " +
-				"TLS verification may fail when connecting by IP. Consider setting one of these options.")
-		}
-	} else {
-		log.Warn("TLS disabled - connections to processors are insecure (not recommended for production)")
-	}
-	grpcClient.Start()
-	defer grpcClient.Stop()
-
-	// Initialize Kubernetes informers
-	// Parse CLI flags into api config to ensure informer settings match processor settings
+func buildKubeConfig() *api.NetworkTransformKubeConfig {
 	apiConfig := &api.NetworkTransformKubeConfig{
 		ConfigPath: opts.Kubeconfig,
 	}
@@ -277,6 +246,41 @@ func runInformers(ctx context.Context, healthServer *informers.HealthServer) {
 		}
 	}
 
+	return apiConfig
+}
+
+func runInformers(ctx context.Context, healthServer *informers.HealthServer) {
+	log.Info("Starting informers and gRPC client")
+
+	// Create gRPC client
+	clientConfig := k8scache.ClientConfig{
+		TLSEnabled:         opts.TLSEnabled,
+		TLSCertPath:        opts.TLSCertPath,
+		TLSKeyPath:         opts.TLSKeyPath,
+		TLSCAPath:          opts.TLSCAPath,
+		TLSServerName:      opts.TLSServerName,
+		InsecureSkipVerify: opts.InsecureSkipVerify,
+		UpdateBufferSize:   opts.UpdateBufferSize,
+		SendTimeout:        time.Duration(opts.SendTimeoutSec) * time.Second,
+		BatchSize:          opts.BatchSize,
+	}
+	grpcClient := k8scache.NewClient(&clientConfig)
+
+	if opts.TLSEnabled {
+		log.Info("TLS enabled for gRPC connections to processors")
+		// Warn if neither TLSServerName nor ProcessorServiceName is set (may cause TLS verification issues)
+		if opts.TLSServerName == "" && opts.ProcessorServiceName == "" {
+			log.Warn("TLS enabled but neither --tls-server-name nor --processor-service-name is set. " +
+				"TLS verification may fail when connecting by IP. Consider setting one of these options.")
+		}
+	} else {
+		log.Warn("TLS disabled - connections to processors are insecure (not recommended for production)")
+	}
+	grpcClient.Start()
+	defer grpcClient.Stop()
+
+	// Initialize Kubernetes informers
+	apiConfig := buildKubeConfig()
 	infConfig := k8sinformers.NewConfig(apiConfig)
 	inf := &k8sinformers.Informers{}
 	opMetrics := operational.NewMetrics(&config.MetricsSettings{})

--- a/cmd/flp-informers/main.go
+++ b/cmd/flp-informers/main.go
@@ -262,9 +262,15 @@ func runInformers(ctx context.Context, healthServer *informers.HealthServer) {
 		indexTypes := strings.Split(opts.SecondaryNetworks, ",")
 		indexMap := map[string]any{}
 		for _, t := range indexTypes {
-			indexMap[strings.TrimSpace(t)] = nil
+			t = strings.TrimSpace(t)
+			if t == "" {
+				continue
+			}
+			indexMap[t] = nil
 		}
-		apiConfig.SecondaryNetworks = []api.SecondaryNetwork{{Index: indexMap}}
+		if len(indexMap) > 0 {
+			apiConfig.SecondaryNetworks = []api.SecondaryNetwork{{Index: indexMap}}
+		}
 	}
 
 	infConfig := k8sinformers.NewConfig(apiConfig)

--- a/cmd/flp-informers/main.go
+++ b/cmd/flp-informers/main.go
@@ -52,8 +52,9 @@ type options struct {
 	HealthPort           int  // Port for health check HTTP server
 	MetricsPort          int  // Port for Prometheus metrics HTTP server
 	// Kubernetes informer configuration (must match processor settings)
-	ManagedCNI   string // Comma-separated list of CNI plugins to manage (e.g., "ovn")
-	TrackedKinds string // Comma-separated list of Kubernetes kinds to track (e.g., "Deployment,Gateway")
+	ManagedCNI        string // Comma-separated list of CNI plugins to manage (e.g., "ovn")
+	TrackedKinds      string // Comma-separated list of Kubernetes kinds to track (e.g., "Deployment,Gateway")
+	SecondaryNetworks string // Comma-separated list of secondary network index types (e.g., "ip,mac,interface,udn")
 }
 
 var opts = options{}
@@ -138,6 +139,7 @@ func initFlags() {
 	// Kubernetes informer configuration
 	rootCmd.PersistentFlags().StringVar(&opts.ManagedCNI, "managed-cni", "", "Comma-separated list of CNI plugins to manage (e.g., 'ovn'). Must match processor configuration.")
 	rootCmd.PersistentFlags().StringVar(&opts.TrackedKinds, "tracked-kinds", "", "Comma-separated list of Kubernetes kinds to track for ownership (e.g., 'Deployment,Gateway'). Must match processor configuration.")
+	rootCmd.PersistentFlags().StringVar(&opts.SecondaryNetworks, "secondary-networks", "", "Comma-separated list of secondary network index types (e.g., 'ip,mac,interface,udn'). Must match processor configuration.")
 }
 
 func main() {
@@ -253,6 +255,16 @@ func runInformers(ctx context.Context, healthServer *informers.HealthServer) {
 		for i := range apiConfig.TrackedKinds {
 			apiConfig.TrackedKinds[i] = strings.TrimSpace(apiConfig.TrackedKinds[i])
 		}
+	}
+
+	// Parse comma-separated secondary network index types
+	if opts.SecondaryNetworks != "" {
+		indexTypes := strings.Split(opts.SecondaryNetworks, ",")
+		indexMap := map[string]any{}
+		for _, t := range indexTypes {
+			indexMap[strings.TrimSpace(t)] = nil
+		}
+		apiConfig.SecondaryNetworks = []api.SecondaryNetwork{{Index: indexMap}}
 	}
 
 	infConfig := k8sinformers.NewConfig(apiConfig)

--- a/cmd/flp-informers/main.go
+++ b/cmd/flp-informers/main.go
@@ -54,7 +54,7 @@ type options struct {
 	// Kubernetes informer configuration (must match processor settings)
 	ManagedCNI        string // Comma-separated list of CNI plugins to manage (e.g., "ovn")
 	TrackedKinds      string // Comma-separated list of Kubernetes kinds to track (e.g., "Deployment,Gateway")
-	SecondaryNetworks string // Comma-separated list of secondary network index types (e.g., "ip,mac,interface,udn")
+	SecondaryNetworks string // Semicolon-separated index sets, comma-separated within (e.g., "interface,ip;interface,mac;udn")
 }
 
 var opts = options{}
@@ -139,7 +139,7 @@ func initFlags() {
 	// Kubernetes informer configuration
 	rootCmd.PersistentFlags().StringVar(&opts.ManagedCNI, "managed-cni", "", "Comma-separated list of CNI plugins to manage (e.g., 'ovn'). Must match processor configuration.")
 	rootCmd.PersistentFlags().StringVar(&opts.TrackedKinds, "tracked-kinds", "", "Comma-separated list of Kubernetes kinds to track for ownership (e.g., 'Deployment,Gateway'). Must match processor configuration.")
-	rootCmd.PersistentFlags().StringVar(&opts.SecondaryNetworks, "secondary-networks", "", "Comma-separated list of secondary network index types (e.g., 'ip,mac,interface,udn'). Must match processor configuration.")
+	rootCmd.PersistentFlags().StringVar(&opts.SecondaryNetworks, "secondary-networks", "", "Semicolon-separated index sets, comma-separated within (e.g., 'interface,ip;interface,mac;udn'). Must match processor configuration.")
 }
 
 func main() {
@@ -257,19 +257,23 @@ func runInformers(ctx context.Context, healthServer *informers.HealthServer) {
 		}
 	}
 
-	// Parse comma-separated secondary network index types
+	// Parse secondary network index sets (semicolon-separated groups, comma-separated within each group)
 	if opts.SecondaryNetworks != "" {
-		indexTypes := strings.Split(opts.SecondaryNetworks, ",")
-		indexMap := map[string]any{}
-		for _, t := range indexTypes {
-			t = strings.TrimSpace(t)
-			if t == "" {
+		for _, group := range strings.Split(opts.SecondaryNetworks, ";") {
+			group = strings.TrimSpace(group)
+			if group == "" {
 				continue
 			}
-			indexMap[t] = nil
-		}
-		if len(indexMap) > 0 {
-			apiConfig.SecondaryNetworks = []api.SecondaryNetwork{{Index: indexMap}}
+			indexMap := map[string]any{}
+			for _, t := range strings.Split(group, ",") {
+				t = strings.TrimSpace(t)
+				if t != "" {
+					indexMap[t] = nil
+				}
+			}
+			if len(indexMap) > 0 {
+				apiConfig.SecondaryNetworks = append(apiConfig.SecondaryNetworks, api.SecondaryNetwork{Index: indexMap})
+			}
 		}
 	}
 

--- a/pkg/pipeline/transform/kubernetes/datasource/datasource.go
+++ b/pkg/pipeline/transform/kubernetes/datasource/datasource.go
@@ -43,6 +43,7 @@ func (d *Datasource) IndexLookup(potentialKeys []string, ip string) *model.Resou
 	if d.kubernetesStore != nil {
 		return d.kubernetesStore.IndexLookup(potentialKeys, ip)
 	}
+	// Fallback to local informers if available (nil when k8scache is enabled)
 	if d.Informers != nil {
 		return d.Informers.IndexLookup(potentialKeys, ip)
 	}

--- a/pkg/pipeline/transform/kubernetes/datasource/datasource.go
+++ b/pkg/pipeline/transform/kubernetes/datasource/datasource.go
@@ -40,21 +40,13 @@ func NewDatasourceK8sCache() *Datasource {
 }
 
 func (d *Datasource) IndexLookup(potentialKeys []string, ip string) *model.ResourceMetaData {
-	var result *model.ResourceMetaData
 	if d.kubernetesStore != nil {
-		result = d.kubernetesStore.IndexLookup(potentialKeys, ip)
-	} else if d.Informers != nil {
-		result = d.Informers.IndexLookup(potentialKeys, ip)
+		return d.kubernetesStore.IndexLookup(potentialKeys, ip)
 	}
-	if result != nil {
-		for _, key := range potentialKeys {
-			if name, ok := result.SecondaryNetNames[key]; ok {
-				result.NetworkName = name
-				break
-			}
-		}
+	if d.Informers != nil {
+		return d.Informers.IndexLookup(potentialKeys, ip)
 	}
-	return result
+	return nil
 }
 
 func (d *Datasource) GetNodeByName(name string) (*model.ResourceMetaData, error) {

--- a/pkg/pipeline/transform/kubernetes/datasource/datasource.go
+++ b/pkg/pipeline/transform/kubernetes/datasource/datasource.go
@@ -40,14 +40,21 @@ func NewDatasourceK8sCache() *Datasource {
 }
 
 func (d *Datasource) IndexLookup(potentialKeys []string, ip string) *model.ResourceMetaData {
+	var result *model.ResourceMetaData
 	if d.kubernetesStore != nil {
-		return d.kubernetesStore.IndexLookup(potentialKeys, ip)
+		result = d.kubernetesStore.IndexLookup(potentialKeys, ip)
+	} else if d.Informers != nil {
+		result = d.Informers.IndexLookup(potentialKeys, ip)
 	}
-	// Fallback to local informers if available (nil when k8scache is enabled)
-	if d.Informers != nil {
-		return d.Informers.IndexLookup(potentialKeys, ip)
+	if result != nil {
+		for _, key := range potentialKeys {
+			if name, ok := result.SecondaryNetNames[key]; ok {
+				result.NetworkName = name
+				break
+			}
+		}
 	}
-	return nil
+	return result
 }
 
 func (d *Datasource) GetNodeByName(name string) (*model.ResourceMetaData, error) {

--- a/pkg/pipeline/transform/kubernetes/datasource/kubernetesstore.go
+++ b/pkg/pipeline/transform/kubernetes/datasource/kubernetesstore.go
@@ -145,12 +145,14 @@ func (s *KubernetesStore) Delete(entries []*model.ResourceMetaData) {
 
 // IndexLookup finds metadata by secondary network keys first, then by IP.
 // Implements the same semantics as informers.Interface for use when KubernetesStore is the source.
+// When found via a secondary key, NetworkName is set on the result (requires write lock).
 func (s *KubernetesStore) IndexLookup(potentialKeys []string, ip string) *model.ResourceMetaData {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	for _, key := range potentialKeys {
 		if meta, ok := s.bySecondaryKey[key]; ok {
+			meta.NetworkName = meta.SecondaryNetNames[key]
 			return meta
 		}
 	}

--- a/pkg/pipeline/transform/kubernetes/datasource/kubernetesstore.go
+++ b/pkg/pipeline/transform/kubernetes/datasource/kubernetesstore.go
@@ -145,15 +145,17 @@ func (s *KubernetesStore) Delete(entries []*model.ResourceMetaData) {
 
 // IndexLookup finds metadata by secondary network keys first, then by IP.
 // Implements the same semantics as informers.Interface for use when KubernetesStore is the source.
-// When found via a secondary key, NetworkName is set on the result (requires write lock).
+// When found via a secondary key, a shallow copy is returned with NetworkName set,
+// to avoid mutating the shared index entry visible to other lookup paths.
 func (s *KubernetesStore) IndexLookup(potentialKeys []string, ip string) *model.ResourceMetaData {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
 	for _, key := range potentialKeys {
 		if meta, ok := s.bySecondaryKey[key]; ok {
-			meta.NetworkName = meta.SecondaryNetNames[key]
-			return meta
+			result := *meta
+			result.NetworkName = meta.SecondaryNetNames[key]
+			return &result
 		}
 	}
 	if ip != "" {

--- a/pkg/pipeline/transform/kubernetes/datasource/kubernetesstore_test.go
+++ b/pkg/pipeline/transform/kubernetes/datasource/kubernetesstore_test.go
@@ -101,13 +101,14 @@ func TestKubernetesStore_SecondaryNetworkLookup(t *testing.T) {
 
 	store.AddOrUpdate([]*model.ResourceMetaData{pod})
 
-	t.Run("lookup by secondary key", func(t *testing.T) {
+	t.Run("lookup by secondary key sets NetworkName", func(t *testing.T) {
 		result := store.IndexLookup([]string{"~~aa:bb:cc:dd:ee:ff"}, "")
 		require.NotNil(t, result)
 		require.Equal(t, "udn-pod", result.Name)
+		require.Equal(t, "cudn-network", result.NetworkName)
 	})
 
-	t.Run("datasource resolves NetworkName from SecondaryNetNames", func(t *testing.T) {
+	t.Run("datasource delegates NetworkName to KubernetesStore", func(t *testing.T) {
 		ds := &Datasource{}
 		ds.SetKubernetesStore(store)
 

--- a/pkg/pipeline/transform/kubernetes/datasource/kubernetesstore_test.go
+++ b/pkg/pipeline/transform/kubernetes/datasource/kubernetesstore_test.go
@@ -118,6 +118,18 @@ func TestKubernetesStore_SecondaryNetworkLookup(t *testing.T) {
 		require.Equal(t, "cudn-network", result.NetworkName)
 	})
 
+	t.Run("secondary lookup does not leak NetworkName to IP lookup", func(t *testing.T) {
+		// First: lookup by secondary key sets NetworkName on the returned copy
+		byKey := store.IndexLookup([]string{"~~aa:bb:cc:dd:ee:ff"}, "")
+		require.NotNil(t, byKey)
+		require.Equal(t, "cudn-network", byKey.NetworkName)
+
+		// Second: lookup same pod by IP should not have NetworkName from above
+		byIP := store.IndexLookup(nil, "10.0.0.1")
+		require.NotNil(t, byIP)
+		require.Equal(t, "udn-pod", byIP.Name)
+		require.Empty(t, byIP.NetworkName)
+	})
 }
 
 // TestKubernetesStore_FirstMatchWins verifies that byIP honors "first match wins"

--- a/pkg/pipeline/transform/kubernetes/datasource/kubernetesstore_test.go
+++ b/pkg/pipeline/transform/kubernetes/datasource/kubernetesstore_test.go
@@ -82,6 +82,43 @@ func TestKubernetesStore_NilEntries(t *testing.T) {
 	})
 }
 
+// TestKubernetesStore_SecondaryNetworkLookup verifies that IndexLookup by secondary
+// network key returns the entry and that Datasource resolves NetworkName from SecondaryNetNames
+func TestKubernetesStore_SecondaryNetworkLookup(t *testing.T) {
+	store := NewKubernetesStore()
+
+	pod := &model.ResourceMetaData{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "udn-pod",
+			Namespace: "udn-ns",
+			UID:       "uid-udn-pod",
+		},
+		Kind:              "Pod",
+		IPs:               []string{"10.0.0.1"},
+		SecondaryNetKeys:  []string{"~~aa:bb:cc:dd:ee:ff"},
+		SecondaryNetNames: map[string]string{"~~aa:bb:cc:dd:ee:ff": "cudn-network"},
+	}
+
+	store.AddOrUpdate([]*model.ResourceMetaData{pod})
+
+	t.Run("lookup by secondary key", func(t *testing.T) {
+		result := store.IndexLookup([]string{"~~aa:bb:cc:dd:ee:ff"}, "")
+		require.NotNil(t, result)
+		require.Equal(t, "udn-pod", result.Name)
+	})
+
+	t.Run("datasource resolves NetworkName from SecondaryNetNames", func(t *testing.T) {
+		ds := &Datasource{}
+		ds.SetKubernetesStore(store)
+
+		result := ds.IndexLookup([]string{"~~aa:bb:cc:dd:ee:ff"}, "")
+		require.NotNil(t, result)
+		require.Equal(t, "udn-pod", result.Name)
+		require.Equal(t, "cudn-network", result.NetworkName)
+	})
+
+}
+
 // TestKubernetesStore_FirstMatchWins verifies that byIP honors "first match wins"
 // and deletion only removes entries owned by the resource being deleted
 func TestKubernetesStore_FirstMatchWins(t *testing.T) {


### PR DESCRIPTION
## Description

Secondary networks enrichment is broken with FLP informers

## Dependencies
https://github.com/netobserv/netobserv-operator/pull/2880

## Checklist

<!-- If you are not familiar with our processes or don't know what to answer in the list below, let us know in a comment: the maintainers will take care of that. -->

* [ ] Does the changes in PR need specific configuration or environment set up for testing?
   * [ ]  if so please describe it in PR description.
* [ ] I have added thorough unit tests for the change.
* QE requirements (check 1 from the list):
  * [ ] Standard QE validation, with pre-merge tests unless stated otherwise.
  * [ ] Regression tests only (e.g. refactoring with no user-facing change).
  * [x] No QE (e.g. trivial change with high reviewer's confidence, or per agreement with the QE team).

_To run a perfscale test, comment with: `/test flp-node-density-heavy-25nodes`_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `--secondary-networks` option for configuring multiple secondary networks.
  - Supports semicolon-separated network groups with comma-separated index types.
  - Automatically trims entries, ignores empty groups and values, and applies valid configurations during initialization.
  - Secondary-network lookups now identify the associated network name alongside pod metadata.
  - Improves flexibility and accuracy when defining and resolving network-related settings for informer-based workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->