### PR TITLE
NETOBSERV-2912: Enable PQC in OpenSSL: switch to ubi-minimal-pqc base image

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,11 @@
 ARG TARGETARCH
+
+# PQC crypto-policies builder
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8 AS crypto-builder
+RUN microdnf install -y crypto-policies-scripts && \
+    update-crypto-policies --set DEFAULT:PQ && \
+    microdnf clean all && rm -rf /var/cache/*
+
 FROM docker.io/library/golang:1.26 AS builder
 
 ARG TARGETARCH=amd64
@@ -17,8 +24,9 @@ RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -ldflags "$LDFLAGS" -mod vendor -o
 RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -ldflags "$LDFLAGS" -mod vendor -o flp-informers ./cmd/flp-informers
 
 # final stage
-FROM --platform=linux/$TARGETARCH registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
+FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:1784092978
 
+COPY --from=crypto-builder /etc/crypto-policies/ /etc/crypto-policies/
 COPY --from=builder /app/flowlogs-pipeline /app/
 COPY --from=builder /app/flp-informers /app/
 

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -ldflags "$LDFLAGS" -mod vendor -o
 RUN CGO_ENABLED=0 GOARCH=$TARGETARCH go build -ldflags "$LDFLAGS" -mod vendor -o flp-informers ./cmd/flp-informers
 
 # final stage
-FROM --platform=linux/$TARGETARCH registry.access.redhat.com/ubi9/ubi-minimal:1784092978
+FROM --platform=linux/$TARGETARCH registry.redhat.io/ubi9/ubi-minimal-pqc:9.8
 
 COPY --from=builder /app/flowlogs-pipeline /app/
 COPY --from=builder /app/flp-informers /app/


### PR DESCRIPTION
## Description

Enable `DEFAULT:PQ` crypto policy for post-quantum cryptography support using a multi-stage build. A `crypto-builder` stage installs `crypto-policies-scripts`, configures `DEFAULT:PQ`, and the resulting `/etc/crypto-policies/` is copied into the runtime image. This makes ML-KEM available via OpenSSL without changing the base image.

This is part of the OCP 5.0 PQC initiative ([OCPSTRAT-3113](https://issues.redhat.com/browse/OCPSTRAT-3113)). The crypto policy switch is transparent to FLP — it does not alter behavior or APIs.

**Approach:** Based on [openshift/images#230](https://github.com/openshift/images/pull/230).

**Verification:**
```bash
podman build -t flp-pqc-test -f contrib/docker/Dockerfile .
podman run --rm --entrypoint cat flp-pqc-test /etc/crypto-policies/state/current
# Output: DEFAULT:PQ
```

**Images updated:**
- `contrib/docker/Dockerfile` (FLP + flp-informers image)

🤖 Generated with [Claude Code](https://claude.com/claude-code) via `/jira:solve [NETOBSERV-2912](https://redhat.atlassian.net/browse/NETOBSERV-2912)`